### PR TITLE
rate-limit loop detection warnings to one per fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] - 2025-12-26
+
+### Fixed
+
+- **Bridge loop prevention**: Rate-limit warnings to one per message fingerprint
+  - Previously logged a warning on every duplicate detection (~600/minute for heartbeats)
+  - Now logs only on first detection, then suppresses until TTL expires
+  - Reduces log spam when `BridgeDirection::Both` causes expected duplicates
+
 ## [0.16.1] / [mqtt5-wasm 0.7.1] - 2025-12-26
 
 ### Changed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.16.1"
+version = "0.16.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

- Fix excessive WARN log spam from bridge loop detection when `BridgeDirection::Both` is configured
- Previously logged on every duplicate (~600/minute for heartbeats with identical payloads)
- Now logs only on first detection per fingerprint, then suppresses until TTL expires

## Changes

- Add `already_warned` flag to fingerprint cache entries
- Only emit warning when transitioning from false to true
- Bump mqtt5 to 0.16.2

## Test plan

- [x] Existing loop prevention tests pass
- [x] `test_loop_detection` - verifies first message passes, second is blocked
- [x] `test_ttl_expiration` - verifies warning resets after TTL
- [x] `test_different_qos_different_fingerprint` - verifies QoS differentiation