### PR TITLE
downgrade loop detection logging from warn to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.3] - 2025-12-27
+
+### Changed
+
+- **Bridge loop prevention**: Downgrade loop detection from `warn!` to `debug!` level
+  - Loop blocking in `BridgeDirection::Both` is expected behavior, not a warning condition
+  - Use `RUST_LOG=mqtt5::broker::bridge=debug` to see loop detection messages
+
 ## [0.16.2] - 2025-12-26
 
 ### Fixed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.16.2"
+version = "0.16.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/bridge/loop_prevention.rs
+++ b/crates/mqtt5/src/broker/bridge/loop_prevention.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Message fingerprint for loop detection
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -56,7 +56,7 @@ impl LoopPrevention {
         if let Some((first_seen, already_warned)) = cache.get_mut(&fingerprint) {
             if first_seen.elapsed() < self.ttl {
                 if !*already_warned {
-                    warn!("Message loop detected for topic: {}", packet.topic_name);
+                    debug!("Message loop detected for topic: {}", packet.topic_name);
                     *already_warned = true;
                 }
                 return false;


### PR DESCRIPTION
## Summary

- Change loop detection logging from `warn!` to `debug!` level
- Loop blocking in `BridgeDirection::Both` is expected behavior, not a warning condition
- Use `RUST_LOG=mqtt5::broker::bridge=debug` to see loop detection messages

## Changes

- Replace `warn!` with `debug!` in loop_prevention.rs
- Remove unused `warn` import
- Bump mqtt5 to 0.16.3