### PR TITLE
update version numbers in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ```toml
 [dependencies]
-mqtt5 = "0.17"
+mqtt5 = "0.18"
 ```
 
 ### CLI Tool
@@ -492,10 +492,10 @@ The `mqtt5-protocol` crate supports `no_std` environments for embedded systems.
 
 ```toml
 [dependencies]
-mqtt5-protocol = { version = "0.8", default-features = false }
+mqtt5-protocol = { version = "0.9", default-features = false }
 
 # For single-core MCUs (more efficient atomics)
-mqtt5-protocol = { version = "0.8", default-features = false, features = ["embedded-single-core"] }
+mqtt5-protocol = { version = "0.9", default-features = false, features = ["embedded-single-core"] }
 ```
 
 ### Time Provider
@@ -757,7 +757,7 @@ Distributed tracing with OpenTelemetry support:
 
 ```toml
 [dependencies]
-mqtt5 = { version = "0.17", features = ["opentelemetry"] }
+mqtt5 = { version = "0.18", features = ["opentelemetry"] }
 ```
 
 ### Features

--- a/crates/mqtt5-protocol/README.md
+++ b/crates/mqtt5-protocol/README.md
@@ -16,21 +16,21 @@ MQTT v5.0 and v3.1.1 protocol implementation - packets, encoding, and validation
 
 ```toml
 [dependencies]
-mqtt5-protocol = "0.8"
+mqtt5-protocol = "0.9"
 ```
 
 ### For Embedded (no_std)
 
 ```toml
 [dependencies]
-mqtt5-protocol = { version = "0.8", default-features = false }
+mqtt5-protocol = { version = "0.9", default-features = false }
 ```
 
 ### For Single-Core Embedded
 
 ```toml
 [dependencies]
-mqtt5-protocol = { version = "0.8", default-features = false, features = ["embedded-single-core"] }
+mqtt5-protocol = { version = "0.9", default-features = false, features = ["embedded-single-core"] }
 ```
 
 ## Supported Targets

--- a/crates/mqtt5-wasm/README.md
+++ b/crates/mqtt5-wasm/README.md
@@ -26,7 +26,7 @@ npm install mqtt5-wasm
 
 ```toml
 [dependencies]
-mqtt5-wasm = "0.7"
+mqtt5-wasm = "0.8"
 ```
 
 Build with wasm-pack:


### PR DESCRIPTION
## Summary
- Update mqtt5 version from 0.17 to 0.18
- Update mqtt5-protocol version from 0.8 to 0.9
- Update mqtt5-wasm version from 0.7 to 0.8