### PR TITLE
security hardening across packet parsing, auth, codecs, and resource management

### DIFF
--- a/crates/mqtt5-wasm/src/client/mod.rs
+++ b/crates/mqtt5-wasm/src/client/mod.rs
@@ -96,6 +96,14 @@ impl WasmMqttClient {
         url: &str,
         config: &WasmConnectOptions,
     ) -> Result<(), JsValue> {
+        let lower = url.to_ascii_lowercase();
+        if !lower.starts_with("ws://") && !lower.starts_with("wss://") {
+            return Err(JsValue::from_str("URL must start with ws:// or wss://"));
+        }
+        if lower.starts_with("ws://") && (config.username.is_some() || config.password.is_some()) {
+            web_sys::console::warn_1(&"Credentials sent over unencrypted ws:// connection".into());
+        }
+
         self.state.borrow_mut().last_url = Some(url.to_string());
         let transport = WasmTransportType::WebSocket(
             crate::transport::websocket::WasmWebSocketTransport::new(url),

--- a/crates/mqtt5-wasm/src/codec/deflate.rs
+++ b/crates/mqtt5-wasm/src/codec/deflate.rs
@@ -3,10 +3,13 @@ use miniz_oxide::deflate::compress_to_vec;
 use miniz_oxide::inflate::decompress_to_vec;
 use wasm_bindgen::prelude::*;
 
+const DEFAULT_MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
+
 #[wasm_bindgen]
 pub struct WasmDeflateCodec {
     level: u8,
     min_size: usize,
+    max_decompressed_size: usize,
 }
 
 #[wasm_bindgen]
@@ -17,6 +20,7 @@ impl WasmDeflateCodec {
         Self {
             level: 6,
             min_size: 128,
+            max_decompressed_size: DEFAULT_MAX_DECOMPRESSED_SIZE,
         }
     }
 
@@ -31,6 +35,13 @@ impl WasmDeflateCodec {
     #[must_use]
     pub fn with_min_size(mut self, size: usize) -> Self {
         self.min_size = size;
+        self
+    }
+
+    #[wasm_bindgen(js_name = "withMaxDecompressedSize")]
+    #[must_use]
+    pub fn with_max_decompressed_size(mut self, size: usize) -> Self {
+        self.max_decompressed_size = size;
         self
     }
 }
@@ -63,6 +74,15 @@ impl WasmPayloadCodec for WasmDeflateCodec {
     }
 
     fn decode(&self, payload: &[u8]) -> Result<Vec<u8>, String> {
-        decompress_to_vec(payload).map_err(|e| format!("Deflate decompression failed: {e}"))
+        let result =
+            decompress_to_vec(payload).map_err(|e| format!("Deflate decompression failed: {e}"))?;
+        if result.len() > self.max_decompressed_size {
+            return Err(format!(
+                "Deflate decompressed size {} exceeds limit {}",
+                result.len(),
+                self.max_decompressed_size
+            ));
+        }
+        Ok(result)
     }
 }

--- a/crates/mqtt5-wasm/src/config.rs
+++ b/crates/mqtt5-wasm/src/config.rs
@@ -30,7 +30,7 @@ impl WasmReconnectOptions {
             initial_delay_ms: 1000,
             max_delay_ms: 60000,
             backoff_factor: 2.0,
-            max_attempts: None,
+            max_attempts: Some(20),
         }
     }
 

--- a/crates/mqtt5/src/broker/auth/mod.rs
+++ b/crates/mqtt5/src/broker/auth/mod.rs
@@ -4,7 +4,7 @@ mod composite;
 mod providers;
 mod rate_limit;
 
-pub use composite::CompositeAuthProvider;
+pub use composite::{AuthorizationMode, CompositeAuthProvider};
 pub use providers::{
     AllowAllAuthProvider, CertificateAuthProvider, ComprehensiveAuthProvider, PasswordAuthProvider,
 };
@@ -719,18 +719,6 @@ mod tests {
             .has_certificate("1234567890123456789012345678901234567890123456789012345678901234"));
         assert!(provider
             .has_certificate("abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"));
-    }
-
-    #[test]
-    fn test_certificate_common_name_extraction() {
-        let empty_cert = b"";
-        let result = CertificateAuthProvider::extract_common_name(empty_cert);
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
-
-        let fake_cert_with_cn = b"Some certificate data CN=test.example.com,O=Test Org more data";
-        let result = CertificateAuthProvider::extract_common_name(fake_cert_with_cn);
-        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/broker/auth/providers.rs
+++ b/crates/mqtt5/src/broker/auth/providers.rs
@@ -6,7 +6,6 @@ use crate::packet::connect::ConnectPacket;
 use crate::protocol::v5::reason_codes::ReasonCode;
 use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, Salt, SaltString};
 use argon2::Argon2;
-use base64::prelude::*;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use std::future::Future;
@@ -605,29 +604,6 @@ impl CertificateAuthProvider {
         let mut hasher = Sha256::new();
         hasher.update(cert_der);
         hex::encode(hasher.finalize())
-    }
-
-    /// Extracts the Common Name (CN) from a certificate subject
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the certificate cannot be parsed
-    pub fn extract_common_name(cert_der: &[u8]) -> Result<Option<String>> {
-        let _cert_pem = format!(
-            "-----BEGIN CERTIFICATE-----\n{}\n-----END CERTIFICATE-----",
-            BASE64_STANDARD.encode(cert_der)
-        );
-
-        if let Ok(decoded) = std::str::from_utf8(cert_der) {
-            if let Some(cn_start) = decoded.find("CN=") {
-                let cn_part = &decoded[cn_start + 3..];
-                if let Some(cn_end) = cn_part.find(',').or_else(|| cn_part.find('\0')) {
-                    return Ok(Some(cn_part[..cn_end].trim().to_string()));
-                }
-            }
-        }
-
-        Ok(None)
     }
 }
 

--- a/crates/mqtt5/src/codec/gzip.rs
+++ b/crates/mqtt5/src/codec/gzip.rs
@@ -1,4 +1,5 @@
-use std::io::{Read, Write};
+use std::io::Read;
+use std::io::Write;
 
 use bytes::Bytes;
 use flate2::read::GzDecoder;
@@ -8,9 +9,12 @@ use flate2::Compression;
 use super::PayloadCodec;
 use crate::error::{MqttError, Result};
 
+const DEFAULT_MAX_DECOMPRESSED_SIZE: usize = 10 * 1024 * 1024;
+
 pub struct GzipCodec {
     level: Compression,
     min_size: usize,
+    max_decompressed_size: usize,
 }
 
 impl Default for GzipCodec {
@@ -25,6 +29,7 @@ impl GzipCodec {
         Self {
             level: Compression::default(),
             min_size: 128,
+            max_decompressed_size: DEFAULT_MAX_DECOMPRESSED_SIZE,
         }
     }
 
@@ -37,6 +42,12 @@ impl GzipCodec {
     #[must_use]
     pub fn with_min_size(mut self, size: usize) -> Self {
         self.min_size = size;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_decompressed_size(mut self, size: usize) -> Self {
+        self.max_decompressed_size = size;
         self
     }
 }
@@ -62,11 +73,19 @@ impl PayloadCodec for GzipCodec {
     }
 
     fn decode(&self, payload: &[u8]) -> Result<Bytes> {
-        let mut decoder = GzDecoder::new(payload);
+        let limit = self.max_decompressed_size;
+        let mut decoder =
+            GzDecoder::new(payload).take(u64::try_from(limit + 1).unwrap_or(u64::MAX));
         let mut decompressed = Vec::new();
         decoder
             .read_to_end(&mut decompressed)
             .map_err(|e| MqttError::ProtocolError(format!("gzip decode failed: {e}")))?;
+        if decompressed.len() > limit {
+            return Err(MqttError::ProtocolError(format!(
+                "gzip decompressed size {} exceeds limit {limit}",
+                decompressed.len()
+            )));
+        }
         Ok(Bytes::from(decompressed))
     }
 

--- a/crates/mqtt5/tests/tls_direct_config.rs
+++ b/crates/mqtt5/tests/tls_direct_config.rs
@@ -294,18 +294,18 @@ fn test_alpn_protocol_validation() {
 }
 
 #[test]
-#[should_panic(expected = "ALPN protocol cannot be empty")]
-fn test_alpn_empty_protocol_validation() {
-    // This will panic due to empty protocol validation
-    let _ = TlsConfig::new("127.0.0.1:8883".parse().unwrap(), "localhost")
+fn test_alpn_empty_protocol_filtered() {
+    let config = TlsConfig::new("127.0.0.1:8883".parse().unwrap(), "localhost")
         .with_alpn_protocols(&["mqtt", ""]);
+    let protocols = config.alpn_protocols.unwrap();
+    assert_eq!(protocols.len(), 1);
+    assert_eq!(protocols[0], b"mqtt");
 }
 
 #[test]
-#[should_panic(expected = "ALPN protocol cannot exceed 255 bytes")]
-fn test_alpn_long_protocol_validation() {
+fn test_alpn_long_protocol_filtered() {
     let long_protocol = "a".repeat(256);
-    // This will panic due to protocol length validation
-    let _ = TlsConfig::new("127.0.0.1:8883".parse().unwrap(), "localhost")
+    let config = TlsConfig::new("127.0.0.1:8883".parse().unwrap(), "localhost")
         .with_alpn_protocols(&[&long_protocol]);
+    assert!(config.alpn_protocols.is_none());
 }


### PR DESCRIPTION
## Summary

- Enforce max packet size before buffer allocation in all packet read paths (native + WASM), preventing OOM from malicious remaining-length fields
- Add `AuthorizationMode` enum (`PrimaryOnly`/`Or`/`And`) to `CompositeAuthProvider` with safe `PrimaryOnly` default — fallback provider no longer silently grants access
- Add read timeouts to `handle_packets` (keepalive * 1.5) and `handle_packets_no_keepalive` (300s zombie guard)
- Add `max_decompressed_size` (default 10MB) to all 4 codec structs (native gzip/deflate, WASM gzip/deflate) to block decompression bombs
- Add per-username rate limiting alongside existing per-IP rate limiting in `AuthRateLimiter`
- Set WASM reconnect `max_attempts` default to 20; validate WebSocket URL scheme; warn on credentials over `ws://`
- Switch `resource_monitor` to `parking_lot::RwLock` (no lock poisoning); remove dead `extract_common_name`; replace ALPN `assert!` panics with filter + warn

## Test plan

- [x] `cargo make ci-verify` passes (fmt, clippy, clippy-wasm, all tests)
- [x] New `CompositeAuthProvider` tests cover `PrimaryOnly`, `Or`, and `And` modes
- [x] Updated ALPN tests verify filter behavior instead of panics
- [x] All 405+ existing tests continue to pass