### PR TITLE
use http/1.1 ALPN for WSS listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.31.4] - 2026-04-12
+
+### Fixed
+
+- **WSS ALPN mismatch** - WebSocket TLS listener now advertises `http/1.1` ALPN instead of `mqtt`, allowing browsers to complete the TLS handshake on the WSS port
+
 ## [mqtt5 0.31.2] - 2026-04-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **WSS ALPN mismatch** - WebSocket TLS listener now advertises `http/1.1` ALPN instead of `mqtt`, allowing browsers to complete the TLS handshake on the WSS port
 
+## [mqtt5 0.31.3] - 2026-04-11
+
+### Fixed
+
+- **Conformance test fixes** - fix 9 conformance test failures verified against Mosquitto (test parsing bug, spec ambiguity adjustments)
+- **QUIC integration test hardening** - replace ad-hoc sleeps with `ready_receiver()`, fix port conflicts, add graceful connection failure handling
+- **Conformance platform** - vendor-neutral conformance test platform with `#[conformance_test]` proc-macro and CLI runner supporting in-process and external SUT testing
+- **FileBackend deadlock** - fix `get_session()` deadlock caused by Rust 2021 `if let` temporary lifetime holding read guard across write lock
+
 ## [mqtt5 0.31.2] - 2026-04-09
 
 ### Fixed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.31.3"
+version = "0.31.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -451,6 +451,7 @@ impl MqttBroker {
 
                 acceptor_config =
                     acceptor_config.with_require_client_cert(tls_config.require_client_cert);
+                acceptor_config = acceptor_config.with_alpn_protocols(vec![b"http/1.1".to_vec()]);
                 let acceptor = acceptor_config.build_acceptor()?;
 
                 let bind_result =

--- a/crates/mqtt5/tests/wss_alpn_integration.rs
+++ b/crates/mqtt5/tests/wss_alpn_integration.rs
@@ -1,0 +1,133 @@
+mod common;
+use common::{find_workspace_root, TestBroker};
+use mqtt5::broker::config::{
+    BrokerConfig, StorageBackend, StorageConfig, TlsConfig as BrokerTlsConfig, WebSocketConfig,
+};
+use rustls::pki_types::ServerName;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU16, Ordering};
+use std::sync::Arc;
+use tokio::net::TcpStream;
+
+static WSS_PORT_COUNTER: AtomicU16 = AtomicU16::new(21100);
+
+async fn start_wss_broker() -> (TestBroker, u16) {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let workspace_root = find_workspace_root();
+    let wss_port = WSS_PORT_COUNTER.fetch_add(1, Ordering::SeqCst);
+
+    let tls_config = BrokerTlsConfig::new(
+        workspace_root.join("test_certs/server.pem"),
+        workspace_root.join("test_certs/server.key"),
+    )
+    .with_require_client_cert(false)
+    .with_bind_address("127.0.0.1:0".parse::<SocketAddr>().unwrap());
+
+    let ws_tls_config = WebSocketConfig::new()
+        .with_bind_addresses(vec![format!("127.0.0.1:{wss_port}").parse().unwrap()])
+        .with_path("/mqtt".to_string());
+
+    let storage_config = StorageConfig {
+        backend: StorageBackend::Memory,
+        enable_persistence: true,
+        ..Default::default()
+    };
+
+    let config = BrokerConfig::default()
+        .with_bind_address("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .with_storage(storage_config)
+        .with_tls(tls_config)
+        .with_websocket_tls(ws_tls_config);
+
+    let broker = TestBroker::start_with_config(config).await;
+    (broker, wss_port)
+}
+
+fn build_tls_connector(alpn_protocols: Vec<Vec<u8>>) -> tokio_rustls::TlsConnector {
+    let mut root_store = rustls::RootCertStore::empty();
+    let workspace_root = find_workspace_root();
+    let ca_pem = std::fs::read(workspace_root.join("test_certs/ca.pem")).unwrap();
+    let ca_certs: Vec<_> = rustls_pemfile::certs(&mut &ca_pem[..])
+        .filter_map(std::result::Result::ok)
+        .collect();
+    for cert in ca_certs {
+        root_store.add(cert).unwrap();
+    }
+
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    config.alpn_protocols = alpn_protocols;
+
+    tokio_rustls::TlsConnector::from(Arc::new(config))
+}
+
+#[tokio::test]
+async fn test_wss_accepts_http11_alpn() {
+    let (_broker, wss_port) = start_wss_broker().await;
+
+    let connector = build_tls_connector(vec![b"http/1.1".to_vec()]);
+    let tcp = TcpStream::connect(format!("127.0.0.1:{wss_port}"))
+        .await
+        .unwrap();
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = connector.connect(server_name, tcp).await;
+    assert!(
+        result.is_ok(),
+        "WSS port should accept http/1.1 ALPN: {:?}",
+        result.err()
+    );
+
+    let tls_stream = result.unwrap();
+    let negotiated = tls_stream.get_ref().1.alpn_protocol();
+    assert_eq!(
+        negotiated,
+        Some(b"http/1.1".as_slice()),
+        "negotiated ALPN should be http/1.1"
+    );
+}
+
+#[tokio::test]
+async fn test_wss_rejects_mqtt_only_alpn() {
+    let (_broker, wss_port) = start_wss_broker().await;
+
+    let connector = build_tls_connector(vec![b"mqtt".to_vec()]);
+    let tcp = TcpStream::connect(format!("127.0.0.1:{wss_port}"))
+        .await
+        .unwrap();
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = connector.connect(server_name, tcp).await;
+    assert!(
+        result.is_err(),
+        "WSS port should reject mqtt-only ALPN (no overlap with http/1.1)"
+    );
+}
+
+#[tokio::test]
+async fn test_wss_accepts_browser_alpn() {
+    let (_broker, wss_port) = start_wss_broker().await;
+
+    let connector = build_tls_connector(vec![b"h2".to_vec(), b"http/1.1".to_vec()]);
+    let tcp = TcpStream::connect(format!("127.0.0.1:{wss_port}"))
+        .await
+        .unwrap();
+    let server_name = ServerName::try_from("localhost").unwrap();
+
+    let result = connector.connect(server_name, tcp).await;
+    assert!(
+        result.is_ok(),
+        "WSS port should accept browser ALPN (h2 + http/1.1): {:?}",
+        result.err()
+    );
+
+    let tls_stream = result.unwrap();
+    let negotiated = tls_stream.get_ref().1.alpn_protocol();
+    assert_eq!(
+        negotiated,
+        Some(b"http/1.1".as_slice()),
+        "should negotiate http/1.1 (server only offers http/1.1)"
+    );
+}


### PR DESCRIPTION
## Summary
- WSS listener was enforcing `mqtt` ALPN, causing browsers to fail TLS handshake with alert 120 (no application protocol) since they offer `h2,http/1.1`
- Changed WSS `TlsAcceptorConfig` to advertise `http/1.1` ALPN instead of `mqtt`
- MQTTS listener (port 8883) retains `mqtt` ALPN unchanged
- Only `http/1.1` is offered (not `h2`) because the broker doesn't implement RFC 8441 — advertising `h2` would break Firefox WebSocket connections
- Backfilled missing 0.31.3 changelog entry

## Test plan
- [x] `test_wss_accepts_http11_alpn` — raw TLS handshake with `http/1.1` ALPN succeeds
- [x] `test_wss_rejects_mqtt_only_alpn` — `mqtt`-only ALPN is rejected (no overlap)
- [x] `test_wss_accepts_browser_alpn` — browser-style `h2,http/1.1` negotiates `http/1.1`
- [x] Existing TLS integration tests pass (5/5)
- [x] Existing WebSocket integration tests pass (4/4)
- [x] `cargo clippy --all-targets --workspace -- -D warnings -W clippy::pedantic` clean
- [ ] Manual: connect to WSS port from a browser