### PR TITLE
add OpenTelemetry toggle to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,11 @@ on:
         description: 'Image tag (default: dev)'
         required: false
         default: 'dev'
+      opentelemetry:
+        description: 'Enable OpenTelemetry support'
+        type: boolean
+        required: false
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -59,5 +64,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FEATURES=${{ github.event.inputs.opentelemetry == 'true' && '--features opentelemetry' || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM rust:alpine AS builder
 RUN apk add --no-cache musl-dev upx
 WORKDIR /build
 COPY . .
-RUN cargo build --release -p mqttv5-cli \
+ARG FEATURES=""
+RUN cargo build --release -p mqttv5-cli $FEATURES \
     && strip target/release/mqttv5 \
     && upx --best --lzma target/release/mqttv5
 


### PR DESCRIPTION
## Summary
- Adds `opentelemetry` boolean input to the Docker workflow_dispatch trigger
- Passes `--features opentelemetry` as a build-arg to the Dockerfile when enabled
- Tag-push releases are unaffected (no features flag)

## Test plan
- [ ] Trigger workflow manually with `opentelemetry: true`, `tag: dev-otel` — verify `--features opentelemetry` in cargo build logs
- [ ] Trigger without opentelemetry — verify no features flag appears
- [ ] Tag push path unchanged