### PR TITLE
fix OTel env vars ignored when using --config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqttv5-cli 0.27.2] - 2026-04-13
+
+### Fixed
+
+- **OTel ignored with --config** - OpenTelemetry env vars (`MQTT5_OTEL_ENDPOINT`, `MQTT5_OTEL_SERVICE_NAME`, `MQTT5_OTEL_SAMPLING`) were only applied in the CLI-args code path; when using `--config <file>`, the OTel setup was skipped entirely because `opentelemetry_config` is `#[serde(skip)]` and the env var merge lived inside `create_interactive_config()`. Moved OTel initialization to `execute_run()` so it applies regardless of config source.
+
 ## [mqtt5 0.31.4] - 2026-04-12
 
 ### Fixed

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.27.1"
+version = "0.27.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqttv5-cli/src/commands/broker_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/broker_cmd.rs
@@ -467,7 +467,8 @@ async fn execute_run(mut cmd: RunArgs, verbose: bool, debug: bool) -> Result<()>
 
     info!("Starting MQTT v5.0 broker...");
 
-    let (config, config_path) = if let Some(config_path) = &cmd.config {
+    #[cfg_attr(not(feature = "opentelemetry"), allow(unused_mut))]
+    let (mut config, config_path) = if let Some(config_path) = &cmd.config {
         debug!("Loading configuration from: {:?}", config_path);
         let cfg = load_config_from_file(config_path)
             .await
@@ -476,6 +477,19 @@ async fn execute_run(mut cmd: RunArgs, verbose: bool, debug: bool) -> Result<()>
     } else {
         (create_interactive_config(&mut cmd).await?, None)
     };
+
+    #[cfg(feature = "opentelemetry")]
+    if let Some(endpoint) = &cmd.otel_endpoint {
+        use mqtt5::telemetry::TelemetryConfig;
+        let telemetry_config = TelemetryConfig::new(&cmd.otel_service_name)
+            .with_endpoint(endpoint)
+            .with_sampling_ratio(cmd.otel_sampling);
+        config = config.with_opentelemetry(telemetry_config);
+        info!(
+            "OpenTelemetry enabled: endpoint={}, service={}, sampling={}",
+            endpoint, cmd.otel_service_name, cmd.otel_sampling
+        );
+    }
 
     config
         .validate()
@@ -1077,19 +1091,6 @@ async fn create_interactive_config(cmd: &mut RunArgs) -> Result<BrokerConfig> {
         cleanup_interval: std::time::Duration::from_secs(300),
     };
     config.storage_config = storage_config;
-
-    #[cfg(feature = "opentelemetry")]
-    if let Some(endpoint) = &cmd.otel_endpoint {
-        use mqtt5::telemetry::TelemetryConfig;
-        let telemetry_config = TelemetryConfig::new(&cmd.otel_service_name)
-            .with_endpoint(endpoint)
-            .with_sampling_ratio(cmd.otel_sampling);
-        config = config.with_opentelemetry(telemetry_config);
-        info!(
-            "OpenTelemetry enabled: endpoint={}, service={}, sampling={}",
-            endpoint, cmd.otel_service_name, cmd.otel_sampling
-        );
-    }
 
     Ok(config)
 }


### PR DESCRIPTION
## Summary

- OpenTelemetry env vars (`MQTT5_OTEL_ENDPOINT`, `MQTT5_OTEL_SERVICE_NAME`, `MQTT5_OTEL_SAMPLING`) were silently ignored when the broker was started with `--config <file>`. The OTel initialization lived inside `create_interactive_config()`, which is only called in the CLI-args path. The `--config` path calls `load_config_from_file()` instead, and since `opentelemetry_config` is `#[serde(skip)]`, it always deserializes as `None`.
- Moved OTel setup from `create_interactive_config()` to `execute_run()`, after config loading but before validation, so env vars are applied regardless of config source.

## Test plan

- [ ] Build with `--features opentelemetry` and run broker with `--config broker.json` + `MQTT5_OTEL_ENDPOINT=http://localhost:4317` — verify "OpenTelemetry enabled:" log line appears
- [ ] Run broker without `--config` with same env var — verify behavior unchanged
- [ ] Run broker without OTel env var — verify no regression (basic tracing init, no OTel log)