### PR TITLE
default missing broker config fields and update all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING: bumped `getrandom` 0.3 → 0.4** - `getrandom::Error` is exposed in the public API via `ScramCredentials::from_password` and the SCRAM nonce helpers, so the crate-version change of that error type is SemVer-breaking for consumers that name it.
+- **BREAKING: SCRAM credential functions no longer expose `getrandom::Error`** - `ScramCredentials::from_password`, `ScramCredentials::from_password_with_iterations`, `generate_scram_credential_line`, and `generate_scram_credential_line_with_iterations` now return the crate's own `Result<_, MqttError>` (mapping salt-generation failure to `MqttError::Io`) instead of `std::result::Result<_, getrandom::Error>`. This removes the third-party error type from the public API so future `getrandom` bumps are no longer breaking. Callers matching on `getrandom::Error` must switch to `MqttError`; callers using `?` or `anyhow` are unaffected.
 - **Bumped `mqtt5-protocol` dependency to 0.14** - pulls in the breaking `hashbrown` 0.17 change (see below).
-- **Updated remaining dependencies** - `sha2` 0.10 → 0.11, `rand` 0.9 → 0.10 (the `random()` method moved to the new `RngExt` trait, updated internally), `toml` 0.9 → 1, `tokio-tungstenite` 0.28 → 0.29, and the OpenTelemetry stack (`opentelemetry`/`opentelemetry_sdk`/`opentelemetry-otlp` 0.31 → 0.32, `tracing-opentelemetry` 0.32 → 0.33). All internal; no further public-API impact.
+- **Updated dependencies** - `getrandom` 0.3 → 0.4 (now an internal detail), `sha2` 0.10 → 0.11, `rand` 0.9 → 0.10 (the `random()` method moved to the new `RngExt` trait, updated internally), `toml` 0.9 → 1, `tokio-tungstenite` 0.28 → 0.29, and the OpenTelemetry stack (`opentelemetry`/`opentelemetry_sdk`/`opentelemetry-otlp` 0.31 → 0.32, `tracing-opentelemetry` 0.32 → 0.33). All internal; no further public-API impact.
 
 ## [mqtt5-protocol 0.14.0] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.33.0] - 2026-06-13
+
+### Fixed
+
+- **Broker config required every field to be present** - `BrokerConfig` derived `Deserialize` without a container-level `#[serde(default)]`, so a config file passed to `mqttv5 broker --config` failed to parse if it omitted any non-`Option`, non-defaulted field (e.g. `max_clients`), contradicting the per-field defaults documented in `CLI_USAGE.md`. Added `#[serde(default)]` to `BrokerConfig` and the nested `AuthConfig`, `RateLimitConfig`, `StorageConfig`, and `WebSocketConfig`, so omitted fields (including nested sub-fields) fall back to their `Default` impls. A minimal `{}` config is now valid (issue #85).
+
+### Changed
+
+- **BREAKING: bumped `getrandom` 0.3 → 0.4** - `getrandom::Error` is exposed in the public API via `ScramCredentials::from_password` and the SCRAM nonce helpers, so the crate-version change of that error type is SemVer-breaking for consumers that name it.
+- **Bumped `mqtt5-protocol` dependency to 0.14** - pulls in the breaking `hashbrown` 0.17 change (see below).
+- **Updated remaining dependencies** - `sha2` 0.10 → 0.11, `rand` 0.9 → 0.10 (the `random()` method moved to the new `RngExt` trait, updated internally), `toml` 0.9 → 1, `tokio-tungstenite` 0.28 → 0.29, and the OpenTelemetry stack (`opentelemetry`/`opentelemetry_sdk`/`opentelemetry-otlp` 0.31 → 0.32, `tracing-opentelemetry` 0.32 → 0.33). All internal; no further public-API impact.
+
+## [mqtt5-protocol 0.14.0] - 2026-06-13
+
+### Changed
+
+- **BREAKING: bumped `hashbrown` 0.16 → 0.17** - `SubscriptionManager::all()` returns `hashbrown::HashMap<String, Subscription>`, a public return type, so the crate-version change of `HashMap` is SemVer-breaking for consumers that name it.
+
+## [mqtt5-wasm 1.3.3] - 2026-06-13
+
+### Changed
+
+- **Transitive bump: `mqtt5` 0.33 and `mqtt5-protocol` 0.14** - no wasm surface changes; the breaking dependency changes are not re-exported through the wasm API. Also updates own dependencies `getrandom` 0.3 → 0.4, `sha2` 0.10 → 0.11, and `gloo-timers` 0.3 → 0.4.
+
+## [mqttv5-cli 0.27.4] - 2026-06-13
+
+### Changed
+
+- **Transitive bump: `mqtt5` 0.33** - picks up the config-file defaults fix (issue #85) end-to-end. Also updates own dependencies `rand` 0.9 → 0.10, `toml` 0.9 → 1, and `getrandom` 0.3 → 0.4. No CLI surface changes.
+
 ## [mqtt5 0.32.2] - 2026-05-20
 
 ### Changed

--- a/crates/mqtt5-conformance/Cargo.toml
+++ b/crates/mqtt5-conformance/Cargo.toml
@@ -24,12 +24,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-toml = "0.9"
+toml = "1"
 bytes = "1.10"
 ulid = "1.2.1"
 linkme = "0.3.35"
 mqtt5-conformance-macros = { version = "0.1.0", path = "../mqtt5-conformance-macros" }
-tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect"] }
 futures-util = "0.3"
 http = "1.4.0"
 

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0", features = [
     "alloc",
 ], default-features = false }
 tracing = { version = "0.1.41", default-features = false, optional = true }
-hashbrown = "0.16"
+hashbrown = "0.17"
 portable-atomic = { version = "1.12", default-features = false }
 portable-atomic-util = { version = "0.2.4", default-features = false, features = [
     "alloc",

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -36,16 +36,16 @@ wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 js-sys = { version = "0.3", optional = true }
 console_error_panic_hook = "0.1"
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 bytes = "1.10"
 futures = "0.3"
 futures-util = "0.3"
 tracing = "0.1.41"
-gloo-timers = { version = "0.3.0", features = ["futures"] }
+gloo-timers = { version = "0.4", features = ["futures"] }
 flume = "0.12.0"
 miniz_oxide = { version = "0.9", optional = true }
-sha2 = "0.10.9"
+sha2 = "0.11"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.3.2"
+version = "1.3.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,8 +27,8 @@ broker = ["client", "dep:mqtt5", "dep:tokio"]
 codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
-mqtt5-protocol = "0.13.0"
-mqtt5 = { version = "0.32", optional = true, default-features = false, features = [
+mqtt5-protocol = "0.14.0"
+mqtt5 = { version = "0.33", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.32.2"
+version = "0.33.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -120,7 +120,7 @@ opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metric
 opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic", "metrics"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
-mqtt5-protocol = "0.13.0"
+mqtt5-protocol = "0.14.0"
 argon2 = "0.5"
 getrandom = "0.4"
 bebytes = { version = "3.0", features = ["bytes"] }

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -47,7 +47,7 @@ tokio-test = "0.4"
 ulid = "1.2.1"
 proptest = "1.9.0"
 serde_json = "1.0.142"
-rand = "0.9.2"
+rand = "0.10"
 futures = "0.3.31"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 anyhow = "1.0"
@@ -104,25 +104,25 @@ bytes = "1.10"
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }
 hex = "0.4"
-rand = "0.9"
+rand = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = "2.0"
-toml = "0.9"
+toml = "1"
 tracing = "0.1"
 url = "2.5"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
 turmoil = { version = "0.7", optional = true }
-opentelemetry_sdk = { version = "0.31", features = ["trace", "rt-tokio", "metrics"], optional = true }
-opentelemetry-otlp = { version = "0.31", features = ["trace", "grpc-tonic", "metrics"], optional = true }
-tracing-opentelemetry = { version = "0.32", optional = true }
-opentelemetry = { version = "0.31", features = ["metrics", "trace"], optional = true }
+opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metrics"], optional = true }
+opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic", "metrics"], optional = true }
+tracing-opentelemetry = { version = "0.33", optional = true }
+opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
 mqtt5-protocol = "0.13.0"
 argon2 = "0.5"
-getrandom = "0.3"
+getrandom = "0.4"
 bebytes = { version = "3.0", features = ["bytes"] }
 regex = "1.12.2"
 flume = { version = "0.12.0", features = ["async"] }
@@ -147,12 +147,12 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pki-types = "1.13.0"
 tokio = { version = "1.47", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
-tokio-tungstenite = { version = "0.28", default-features = false, features = ["connect", "rustls-tls-native-roots"], optional = true }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-native-roots"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["rustls-ring", "runtime-tokio", "platform-verifier"], optional = true }
 webpki-roots = "1.0"
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 tokio = { version = "1.47", features = [
     "sync",
     "macros",

--- a/crates/mqtt5/src/broker/auth_mechanisms/scram.rs
+++ b/crates/mqtt5/src/broker/auth_mechanisms/scram.rs
@@ -1,5 +1,5 @@
 use crate::broker::auth::{AuthProvider, AuthResult, EnhancedAuthResult};
-use crate::error::Result;
+use crate::error::{MqttError, Result};
 use crate::packet::connect::ConnectPacket;
 use crate::protocol::v5::reason_codes::ReasonCode;
 use base64::prelude::*;
@@ -33,7 +33,7 @@ impl ScramCredentials {
     ///
     /// # Errors
     /// Returns an error if random salt generation fails.
-    pub fn from_password(password: &str) -> std::result::Result<Self, getrandom::Error> {
+    pub fn from_password(password: &str) -> Result<Self> {
         Self::from_password_with_iterations(password, SCRAM_ITERATION_COUNT)
     }
 
@@ -41,12 +41,10 @@ impl ScramCredentials {
     ///
     /// # Errors
     /// Returns an error if random salt generation fails.
-    pub fn from_password_with_iterations(
-        password: &str,
-        iterations: u32,
-    ) -> std::result::Result<Self, getrandom::Error> {
+    pub fn from_password_with_iterations(password: &str, iterations: u32) -> Result<Self> {
         let mut salt = vec![0u8; SCRAM_SALT_LENGTH];
-        getrandom::fill(&mut salt)?;
+        getrandom::fill(&mut salt)
+            .map_err(|e| MqttError::Io(format!("failed to generate random salt: {e}")))?;
 
         Ok(Self::from_password_and_salt(password, &salt, iterations))
     }
@@ -181,10 +179,7 @@ impl ScramCredentialStore for FileBasedScramCredentialStore {
 ///
 /// # Errors
 /// Returns an error if random salt generation fails.
-pub fn generate_scram_credential_line(
-    username: &str,
-    password: &str,
-) -> std::result::Result<String, getrandom::Error> {
+pub fn generate_scram_credential_line(username: &str, password: &str) -> Result<String> {
     let creds = ScramCredentials::from_password(password)?;
     Ok(format!(
         "{}:{}:{}:{}:{}",
@@ -204,7 +199,7 @@ pub fn generate_scram_credential_line_with_iterations(
     username: &str,
     password: &str,
     iterations: u32,
-) -> std::result::Result<String, getrandom::Error> {
+) -> Result<String> {
     let creds = ScramCredentials::from_password_with_iterations(password, iterations)?;
     Ok(format!(
         "{}:{}:{}:{}:{}",

--- a/crates/mqtt5/src/broker/bridge/connection.rs
+++ b/crates/mqtt5/src/broker/bridge/connection.rs
@@ -11,7 +11,7 @@ use crate::time::{Duration, Instant};
 use crate::transport::tls::TlsConfig;
 use crate::types::ConnectOptions;
 use mqtt5_protocol::bridge::{evaluate_forwarding, TopicMappingCore};
-use rand::Rng;
+use rand::RngExt;
 use std::collections::VecDeque;
 use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};

--- a/crates/mqtt5/src/broker/config/auth.rs
+++ b/crates/mqtt5/src/broker/config/auth.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct AuthConfig {
     pub allow_anonymous: bool,
     pub password_file: Option<PathBuf>,
@@ -16,6 +17,7 @@ pub struct AuthConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct RateLimitConfig {
     pub enabled: bool,
     pub max_attempts: u32,

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -64,6 +64,7 @@ impl LoadBalancerConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
+#[serde(default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct BrokerConfig {
     pub bind_addresses: Vec<SocketAddr>,
@@ -430,6 +431,33 @@ mod tests {
         assert_eq!(config.max_clients, 10000);
         assert_eq!(config.maximum_qos, 2);
         assert!(config.retain_available);
+    }
+
+    #[test]
+    fn test_partial_config_uses_defaults() {
+        let config: BrokerConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.max_clients, 10000);
+        assert_eq!(config.maximum_qos, 2);
+        assert!(config.retain_available);
+        assert_eq!(config.bind_addresses.len(), 2);
+    }
+
+    #[test]
+    fn test_partial_config_overrides_single_field() {
+        let config: BrokerConfig = serde_json::from_str(r#"{"max_clients": 42}"#).unwrap();
+        assert_eq!(config.max_clients, 42);
+        assert_eq!(config.maximum_qos, 2);
+        assert!(config.retain_available);
+        assert!(config.auth_config.allow_anonymous);
+    }
+
+    #[test]
+    fn test_partial_nested_config_uses_defaults() {
+        let config: BrokerConfig =
+            serde_json::from_str(r#"{"auth_config": {"allow_anonymous": false}}"#).unwrap();
+        assert!(!config.auth_config.allow_anonymous);
+        assert_eq!(config.auth_config.auth_method, AuthMethod::None);
+        assert!(config.auth_config.rate_limit.enabled);
     }
 
     #[test]

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -461,6 +461,18 @@ mod tests {
     }
 
     #[test]
+    fn test_partial_storage_config_uses_defaults() {
+        let config: BrokerConfig =
+            serde_json::from_str(r#"{"storage_config": {"enable_persistence": false}}"#).unwrap();
+        assert!(!config.storage_config.enable_persistence);
+        assert_eq!(config.storage_config.backend, StorageBackend::File);
+        assert_eq!(
+            config.storage_config.base_dir,
+            std::path::PathBuf::from("./mqtt_storage")
+        );
+    }
+
+    #[test]
     fn test_config_builder() {
         let config = BrokerConfig::new()
             .with_bind_address("127.0.0.1:1884".parse::<SocketAddr>().unwrap())

--- a/crates/mqtt5/src/broker/config/storage.rs
+++ b/crates/mqtt5/src/broker/config/storage.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct StorageConfig {
     pub backend: StorageBackend,
     pub base_dir: PathBuf,

--- a/crates/mqtt5/src/broker/config/transport.rs
+++ b/crates/mqtt5/src/broker/config/transport.rs
@@ -80,6 +80,7 @@ impl QuicConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct WebSocketConfig {
     pub bind_addresses: Vec<SocketAddr>,
     pub path: String,

--- a/crates/mqtt5/tests/bridge_quic_integration.rs
+++ b/crates/mqtt5/tests/bridge_quic_integration.rs
@@ -130,7 +130,7 @@ async fn test_quic_bridge_outbound() {
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_millis(2000)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let count = received.load(Ordering::Relaxed);
     eprintln!("Messages received on remote broker: {count}");
@@ -206,7 +206,7 @@ async fn test_quic_bridge_inbound() {
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_millis(2000)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let count = received.load(Ordering::Relaxed);
     eprintln!("Messages received on local broker: {count}");
@@ -316,7 +316,7 @@ async fn test_quic_bridge_bidirectional() {
         .await
         .unwrap();
 
-    tokio::time::sleep(Duration::from_millis(2000)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     let local_count = local_received.load(Ordering::Relaxed);
     let remote_count = remote_received.load(Ordering::Relaxed);

--- a/crates/mqtt5/tests/error_recovery.rs
+++ b/crates/mqtt5/tests/error_recovery.rs
@@ -158,11 +158,11 @@ async fn test_retry_delay_calculation() {
 
     assert_eq!(
         retry_delay(RecoverableError::QuotaExceeded, 0, &config),
-        Duration::from_millis(1000)
+        Duration::from_secs(1)
     );
     assert_eq!(
         retry_delay(RecoverableError::QuotaExceeded, 1, &config),
-        Duration::from_millis(2000)
+        Duration::from_secs(2)
     );
 
     assert_eq!(

--- a/crates/mqtt5/tests/integration_complete_flow.rs
+++ b/crates/mqtt5/tests/integration_complete_flow.rs
@@ -394,7 +394,7 @@ async fn test_session_persistence() {
 
     // Wait longer to see if the offline message is delivered automatically
     println!("Waiting for offline message from restored session...");
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
     let count = received.load(Ordering::SeqCst);
     println!("Received message count after waiting: {count}");
 

--- a/crates/mqtt5/tests/integration_reconnection.rs
+++ b/crates/mqtt5/tests/integration_reconnection.rs
@@ -775,7 +775,7 @@ async fn test_subscription_restoration_after_reconnect() {
     // Disconnect and reconnect
     println!("Disconnecting...");
     client.disconnect().await.expect("Failed to disconnect");
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
     message_count.store(0, Ordering::SeqCst);
 
     println!("Reconnecting...");

--- a/crates/mqtt5/tests/quic_multistream_integration.rs
+++ b/crates/mqtt5/tests/quic_multistream_integration.rs
@@ -507,7 +507,7 @@ async fn test_quic_mixed_qos_with_streams() {
     pub_client.publish_qos1(&topic, b"qos1").await.unwrap();
     pub_client.publish_qos2(&topic, b"qos2").await.unwrap();
 
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     assert!(
         received.load(Ordering::Relaxed) >= 2,
@@ -644,7 +644,7 @@ async fn test_quic_large_payload_per_stream() {
         pub_client.publish(&topic, payload).await.unwrap();
     }
 
-    tokio::time::sleep(Duration::from_millis(1000)).await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
 
     let received = received_sizes.lock().await;
     assert_eq!(

--- a/crates/mqtt5/tests/separate_clients.rs
+++ b/crates/mqtt5/tests/separate_clients.rs
@@ -225,7 +225,7 @@ async fn test_qos_levels_separate_clients() {
         .await
         .unwrap();
 
-    sleep(Duration::from_millis(1000)).await;
+    sleep(Duration::from_secs(1)).await;
 
     {
         let messages = qos_messages.lock().unwrap();

--- a/crates/mqttv5-cli/CLI_USAGE.md
+++ b/crates/mqttv5-cli/CLI_USAGE.md
@@ -1064,6 +1064,8 @@ mqttv5 acl role-list --file acl.txt
 
 The broker accepts a JSON configuration file via `--config`. This section documents every field and provides ready-to-use examples.
 
+Every field is optional. Any field omitted from the file falls back to the default listed in the tables below, including nested objects such as `auth_config` and `storage_config`, where individual sub-fields may also be omitted. A minimal config such as `{}` is valid and starts the broker entirely on defaults.
+
 ### Complete Configuration Schema
 
 ```json

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.27.3"
+version = "0.27.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.32" }
+mqtt5 = { path = "../mqtt5", version = "0.33" }
 anyhow = "1.0"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 hex = "0.4.3"
-getrandom = "0.3"
+getrandom = "0.4"
 humantime = "2.3.0"
 time = { version = "0.3.44", features = ["local-offset", "parsing", "formatting", "macros"] }
 bebytes = "3.0.2"
@@ -40,8 +40,8 @@ clap = { version = "4.5", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-toml = "0.9"
-rand = "0.9.2"
+toml = "1"
+rand = "0.10"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 rpassword = "7.4"
 argon2 = "0.5"

--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -8,7 +8,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use mqtt5::time::Duration;
 use mqtt5::{ConnectOptions, MqttClient, QoS};
-use rand::Rng;
+use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use std::io::{Read as _, Write as _};
 use std::path::PathBuf;
@@ -239,14 +239,10 @@ fn decode_timestamp(format: PayloadFormat, payload: &[u8]) -> u64 {
                 0
             }
         }
-        PayloadFormat::Json => serde_json::from_slice::<JsonPayload>(payload)
-            .map(|p| p.ts)
-            .unwrap_or(0),
+        PayloadFormat::Json => serde_json::from_slice::<JsonPayload>(payload).map_or(0, |p| p.ts),
         PayloadFormat::Bebytes => {
             if payload.len() >= BEBYTES_HEADER_SIZE {
-                BebytesHeader::try_from_be_bytes(payload)
-                    .map(|(h, _)| h.timestamp_ns)
-                    .unwrap_or(0)
+                BebytesHeader::try_from_be_bytes(payload).map_or(0, |(h, _)| h.timestamp_ns)
             } else {
                 0
             }
@@ -255,9 +251,7 @@ fn decode_timestamp(format: PayloadFormat, payload: &[u8]) -> u64 {
             let mut decoder = GzDecoder::new(payload);
             let mut json_bytes = Vec::new();
             if decoder.read_to_end(&mut json_bytes).is_ok() {
-                serde_json::from_slice::<JsonPayload>(&json_bytes)
-                    .map(|p| p.ts)
-                    .unwrap_or(0)
+                serde_json::from_slice::<JsonPayload>(&json_bytes).map_or(0, |p| p.ts)
             } else {
                 0
             }
@@ -274,14 +268,10 @@ fn decode_sequence(format: PayloadFormat, payload: &[u8]) -> u32 {
                 0
             }
         }
-        PayloadFormat::Json => serde_json::from_slice::<JsonPayload>(payload)
-            .map(|p| p.seq)
-            .unwrap_or(0),
+        PayloadFormat::Json => serde_json::from_slice::<JsonPayload>(payload).map_or(0, |p| p.seq),
         PayloadFormat::Bebytes => {
             if payload.len() >= BEBYTES_HEADER_SIZE {
-                BebytesHeader::try_from_be_bytes(payload)
-                    .map(|(h, _)| h.sequence)
-                    .unwrap_or(0)
+                BebytesHeader::try_from_be_bytes(payload).map_or(0, |(h, _)| h.sequence)
             } else {
                 0
             }
@@ -290,9 +280,7 @@ fn decode_sequence(format: PayloadFormat, payload: &[u8]) -> u32 {
             let mut decoder = GzDecoder::new(payload);
             let mut json_bytes = Vec::new();
             if decoder.read_to_end(&mut json_bytes).is_ok() {
-                serde_json::from_slice::<JsonPayload>(&json_bytes)
-                    .map(|p| p.seq)
-                    .unwrap_or(0)
+                serde_json::from_slice::<JsonPayload>(&json_bytes).map_or(0, |p| p.seq)
             } else {
                 0
             }

--- a/crates/mqttv5-cli/src/commands/pub_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/pub_cmd.rs
@@ -946,4 +946,4 @@ async fn get_message_content(cmd: &mut PubCommand) -> Result<String> {
     anyhow::bail!("Message content is required. Use one of:\n  --message \"your message\"\n  --file message.txt\n  --stdin\n  Or run without --non-interactive to be prompted");
 }
 
-use rand::Rng;
+use rand::RngExt;

--- a/crates/mqttv5-cli/src/commands/sub_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/sub_cmd.rs
@@ -629,4 +629,4 @@ fn validate_topic_filter(topic: &str) -> Result<()> {
     Ok(())
 }
 
-use rand::Rng;
+use rand::RngExt;


### PR DESCRIPTION
Closes #85

## Config defaults (fixes #85)
`load_config_from_file` deserializes the JSON config straight into `BrokerConfig`, but the struct had no container-level `#[serde(default)]`, so any omitted non-`Option`/non-defaulted field (e.g. `max_clients`) made parsing fail — contradicting the per-field defaults documented in `CLI_USAGE.md`.

- Added `#[serde(default)]` at the container level to `BrokerConfig` and nested `AuthConfig`, `RateLimitConfig`, `StorageConfig`, `WebSocketConfig`. Missing fields now fall back to their `Default` impls. A minimal `{}` config is valid.
- Documented the optional-field behavior in `CLI_USAGE.md`.
- Added regression tests: empty config, single-field override, partial nested `auth_config`, and partial nested `storage_config`.
- Verified end-to-end against the built `mqttv5` binary: `mqttv5 broker -c <partial.conf>` and `{}` both start on defaults.

**Scope note:** `TlsConfig` and `QuicConfig` are intentionally *not* given a container-level `#[serde(default)]`. They require explicit `cert_file`/`key_file` paths, so a partial TLS/QUIC block should fail loudly rather than silently start a TLS-based listener with empty cert paths. Only the configs that have a meaningful all-defaults state (`auth`/`storage`/`websocket`/`rate-limit`) are defaulted.

## Dependency updates
`cargo update` for all in-range bumps, plus every remaining major version:

- `hashbrown` 0.16→0.17, `sha2` 0.10→0.11, `toml` 0.9→1, `tokio-tungstenite` 0.28→0.29, `gloo-timers` 0.3→0.4, `getrandom` 0.3→0.4
- `rand` 0.9→0.10 — the `.random()` method moved from `Rng` to the new `RngExt` trait; updated 4 imports accordingly
- opentelemetry stack 0.31→0.32 and `tracing-opentelemetry` 0.32→0.33

`cargo outdated` now reports all dependencies up to date.

## Public API cleanup
The four SCRAM credential functions (`ScramCredentials::from_password` / `from_password_with_iterations`, `generate_scram_credential_line` / `_with_iterations`) previously returned `std::result::Result<_, getrandom::Error>`, leaking a third-party error type. They now return the crate's `Result<_, MqttError>` (salt-generation failure → `MqttError::Io`). This removes `getrandom` from the public API entirely, so future `getrandom` bumps are no longer breaking. Callers using `?`/`anyhow` are unaffected; only direct matches on `getrandom::Error` need to switch to `MqttError`.

## Version bumps (SemVer)
Two breaking public-API changes drive minor bumps:

- `mqtt5-protocol` **0.13.0 → 0.14.0** — `SubscriptionManager::all()` returns `hashbrown::HashMap`, so the `hashbrown` 0.17 bump changes a public return type.
- `mqtt5` **0.32.2 → 0.33.0** — SCRAM error-type change above (the signatures change regardless of the wrap). Also bumps its `mqtt5-protocol` requirement to `0.14`.

Transitive (non-breaking) bumps + requirement updates so the workspace `[patch.crates-io]` keeps resolving:

- `mqtt5-wasm` **1.3.2 → 1.3.3** (deps: `mqtt5` `0.33`, `mqtt5-protocol` `0.14`)
- `mqttv5-cli` **0.27.3 → 0.27.4** (dep: `mqtt5` `0.33`)
- conformance crates unchanged (`publish = false`, path-only deps)

CHANGELOG updated for all four published crates.

## Cleanup
Fixed all workspace clippy warnings surfaced under the newer toolchain (10 `duration_suboptimal_units`, 6 `map().unwrap_or()` → `map_or`).

## Verification
- `cargo make ci-verify` (fmt + clippy + tests) passes
- full all-features build, 326+ unit tests, SCRAM unit tests, and dep-sensitive integration tests (bridge, websocket) pass
- e2e: `mqttv5 scram --stdout --batch ... ` produces a valid credential line through the wrapped error path
- wasm32 target builds; `cargo metadata`/`cargo tree` confirm `mqtt5 0.33.0` and `mqtt5-protocol 0.14.0` resolve to local paths
