### PR TITLE
fix release notes changelog extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,9 +200,11 @@ jobs:
         id: changelog
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          # Extract the changelog section for this version
-          sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d' > release_notes.md
-          # If empty, use a default message
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[mqtt5 " ver "\\]" {capture=1; print; next}
+            capture && /^## \[mqtt5 / {exit}
+            capture {print}
+          ' CHANGELOG.md > release_notes.md
           if [ ! -s release_notes.md ]; then
             echo "Release ${VERSION}" > release_notes.md
           fi


### PR DESCRIPTION
The release workflow extracted notes with `sed -n "/## \[${VERSION}\]/..."`, looking for `## [0.33.0]`. Our CHANGELOG headers are per-crate (`## [mqtt5 0.33.0]`), so the pattern never matched and the GitHub Release body fell back to the bare `Release <version>` text.

Replaced it with an awk extractor anchored on the `## [mqtt5 <version>]` header (the release is already gated on the tag matching mqtt5's version) that captures every section down to the previous `## [mqtt5 ...]` entry. Since each release cycle is anchored by a new mqtt5 entry with the sibling crate bumps listed beneath it, this pulls in all four crate sections (mqtt5, mqtt5-protocol, mqtt5-wasm, mqttv5-cli) for the cycle and stops at the prior release.

Verified locally against the current CHANGELOG for `0.33.0` — extracts the full mqtt5 + protocol + wasm + cli sections and stops at `## [mqtt5 0.32.2]`.