### PR TITLE
generate test tls key at runtime instead of embedding

### DIFF
--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -55,6 +55,7 @@ wasm-bindgen-test = "0.3"
 
 url = "2.5.4"
 tempfile = "3.12.0"
+rcgen = "0.14.8"
 
 [[example]]
 name = "simple_broker"

--- a/crates/mqtt5/src/transport/tls.rs
+++ b/crates/mqtt5/src/transport/tls.rs
@@ -673,20 +673,12 @@ TA==
             "localhost",
         );
 
-        // Test valid RSA private key in PEM format
-        let valid_key_pem = b"-----BEGIN RSA PRIVATE KEY-----
-MIIBOgIBAAJBALtUlNS31SzxwoFSZEq9bZogYwEwTF2oanidzJ/gHMZM4hS1KGA/
-r67uSPuYEfar2w/ls7EUqpBLMAODyFI3jPzPajcZhQGPm4QmOHyJVHU4aWa/SJiD
-OBlaOknDsEsbQczA19v4fiFOWByllgfyAzGYZCJCY7FIo0kDPnE8lMEY0mO8/5nc
-13xtB7aqc7PgenezaqzsLgapo9U/mrsvFcgCAgMBAAECQBKmZi7m2J+5nEoM0YKU
-wQgRqT2kFz8tJO0Q9r4rQfkbFm8OmVZs9FcX+Z8vCcOqS8nG0z8cRGhX+rKhRrVu
-uoECIQDdwJmRZQhCGpX0P8Q6v5B2J7mOZQVg7VK1g4YFcYHyeQIhANJFfHjHgKqJ
-x8Z9fQzK8u0FDlq0wGHkL1rCgJzQLHmBAiEA6VjXlZGhF2G8EL4P+7+P6u6W2Qrb
-u9W5m0K4kV2sQ2ECIDTqoHEfL2+OzPsQpBxZ5kD6XpGuL6UKYXyF+VZw9uGBAiBm
-QK8Q2JGfQtK+7F6vGgR8QKrMgJh6EwZhLl3mPVH+QQ==
------END RSA PRIVATE KEY-----";
+        let key_pair = rcgen::KeyPair::generate().expect("generate key pair");
+        let valid_key_pem = key_pair.serialize_pem();
 
-        assert!(config.load_client_key_pem_bytes(valid_key_pem).is_ok());
+        assert!(config
+            .load_client_key_pem_bytes(valid_key_pem.as_bytes())
+            .is_ok());
         assert!(config.client_key.is_some());
 
         // Test invalid PEM data


### PR DESCRIPTION
Resolves the secret-scanning alert for `crates/mqtt5/src/transport/tls.rs` (RSA Private Key, commit `dea578ac`).

The TLS PEM-loading unit test embedded a hardcoded RSA private key blob, which secret scanning flags. It was a throwaway test fixture guarding nothing, but its presence in source keeps triggering detection.

## Change
- Generate the key at test runtime via `rcgen::KeyPair::generate().serialize_pem()` instead of embedding a private-key literal.
- Add `rcgen` as a dev-dependency.

`load_client_key_pem_bytes` uses rustls `pem_slice_iter`, which accepts the PKCS#8 PEM that rcgen emits. Test passes; clippy clean.

## Not addressed here (no code in current tree)
The other two alerts are history-only test fixtures already removed from tracking in `65eb0c5` and gitignored (`test_certs/*.key`):
- `test_certs/ca.key` (commit `e340249`)
- `test_certs/client.key` (commit `e340249`)

Per decision, git history will not be rewritten — those alerts should be dismissed as "used in tests". After this merges, the `tls.rs` alert can likewise be dismissed (the key still exists in history, only removed from HEAD).