### PR TITLE
broker hardening: configurable inbound limits, drop dead memory limiter, SCRAM lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING: removed the unenforced memory-limit API** - deleted `ResourceLimits.max_memory_bytes` (public field) and the `ResourceMonitor::get_memory_usage` / `ResourceMonitor::is_memory_limit_exceeded` methods. They were never wired into connection admission, and the estimate was a fixed `connections * 4096` that undercounted real usage; `max_clients` remains the deterministic bound on connection memory. Code referencing these items must drop those references.
 
-## [mqtt5-wasm 1.3.4] - 2026-06-28
+## [mqtt5-wasm 1.4.0] - 2026-06-28
+
+### Added
+
+- **Inbound per-client rate and bandwidth limits are now configurable on the wasm broker** - the wasm `BrokerConfig` binding gained `maxMessageRatePerClient` (messages/sec) and `maxBandwidthPerClient` (bytes/sec) setters, both defaulting to `0` (unlimited). They drive the broker's per-client inbound limiter and are applied both on construction and through `updateConfig`, mirroring the new native `mqtt5` 0.34 `BrokerConfig` fields.
 
 ### Changed
 
-- **Transitive bump: `mqtt5` 0.34** - picks up the configurable inbound rate/bandwidth limits and the removal of the unenforced memory-limit API. No wasm surface changes; the affected `mqtt5` items are not re-exported through the wasm API.
+- **Transitive bump: `mqtt5` 0.34** - picks up the configurable inbound rate/bandwidth limits and the removal of the unenforced memory-limit API. The wasm broker now wires these inbound limits through to its resource monitor; previously it always used the library defaults regardless of config.
 
 ## [mqttv5-cli 0.28.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.34.0] - 2026-06-28
+
+### Added
+
+- **Inbound per-client rate and bandwidth limits are now configurable** - `BrokerConfig` gained `max_message_rate_per_client` (messages/sec) and `max_bandwidth_per_client` (bytes/sec), both defaulting to `0` (unlimited). These drive the broker's existing per-client inbound limiters, which were previously hardcoded "off" and unreachable from a config file. The values are hot-reloadable through the existing SIGHUP path. Adding these public fields to `BrokerConfig` (not `#[non_exhaustive]`) is technically breaking for code that constructs it with a struct literal; builder- and `Default`-based construction is unaffected.
+
+### Changed
+
+- **Inbound rate and bandwidth limits are now enforced independently** - `ResourceMonitor::can_send_message` previously short-circuited on `max_message_rate >= 1_000_000`, so the bandwidth limit silently did nothing unless message-rate limiting was also enabled. Each limit is now evaluated on its own (`0 = unlimited`), so `max_bandwidth_per_client` takes effect without also setting a message-rate cap. Default behavior is unchanged: both `0` takes the fast path with no per-message accounting.
+- **SCRAM credential store no longer uses a poisoning lock** - `FileBasedScramCredentialStore` switched from `std::sync::RwLock` to `parking_lot::RwLock`, matching the rest of the broker and removing the poison-on-panic footgun on the authentication path. Internal; no public-API impact.
+
+### Removed
+
+- **BREAKING: removed the unenforced memory-limit API** - deleted `ResourceLimits.max_memory_bytes` (public field) and the `ResourceMonitor::get_memory_usage` / `ResourceMonitor::is_memory_limit_exceeded` methods. They were never wired into connection admission, and the estimate was a fixed `connections * 4096` that undercounted real usage; `max_clients` remains the deterministic bound on connection memory. Code referencing these items must drop those references.
+
+## [mqtt5-wasm 1.3.4] - 2026-06-28
+
+### Changed
+
+- **Transitive bump: `mqtt5` 0.34** - picks up the configurable inbound rate/bandwidth limits and the removal of the unenforced memory-limit API. No wasm surface changes; the affected `mqtt5` items are not re-exported through the wasm API.
+
+## [mqttv5-cli 0.28.0] - 2026-06-28
+
+### Added
+
+- **`generate-config` emits the new inbound limit keys** - the example config produced by `mqttv5 broker generate-config` now includes `max_message_rate_per_client` and `max_bandwidth_per_client` (both `0` = unlimited), matching the new `mqtt5` 0.34 `BrokerConfig` fields.
+
+### Changed
+
+- **Transitive bump: `mqtt5` 0.34** - no other CLI surface changes.
+
 ## [mqtt5 0.33.0] - 2026-06-13
 
 ### Fixed

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.3.4"
+version = "1.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.3.3"
+version = "1.3.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
 mqtt5-protocol = "0.14.0"
-mqtt5 = { version = "0.33", optional = true, default-features = false, features = [
+mqtt5 = { version = "0.34", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5-wasm/src/bridge/loop_prevention.rs
+++ b/crates/mqtt5-wasm/src/bridge/loop_prevention.rs
@@ -155,10 +155,30 @@ mod tests {
 
     #[test]
     fn test_fingerprint_uniqueness() {
-        let fp1 = WasmLoopPrevention::calculate_fingerprint("topic/a", b"payload", 1, false);
-        let fp2 = WasmLoopPrevention::calculate_fingerprint("topic/b", b"payload", 1, false);
-        let fp3 = WasmLoopPrevention::calculate_fingerprint("topic/a", b"payload", 2, false);
-        let fp4 = WasmLoopPrevention::calculate_fingerprint("topic/a", b"payload", 1, true);
+        let fp1 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/a",
+            b"payload",
+            QoS::AtLeastOnce,
+            false,
+        );
+        let fp2 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/b",
+            b"payload",
+            QoS::AtLeastOnce,
+            false,
+        );
+        let fp3 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/a",
+            b"payload",
+            QoS::ExactlyOnce,
+            false,
+        );
+        let fp4 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/a",
+            b"payload",
+            QoS::AtLeastOnce,
+            true,
+        );
 
         assert_ne!(fp1, fp2);
         assert_ne!(fp1, fp3);
@@ -167,8 +187,18 @@ mod tests {
 
     #[test]
     fn test_fingerprint_same_content() {
-        let fp1 = WasmLoopPrevention::calculate_fingerprint("topic/a", b"payload", 1, false);
-        let fp2 = WasmLoopPrevention::calculate_fingerprint("topic/a", b"payload", 1, false);
+        let fp1 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/a",
+            b"payload",
+            QoS::AtLeastOnce,
+            false,
+        );
+        let fp2 = WasmLoopPrevention::calculate_fingerprint(
+            "topic/a",
+            b"payload",
+            QoS::AtLeastOnce,
+            false,
+        );
 
         assert_eq!(fp1, fp2);
     }

--- a/crates/mqtt5-wasm/src/broker.rs
+++ b/crates/mqtt5-wasm/src/broker.rs
@@ -47,6 +47,8 @@ struct ConfigHashFields {
     echo_suppression_enabled: bool,
     echo_suppression_property_key: Option<String>,
     max_outbound_rate_per_client: u32,
+    max_message_rate_per_client: u32,
+    max_bandwidth_per_client: u64,
     load_balancer_backends: Vec<String>,
 }
 
@@ -69,6 +71,8 @@ pub struct WasmBrokerConfig {
     echo_suppression_enabled: bool,
     echo_suppression_property_key: Option<String>,
     max_outbound_rate_per_client: u32,
+    max_message_rate_per_client: u32,
+    max_bandwidth_per_client: u64,
     load_balancer_backends: Vec<String>,
 }
 
@@ -94,6 +98,8 @@ impl WasmBrokerConfig {
             echo_suppression_enabled: false,
             echo_suppression_property_key: None,
             max_outbound_rate_per_client: 0,
+            max_message_rate_per_client: 0,
+            max_bandwidth_per_client: 0,
             load_balancer_backends: Vec::new(),
         }
     }
@@ -183,6 +189,16 @@ impl WasmBrokerConfig {
         self.max_outbound_rate_per_client = value;
     }
 
+    #[wasm_bindgen(setter, js_name = "maxMessageRatePerClient")]
+    pub fn set_max_message_rate_per_client(&mut self, value: u32) {
+        self.max_message_rate_per_client = value;
+    }
+
+    #[wasm_bindgen(setter, js_name = "maxBandwidthPerClient")]
+    pub fn set_max_bandwidth_per_client(&mut self, value: u64) {
+        self.max_bandwidth_per_client = value;
+    }
+
     #[wasm_bindgen(js_name = "addLoadBalancerBackend")]
     pub fn add_load_balancer_backend(&mut self, backend: String) {
         self.load_balancer_backends.push(backend);
@@ -221,6 +237,8 @@ impl WasmBrokerConfig {
                     .unwrap_or_else(|| "x-origin-client-id".to_string()),
             },
             max_outbound_rate_per_client: self.max_outbound_rate_per_client,
+            max_message_rate_per_client: self.max_message_rate_per_client,
+            max_bandwidth_per_client: self.max_bandwidth_per_client,
             load_balancer: if self.load_balancer_backends.is_empty() {
                 None
             } else {
@@ -248,6 +266,8 @@ impl WasmBrokerConfig {
             echo_suppression_enabled: self.echo_suppression_enabled,
             echo_suppression_property_key: self.echo_suppression_property_key.clone(),
             max_outbound_rate_per_client: self.max_outbound_rate_per_client,
+            max_message_rate_per_client: self.max_message_rate_per_client,
+            max_bandwidth_per_client: self.max_bandwidth_per_client,
             load_balancer_backends: self.load_balancer_backends.clone(),
         };
         let mut hasher = DefaultHasher::new();
@@ -259,6 +279,16 @@ impl WasmBrokerConfig {
 impl Default for WasmBrokerConfig {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+fn resource_limits_from(config: &BrokerConfig) -> ResourceLimits {
+    ResourceLimits {
+        max_connections: config.max_clients,
+        max_message_rate_per_client: config.max_message_rate_per_client,
+        max_bandwidth_per_client: config.max_bandwidth_per_client,
+        rate_limit_window: Duration::from_secs(1),
+        ..Default::default()
     }
 }
 
@@ -324,11 +354,9 @@ impl WasmBroker {
 
         let stats = Arc::new(BrokerStats::new());
 
-        let max_clients = config.read().map_or(1000, |c| c.max_clients);
-        let limits = ResourceLimits {
-            max_connections: max_clients,
-            ..Default::default()
-        };
+        let limits = config
+            .read()
+            .map_or_else(|_| ResourceLimits::default(), |c| resource_limits_from(&c));
         let resource_monitor = Arc::new(ResourceMonitor::new(limits));
 
         let bridge_manager = Rc::new(RefCell::new(WasmBridgeManager::new(Arc::clone(&router))));
@@ -659,6 +687,7 @@ impl WasmBroker {
             None
         };
         let max_rate = broker_config.max_outbound_rate_per_client;
+        let new_limits = resource_limits_from(&broker_config);
 
         if let Ok(mut config) = self.config.try_write() {
             *config = broker_config;
@@ -678,6 +707,7 @@ impl WasmBroker {
         }
 
         self.router.update_max_outbound_rate(max_rate);
+        self.resource_monitor.update_limits(new_limits);
 
         self.config_hash.set(new_hash);
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.33.0"
+version = "0.34.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/auth_mechanisms/scram.rs
+++ b/crates/mqtt5/src/broker/auth_mechanisms/scram.rs
@@ -3,6 +3,7 @@ use crate::error::{MqttError, Result};
 use crate::packet::connect::ConnectPacket;
 use crate::protocol::v5::reason_codes::ReasonCode;
 use base64::prelude::*;
+use parking_lot::RwLock;
 use ring::{hmac, pbkdf2};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -10,7 +11,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::num::NonZeroU32;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock as TokioRwLock;
 use tracing::{debug, warn};
@@ -171,7 +172,7 @@ impl Default for FileBasedScramCredentialStore {
 
 impl ScramCredentialStore for FileBasedScramCredentialStore {
     fn get_credentials(&self, username: &str) -> Option<ScramCredentials> {
-        self.credentials.read().unwrap().get(username).cloned()
+        self.credentials.read().get(username).cloned()
     }
 }
 
@@ -599,24 +600,18 @@ mod tests {
 
         fn add_user(&self, username: &str, password: &str) {
             let creds = ScramCredentials::from_password(password).unwrap();
-            self.credentials
-                .write()
-                .unwrap()
-                .insert(username.to_string(), creds);
+            self.credentials.write().insert(username.to_string(), creds);
         }
 
         fn add_user_with_salt(&self, username: &str, password: &str, salt: &[u8], iterations: u32) {
             let creds = ScramCredentials::from_password_and_salt(password, salt, iterations);
-            self.credentials
-                .write()
-                .unwrap()
-                .insert(username.to_string(), creds);
+            self.credentials.write().insert(username.to_string(), creds);
         }
     }
 
     impl ScramCredentialStore for TestCredentialStore {
         fn get_credentials(&self, username: &str) -> Option<ScramCredentials> {
-            self.credentials.read().unwrap().get(username).cloned()
+            self.credentials.read().get(username).cloned()
         }
     }
 

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -105,6 +105,10 @@ pub struct BrokerConfig {
     #[serde(default)]
     pub max_outbound_rate_per_client: u32,
     #[serde(default)]
+    pub max_message_rate_per_client: u32,
+    #[serde(default)]
+    pub max_bandwidth_per_client: u64,
+    #[serde(default)]
     pub server_delivery_strategy: ServerDeliveryStrategy,
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(default)]
@@ -166,6 +170,11 @@ impl std::fmt::Debug for BrokerConfig {
                 "max_outbound_rate_per_client",
                 &self.max_outbound_rate_per_client,
             )
+            .field(
+                "max_message_rate_per_client",
+                &self.max_message_rate_per_client,
+            )
+            .field("max_bandwidth_per_client", &self.max_bandwidth_per_client)
             .field("server_delivery_strategy", &self.server_delivery_strategy)
             .field("load_balancer", &self.load_balancer);
         #[cfg(not(target_arch = "wasm32"))]
@@ -210,6 +219,8 @@ impl Default for BrokerConfig {
             change_only_delivery_config: ChangeOnlyDeliveryConfig::default(),
             echo_suppression_config: EchoSuppressionConfig::default(),
             max_outbound_rate_per_client: 0,
+            max_message_rate_per_client: 0,
+            max_bandwidth_per_client: 0,
             server_delivery_strategy: ServerDeliveryStrategy::default(),
             #[cfg(not(target_arch = "wasm32"))]
             bridges: vec![],

--- a/crates/mqtt5/src/broker/resource_monitor.rs
+++ b/crates/mqtt5/src/broker/resource_monitor.rs
@@ -23,10 +23,7 @@ pub struct ResourceLimits {
     /// Maximum connections per IP address
     pub max_connections_per_ip: usize,
 
-    /// Maximum memory usage in bytes (0 = unlimited)
-    pub max_memory_bytes: u64,
-
-    /// Maximum message rate per client (messages/second)
+    /// Maximum message rate per client (messages/second, 0 = unlimited)
     pub max_message_rate_per_client: u32,
 
     /// Maximum bandwidth per client (bytes/second)
@@ -44,10 +41,9 @@ impl Default for ResourceLimits {
         Self {
             max_connections: 10_000,
             max_connections_per_ip: 100,
-            max_memory_bytes: 1024 * 1024 * 1024,       // 1GB
-            max_message_rate_per_client: 1000,          // 1000 msg/sec
+            max_message_rate_per_client: 1000, // 1000 msg/sec
             max_bandwidth_per_client: 10 * 1024 * 1024, // 10MB/sec
-            max_connection_rate: 100,                   // 100 conn/sec
+            max_connection_rate: 100,          // 100 conn/sec
             rate_limit_window: Duration::from_secs(60),
         }
     }
@@ -250,7 +246,10 @@ impl ResourceMonitor {
             )
         };
 
-        if max_message_rate >= 1_000_000 {
+        let rate_limited = max_message_rate > 0;
+        let bandwidth_limited = max_bandwidth > 0;
+
+        if !rate_limited && !bandwidth_limited {
             self.total_messages.fetch_add(1, Ordering::Relaxed);
             self.total_bytes
                 .fetch_add(message_size as u64, Ordering::Relaxed);
@@ -267,22 +266,26 @@ impl ResourceMonitor {
             resources.reset_window();
         }
 
-        let current_messages = resources.message_count.load(Ordering::Relaxed);
-        if current_messages >= u64::from(max_message_rate) {
-            warn!(
-                "Message rejected for {client_id}: rate limit exceeded ({current_messages} msg/{}s)",
-                rate_limit_window.as_secs()
-            );
-            return false;
+        if rate_limited {
+            let current_messages = resources.message_count.load(Ordering::Relaxed);
+            if current_messages >= u64::from(max_message_rate) {
+                warn!(
+                    "Message rejected for {client_id}: rate limit exceeded ({current_messages} msg/{}s)",
+                    rate_limit_window.as_secs()
+                );
+                return false;
+            }
         }
 
-        let current_bytes = resources.bytes_transferred.load(Ordering::Relaxed);
-        if current_bytes + message_size as u64 > max_bandwidth {
-            warn!(
-                "Message rejected for {client_id}: bandwidth limit exceeded ({current_bytes} bytes/{}s)",
-                rate_limit_window.as_secs()
-            );
-            return false;
+        if bandwidth_limited {
+            let current_bytes = resources.bytes_transferred.load(Ordering::Relaxed);
+            if current_bytes + message_size as u64 > max_bandwidth {
+                warn!(
+                    "Message rejected for {client_id}: bandwidth limit exceeded ({current_bytes} bytes/{}s)",
+                    rate_limit_window.as_secs()
+                );
+                return false;
+            }
         }
 
         resources.message_count.fetch_add(1, Ordering::Relaxed);
@@ -313,20 +316,6 @@ impl ResourceMonitor {
             total_messages: self.total_messages.load(Ordering::Relaxed),
             total_bytes: self.total_bytes.load(Ordering::Relaxed),
         }
-    }
-
-    pub fn get_memory_usage(&self) -> u64 {
-        let connection_count = self.connection_count.load(Ordering::Relaxed) as u64;
-        let memory_per_connection = 4096_u64;
-        connection_count * memory_per_connection
-    }
-
-    pub fn is_memory_limit_exceeded(&self) -> bool {
-        let max_memory_bytes = self.limits.read().max_memory_bytes;
-        if max_memory_bytes == 0 {
-            return false;
-        }
-        self.get_memory_usage() > max_memory_bytes
     }
 
     pub async fn update_connection_ip(&self, client_id: &str, old_ip: IpAddr, new_ip: IpAddr) {

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -347,9 +347,8 @@ impl MqttBroker {
 
         let auth_provider = create_auth_provider(&config.auth_config).await?;
         let stats = Arc::new(BrokerStats::new());
-        let resource_monitor = Arc::new(ResourceMonitor::new(Self::default_resource_limits(
-            config.max_clients,
-        )));
+        let resource_monitor =
+            Arc::new(ResourceMonitor::new(Self::default_resource_limits(&config)));
         let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
         let (ready_tx, ready_rx) = watch::channel(false);
 
@@ -764,13 +763,12 @@ impl MqttBroker {
         Arc::new(router)
     }
 
-    fn default_resource_limits(max_clients: usize) -> ResourceLimits {
+    fn default_resource_limits(config: &BrokerConfig) -> ResourceLimits {
         ResourceLimits {
-            max_connections: max_clients,
+            max_connections: config.max_clients,
             max_connections_per_ip: 10_000,
-            max_memory_bytes: 1024 * 1024 * 1024,
-            max_message_rate_per_client: 10_000_000,
-            max_bandwidth_per_client: 1024 * 1024 * 1024,
+            max_message_rate_per_client: config.max_message_rate_per_client,
+            max_bandwidth_per_client: config.max_bandwidth_per_client,
             max_connection_rate: 10_000,
             rate_limit_window: crate::time::Duration::from_secs(1),
         }
@@ -1544,8 +1542,7 @@ impl MqttBroker {
 
                 Self::warn_non_reloadable_changes(&old_config, &new_config);
 
-                resource_monitor
-                    .update_limits(Self::default_resource_limits(new_config.max_clients));
+                resource_monitor.update_limits(Self::default_resource_limits(&new_config));
 
                 match create_auth_provider(&new_config.auth_config).await {
                     Ok(new_auth) => {

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -225,7 +225,11 @@ impl DirectClientInner {
     }
 
     async fn reset_connection_runtime(&mut self, reason: &[u8]) {
-        self.stop_background_tasks();
+        tracing::debug!(
+            reason = %String::from_utf8_lossy(reason),
+            "resetting connection runtime"
+        );
+        self.stop_background_tasks().await;
         self.keepalive_state.lock().reset();
 
         #[cfg(feature = "transport-quic")]
@@ -1358,20 +1362,24 @@ impl DirectClientInner {
         Ok(())
     }
 
-    fn stop_background_tasks(&mut self) {
+    async fn stop_background_tasks(&mut self) {
         if let Some(handle) = self.packet_reader_handle.take() {
             handle.abort();
+            let _ = handle.await;
         }
         if let Some(handle) = self.keepalive_handle.take() {
             handle.abort();
+            let _ = handle.await;
         }
         #[cfg(feature = "transport-quic")]
         if let Some(handle) = self.quic_stream_acceptor_handle.take() {
             handle.abort();
+            let _ = handle.await;
         }
         #[cfg(feature = "transport-quic")]
         if let Some(handle) = self.flow_expiration_handle.take() {
             handle.abort();
+            let _ = handle.await;
         }
     }
 }

--- a/crates/mqtt5/tests/resource_monitoring_integration.rs
+++ b/crates/mqtt5/tests/resource_monitoring_integration.rs
@@ -116,54 +116,13 @@ async fn test_message_rate_limiting() {
         .register_connection("test_client".to_string(), ip)
         .await;
 
-    // Test message rate limiting (default is 1000 messages/sec)
-    // Send messages within limit
     for _ in 0..10 {
         assert!(resource_monitor.can_send_message("test_client", 100).await);
     }
 
-    // Check stats were updated
     let stats = resource_monitor.get_stats().await;
     assert_eq!(stats.total_messages, 10);
-    assert_eq!(stats.total_bytes, 1000); // 10 messages * 100 bytes each
-
-    broker_handle.abort();
-}
-
-#[tokio::test]
-async fn test_memory_monitoring() {
-    let config = BrokerConfig::default()
-        .with_bind_address("127.0.0.1:0".parse::<std::net::SocketAddr>().unwrap())
-        .with_max_clients(5);
-
-    let mut broker = MqttBroker::with_config(config).await.unwrap();
-    let resource_monitor = broker.resource_monitor();
-
-    let broker_handle = tokio::spawn(async move {
-        let _ = broker.run().await;
-    });
-
-    sleep(Duration::from_millis(100)).await;
-
-    // Test memory usage estimation
-    let initial_memory = resource_monitor.get_memory_usage();
-    assert_eq!(initial_memory, 0); // No connections initially
-
-    let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
-
-    // Add some connections
-    for i in 0..3 {
-        resource_monitor
-            .register_connection(format!("client{i}"), ip)
-            .await;
-    }
-
-    let memory_with_connections = resource_monitor.get_memory_usage();
-    assert!(memory_with_connections > initial_memory);
-    assert_eq!(memory_with_connections, 3 * 4096); // 3 connections * 4KB estimate each
-
-    // Test memory limit checking (default is 1GB, should not be exceeded)
-    assert!(!resource_monitor.is_memory_limit_exceeded());
+    assert_eq!(stats.total_bytes, 1000);
 
     broker_handle.abort();
 }

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.27.4"
+version = "0.28.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.33" }
+mqtt5 = { path = "../mqtt5", version = "0.34" }
 anyhow = "1.0"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mqttv5-cli/src/commands/broker_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/broker_cmd.rs
@@ -346,6 +346,8 @@ fn build_example_config() -> BrokerConfig {
         change_only_delivery_config: ChangeOnlyDeliveryConfig::default(),
         echo_suppression_config: mqtt5::broker::config::EchoSuppressionConfig::default(),
         max_outbound_rate_per_client: 0,
+        max_message_rate_per_client: 0,
+        max_bandwidth_per_client: 0,
         server_delivery_strategy: mqtt5::broker::config::ServerDeliveryStrategy::default(),
         load_balancer: None,
         bridges: vec![],


### PR DESCRIPTION
## Summary

Broker-hardening cleanups to the `mqtt5` crate (surfaced while reviewing the public AWS broker deployment), now also wired through the wasm broker:

1. **Configurable inbound limits.** `BrokerConfig` gains `max_message_rate_per_client` (msg/s) and `max_bandwidth_per_client` (bytes/s), both `0 = unlimited`. These drive the broker's existing per-client inbound limiters, which were previously hardcoded "off" and unreachable from a config file. They're hot-reloadable via the existing SIGHUP path.
   - Also fixes a latent bug: `can_send_message` short-circuited on `max_message_rate >= 1_000_000`, so the bandwidth limit silently did nothing unless message-rate limiting was also enabled. Each limit is now enforced independently. Defaults (`0`/`0`) preserve current behavior — fast path, no per-message accounting, no regression.
2. **Dropped the dead memory limiter.** Removed `ResourceLimits.max_memory_bytes` and `ResourceMonitor::{get_memory_usage, is_memory_limit_exceeded}`. These were never wired into connection admission, and the estimate was a fabricated `connections * 4096` that undercounted real usage. `max_clients` remains the deterministic bound on connection memory.
3. **SCRAM lock.** `FileBasedScramCredentialStore` switched from `std::sync::RwLock` to `parking_lot::RwLock`, matching the rest of the broker and removing the poison-on-panic footgun on the authentication path. Internal; no public-API impact.
4. **Wasm broker honors the inbound limits.** The wasm `BrokerConfig` binding gains `maxMessageRatePerClient` / `maxBandwidthPerClient` setters (both `0 = unlimited`), plumbed through `to_broker_config`, the config hash, and into `ResourceLimits` on both construction and `updateConfig` (hot reload) — mirroring the native path. Previously the wasm broker built `ResourceLimits::default()` and silently enforced 1000 msg/60s + 10 MB/s regardless of config; it now defaults to unlimited, consistent with the native broker.
   - Also fixes two pre-existing wasm clippy/build failures unrelated to the limits work: `loop_prevention` tests passed integer literals where `QoS` is required (`E0308`), and `reset_connection_runtime` tripped `unused_async`/unused-variable in no-quic builds (the wasm config) because its only `.await` and only use of `reason` were quic-gated. `stop_background_tasks` is now async and awaits the aborted task handles (deterministic teardown), and the reset reason is logged.

## Breaking change

Removing the public memory-limit API and adding fields to the non-`#[non_exhaustive]` `BrokerConfig` are SemVer-breaking, so `mqtt5` takes a minor bump (0.x). Adding the wasm config setters is additive public API, so `mqtt5-wasm` takes a minor bump.

## Version bumps

| Crate | From | To | Reason |
|---|---|---|---|
| `mqtt5` | 0.33.0 | **0.34.0** | breaking change |
| `mqttv5-cli` | 0.27.4 | **0.28.0** | `generate-config` emits the new keys; `mqtt5` dep req `0.33` → `0.34` |
| `mqtt5-wasm` | 1.3.3 | **1.4.0** | new wasm broker inbound-limit setters (additive API); `mqtt5` dep req `0.33` → `0.34` |

The two `mqtt5` dependency-requirement bumps are required for the workspace to keep resolving the local `mqtt5` through `[patch.crates-io]` (otherwise the cli path-pin hard-errors and the wasm dep silently falls back to crates.io 0.33). `mqtt5-protocol` and the `publish = false` conformance crates are unaffected.

`CHANGELOG.md` updated with sections for all three crates, laid out so the release workflow's `awk` extraction scoops them into the `v0.34.0` notes.

## Verification

- `cargo check` / `cargo clippy --all-targets --workspace -- -D warnings -W clippy::pedantic` / `cargo fmt --check` — clean (native + `wasm32` broker target, via the pre-commit hook).
- `cargo clippy -p mqtt5 --all-features --all-targets` and `-p mqtt5-wasm --features broker` (native + `wasm32 --all-targets`) — clean.
- Tests: `resource_monitor` 4/4, `resource_monitoring_integration` 3/3, `scram` 16/16, `client::direct` 17/17.
- `cargo tree` confirms `mqttv5-cli` and `mqtt5-wasm --features broker` both resolve to local `mqtt5 v0.34.0`; `cargo metadata` reports no unused-patch warnings.
