### PR TITLE
wire up broker graceful shutdown via shutdown_handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.35.0] - 2026-07-04
+
+### Added
+
+- **`MqttBroker::shutdown_handle()` returns a cloneable `BrokerShutdownHandle`** - obtain the handle before moving the broker into `run()`, then call `handle.shutdown()` from a signal handler or any other task to make `run()` return after completing its graceful shutdown. This is the correct way to trigger shutdown of a running broker; the previous pattern of racing `run()` in a `tokio::select!` dropped the `run()` future without signaling it, leaving the `$SYS` publisher and transport accept loops running as detached tasks.
+
+### Changed
+
+- **BREAKING: `MqttBroker::shutdown()` is now `fn shutdown(&self)` instead of `async fn shutdown(&self) -> Result<()>`** - it now only fires the internal shutdown signal, which is synchronous. The graceful teardown (aborting the `$SYS` task, stopping bridges, joining transport accept loops with a 5s timeout, flushing telemetry) moved into `run()`'s post-signal path, where the spawned tasks actually live. Callers using `broker.shutdown().await?` must drop the `.await` and `?`. The old method was effectively a no-op once `run()` had started, because `run()` had taken ownership of the shutdown sender.
+
 ## [mqtt5 0.34.0] - 2026-06-28
 
 ### Added

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -28,7 +28,7 @@ codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
 mqtt5-protocol = "0.14.0"
-mqtt5 = { version = "0.34", optional = true, default-features = false, features = [
+mqtt5 = { version = "0.35", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.34.0"
+version = "0.35.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/examples/broker_all_transports.rs
+++ b/crates/mqtt5/examples/broker_all_transports.rs
@@ -61,16 +61,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("  QUIC:       quic://localhost:14567");
     info!("Press Ctrl+C to stop");
 
-    // Run until shutdown signal
-    tokio::select! {
-        result = broker.run() => {
-            if let Err(e) = result {
-                eprintln!("Broker error: {e}");
-            }
-        }
-        _ = tokio::signal::ctrl_c() => {
-            info!("Shutting down...");
-        }
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Shutting down...");
+        shutdown.shutdown();
+    });
+
+    if let Err(e) = broker.run().await {
+        eprintln!("Broker error: {e}");
     }
 
     Ok(())

--- a/crates/mqtt5/examples/broker_with_enhanced_auth.rs
+++ b/crates/mqtt5/examples/broker_with_enhanced_auth.rs
@@ -171,23 +171,17 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     info!("📋 Expected response: correct-response-67890");
     info!("🛑 Press Ctrl+C to stop\n");
 
-    let shutdown = tokio::spawn(async {
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
         tokio::signal::ctrl_c()
             .await
             .expect("Failed to listen for ctrl-c");
         info!("\n⚠️  Shutdown signal received");
+        shutdown.shutdown();
     });
 
-    tokio::select! {
-        result = broker.run() => {
-            match result {
-                Ok(()) => info!("Broker stopped normally"),
-                Err(e) => error!("Broker error: {e}"),
-            }
-        }
-        _ = shutdown => {
-            info!("Shutting down broker...");
-        }
+    if let Err(e) = broker.run().await {
+        error!("Broker error: {e}");
     }
 
     info!("✅ Broker shutdown complete");

--- a/crates/mqtt5/examples/broker_with_tls.rs
+++ b/crates/mqtt5/examples/broker_with_tls.rs
@@ -38,16 +38,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("  TLS: mqtts://localhost:8883");
     info!("Press Ctrl+C to stop");
 
-    // Run until shutdown signal
-    tokio::select! {
-        result = broker.run() => {
-            if let Err(e) = result {
-                eprintln!("Broker error: {e}");
-            }
-        }
-        _ = tokio::signal::ctrl_c() => {
-            info!("Shutting down...");
-        }
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Shutting down...");
+        shutdown.shutdown();
+    });
+
+    if let Err(e) = broker.run().await {
+        eprintln!("Broker error: {e}");
     }
 
     Ok(())

--- a/crates/mqtt5/examples/broker_with_websocket.rs
+++ b/crates/mqtt5/examples/broker_with_websocket.rs
@@ -30,16 +30,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("  WebSocket: ws://localhost:8080/mqtt");
     info!("Press Ctrl+C to stop");
 
-    // Run until shutdown signal
-    tokio::select! {
-        result = broker.run() => {
-            if let Err(e) = result {
-                eprintln!("Broker error: {e}");
-            }
-        }
-        _ = tokio::signal::ctrl_c() => {
-            info!("Shutting down...");
-        }
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        info!("Shutting down...");
+        shutdown.shutdown();
+    });
+
+    if let Err(e) = broker.run().await {
+        eprintln!("Broker error: {e}");
     }
 
     Ok(())

--- a/crates/mqtt5/examples/simple_broker.rs
+++ b/crates/mqtt5/examples/simple_broker.rs
@@ -82,25 +82,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("📡 Clients can connect to mqtt://localhost:1883");
     info!("🛑 Press Ctrl+C to stop the broker\n");
 
-    // Handle shutdown signal
-    let shutdown = tokio::spawn(async {
+    // Trigger graceful shutdown on Ctrl+C
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
         tokio::signal::ctrl_c()
             .await
             .expect("Failed to listen for ctrl-c");
         info!("\n⚠️  Shutdown signal received");
+        shutdown.shutdown();
     });
 
-    // Run the broker
-    tokio::select! {
-        result = broker.run() => {
-            match result {
-                Ok(()) => info!("Broker stopped normally"),
-                Err(e) => error!("Broker error: {e}"),
-            }
-        }
-        _ = shutdown => {
-            info!("Shutting down broker...");
-        }
+    // Run the broker until shutdown is signaled
+    if let Err(e) = broker.run().await {
+        error!("Broker error: {e}");
     }
 
     info!("✅ Broker shutdown complete");

--- a/crates/mqtt5/src/broker/mod.rs
+++ b/crates/mqtt5/src/broker/mod.rs
@@ -5,17 +5,19 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use mqtt5::broker::{MqttBroker, BrokerConfig};
+//! use mqtt5::broker::MqttBroker;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     // Start a simple broker
-//!     let broker = MqttBroker::bind("0.0.0.0:1883").await?;
-//!     
-//!     // Run until shutdown signal
-//!     tokio::signal::ctrl_c().await?;
-//!     broker.shutdown().await?;
-//!     
+//!     let mut broker = MqttBroker::bind("0.0.0.0:1883").await?;
+//!
+//!     let shutdown = broker.shutdown_handle();
+//!     tokio::spawn(async move {
+//!         tokio::signal::ctrl_c().await.ok();
+//!         shutdown.shutdown();
+//!     });
+//!
+//!     broker.run().await?;
 //!     Ok(())
 //! }
 //! ```
@@ -73,7 +75,7 @@ pub use events::{
 pub use hot_reload::HotReloadManager;
 pub use resource_monitor::{ResourceLimits, ResourceMonitor, ResourceStats};
 #[cfg(not(target_arch = "wasm32"))]
-pub use server::MqttBroker;
+pub use server::{BrokerShutdownHandle, MqttBroker};
 #[cfg(not(target_arch = "wasm32"))]
 pub use storage::{DynamicStorage, FileBackend, MemoryBackend, Storage, StorageBackend};
 #[cfg(target_arch = "wasm32")]

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -54,6 +54,26 @@ impl AcceptLoopState {
     }
 }
 
+/// Handle for triggering graceful shutdown of a running [`MqttBroker`].
+///
+/// Obtained from [`MqttBroker::shutdown_handle`]. Cloneable and `Send`, so it
+/// can be moved into a signal handler or any other task while the broker itself
+/// is driven by [`MqttBroker::run`].
+#[derive(Clone)]
+pub struct BrokerShutdownHandle {
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
+}
+
+impl BrokerShutdownHandle {
+    /// Signals the broker to shut down gracefully.
+    ///
+    /// Delivery is best effort: if the broker has already stopped, the signal is
+    /// dropped silently.
+    pub fn shutdown(&self) {
+        self.shutdown_tx.send(()).ok();
+    }
+}
+
 /// MQTT v5.0 Broker
 pub struct MqttBroker {
     config: Arc<BrokerConfig>,
@@ -82,7 +102,7 @@ pub struct MqttBroker {
     cluster_tls_acceptor: Option<TlsAcceptor>,
     #[cfg(feature = "transport-quic")]
     cluster_quic_endpoints: Vec<Endpoint>,
-    shutdown_tx: Option<tokio::sync::broadcast::Sender<()>>,
+    shutdown_tx: tokio::sync::broadcast::Sender<()>,
     ready_tx: Option<watch::Sender<bool>>,
     ready_rx: watch::Receiver<bool>,
     config_watch_tx: watch::Sender<Arc<BrokerConfig>>,
@@ -388,7 +408,7 @@ impl MqttBroker {
             cluster_tls_acceptor,
             #[cfg(feature = "transport-quic")]
             cluster_quic_endpoints,
-            shutdown_tx: Some(shutdown_tx),
+            shutdown_tx,
             ready_tx: Some(ready_tx),
             ready_rx,
             config_watch_tx,
@@ -1607,11 +1627,7 @@ impl MqttBroker {
         #[cfg(feature = "transport-quic")]
         let cluster_quic_endpoints = std::mem::take(&mut self.cluster_quic_endpoints);
 
-        let Some(shutdown_tx) = self.shutdown_tx.take() else {
-            return Err(MqttError::InvalidState(
-                "Broker already running".to_string(),
-            ));
-        };
+        let shutdown_tx = self.shutdown_tx.clone();
 
         let mut task_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
@@ -1696,28 +1712,6 @@ impl MqttBroker {
 
         sys_handle.abort();
 
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            for handle in task_handles {
-                let _ = handle.await;
-            }
-        })
-        .await;
-
-        Ok(())
-    }
-
-    /// Shuts down the broker gracefully
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if no receivers are available for shutdown signal
-    pub async fn shutdown(&self) -> Result<()> {
-        if let Some(ref shutdown_tx) = self.shutdown_tx {
-            shutdown_tx.send(()).map_err(|_| {
-                MqttError::InvalidState("No receivers for shutdown signal".to_string())
-            })?;
-        }
-
         if let Some(ref bridge_manager) = self.bridge_manager {
             info!("Stopping all bridges");
             if let Err(e) = bridge_manager.stop_all().await {
@@ -1725,13 +1719,46 @@ impl MqttBroker {
             }
         }
 
-        tokio::time::sleep(crate::time::Duration::from_millis(100)).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            for handle in task_handles {
+                let _ = handle.await;
+            }
+        })
+        .await;
 
         #[cfg(feature = "opentelemetry")]
         telemetry::shutdown_telemetry();
 
         info!("Broker shutdown complete");
+
         Ok(())
+    }
+
+    /// Signals the broker to shut down gracefully.
+    ///
+    /// This triggers the same graceful shutdown path as [`MqttBroker::run`]
+    /// observing its shutdown signal: background tasks are stopped, bridges are
+    /// closed, and telemetry is flushed inside `run`. Returns once the signal is
+    /// delivered without waiting for `run` to finish unwinding.
+    ///
+    /// Prefer [`MqttBroker::shutdown_handle`] when the broker is moved into a
+    /// task by [`MqttBroker::run`], since that returns a cloneable handle that
+    /// can trigger shutdown from a signal handler.
+    pub fn shutdown(&self) {
+        self.shutdown_tx.send(()).ok();
+    }
+
+    /// Returns a cloneable handle that can trigger graceful shutdown of a
+    /// running broker from another task.
+    ///
+    /// Obtain the handle before moving the broker into [`MqttBroker::run`], then
+    /// call [`BrokerShutdownHandle::shutdown`] from a signal handler or any other
+    /// task to make `run` return after completing its graceful shutdown.
+    #[must_use]
+    pub fn shutdown_handle(&self) -> BrokerShutdownHandle {
+        BrokerShutdownHandle {
+            shutdown_tx: self.shutdown_tx.clone(),
+        }
     }
 
     /// Gets broker statistics
@@ -1824,17 +1851,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_broker_shutdown() {
-        let mut broker = MqttBroker::bind("127.0.0.1:0").await.unwrap();
+        let config = BrokerConfig::default()
+            .with_bind_address(([127, 0, 0, 1], 0))
+            .with_storage(crate::broker::config::StorageConfig::default().with_persistence(false));
+        let mut broker = MqttBroker::with_config(config).await.unwrap();
+        let shutdown = broker.shutdown_handle();
 
-        // Start broker in background
         let broker_handle = tokio::spawn(async move { broker.run().await });
 
-        // Give broker time to start
-        tokio::time::sleep(crate::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(crate::time::Duration::from_millis(50)).await;
 
-        // Now test shutdown - but we can't call it because broker was moved
-        // Just ensure the broker starts without error for now
-        broker_handle.abort();
+        shutdown.shutdown();
+
+        let result = tokio::time::timeout(crate::time::Duration::from_secs(5), broker_handle)
+            .await
+            .expect("run did not return after shutdown signal")
+            .expect("run task panicked");
+        result.expect("run returned an error after shutdown");
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/lib.rs
+++ b/crates/mqtt5/src/lib.rs
@@ -112,16 +112,21 @@
 //! This library also provides a complete MQTT broker implementation:
 //!
 //! ```rust,no_run
-//! use mqtt5::broker::{BrokerConfig, MqttBroker};
+//! use mqtt5::broker::MqttBroker;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), Box<dyn std::error::Error>> {  
-//!     // Create a basic broker
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let mut broker = MqttBroker::bind("0.0.0.0:1883").await?;
-//!     
+//!
 //!     println!("🚀 MQTT broker running on port 1883");
-//!     
-//!     // Run until shutdown
+//!
+//!     // Trigger graceful shutdown on Ctrl+C
+//!     let shutdown = broker.shutdown_handle();
+//!     tokio::spawn(async move {
+//!         tokio::signal::ctrl_c().await.ok();
+//!         shutdown.shutdown();
+//!     });
+//!
 //!     broker.run().await?;
 //!     Ok(())
 //! }
@@ -152,12 +157,18 @@
 //!         );
 //!
 //!     let mut broker = MqttBroker::with_config(config).await?;
-//!     
+//!
 //!     println!("🚀 Multi-transport MQTT broker running");
 //!     println!("  📡 TCP:       mqtt://localhost:1883");
-//!     println!("  🔒 TLS:       mqtts://localhost:8883");  
+//!     println!("  🔒 TLS:       mqtts://localhost:8883");
 //!     println!("  🌐 WebSocket: ws://localhost:8080/mqtt");
-//!     
+//!
+//!     let shutdown = broker.shutdown_handle();
+//!     tokio::spawn(async move {
+//!         tokio::signal::ctrl_c().await.ok();
+//!         shutdown.shutdown();
+//!     });
+//!
 //!     broker.run().await?;
 //!     Ok(())
 //! }

--- a/crates/mqtt5/tests/broker_graceful_shutdown.rs
+++ b/crates/mqtt5/tests/broker_graceful_shutdown.rs
@@ -1,0 +1,109 @@
+use mqtt5::broker::{BrokerConfig, MqttBroker};
+use mqtt5::MqttClient;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpStream;
+
+async fn start_broker() -> (
+    u16,
+    mqtt5::broker::BrokerShutdownHandle,
+    tokio::task::JoinHandle<mqtt5::error::Result<()>>,
+) {
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_storage(mqtt5::broker::config::StorageConfig::default().with_persistence(false));
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let port = broker.local_addr().unwrap().port();
+    let handle = broker.shutdown_handle();
+    let task = tokio::spawn(async move { broker.run().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (port, handle, task)
+}
+
+#[tokio::test]
+async fn graceful_shutdown_stops_accept_loop_and_returns() {
+    let (port, shutdown, task) = start_broker().await;
+    let addr = format!("127.0.0.1:{port}");
+
+    let received = Arc::new(AtomicU32::new(0));
+    let recv_clone = Arc::clone(&received);
+
+    let sub = MqttClient::new("sub");
+    sub.connect(&format!("mqtt://{addr}")).await.unwrap();
+    sub.subscribe("test/topic", move |_msg| {
+        recv_clone.fetch_add(1, Ordering::SeqCst);
+    })
+    .await
+    .unwrap();
+
+    let pubc = MqttClient::new("pub");
+    pubc.connect(&format!("mqtt://{addr}")).await.unwrap();
+    pubc.publish("test/topic", b"hello").await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        received.load(Ordering::SeqCst),
+        1,
+        "message should be delivered before shutdown"
+    );
+
+    assert!(
+        TcpStream::connect(&addr).await.is_ok(),
+        "listener should accept before shutdown"
+    );
+
+    shutdown.shutdown();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("run() did not return after shutdown signal")
+        .expect("run task panicked");
+    assert!(result.is_ok(), "run() returned error: {result:?}");
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut refused = false;
+    for _ in 0..20 {
+        if let Ok(Ok(stream)) =
+            tokio::time::timeout(Duration::from_millis(100), TcpStream::connect(&addr)).await
+        {
+            drop(stream);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        } else {
+            refused = true;
+            break;
+        }
+    }
+    assert!(
+        refused,
+        "listener should stop accepting connections after graceful shutdown"
+    );
+}
+
+#[tokio::test]
+async fn double_run_is_rejected() {
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_storage(mqtt5::broker::config::StorageConfig::default().with_persistence(false));
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let handle = broker.shutdown_handle();
+
+    let first = tokio::spawn(async move {
+        let r = broker.run().await;
+        (broker, r)
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    handle.shutdown();
+    let (mut broker, r1) = tokio::time::timeout(Duration::from_secs(5), first)
+        .await
+        .expect("first run did not return")
+        .expect("first run panicked");
+    assert!(r1.is_ok());
+
+    let r2 = broker.run().await;
+    assert!(
+        r2.is_err(),
+        "second run() should be rejected once listeners are drained"
+    );
+}

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.34" }
+mqtt5 = { path = "../mqtt5", version = "0.35" }
 anyhow = "1.0"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Fixes the broker never actually shutting down when driven by an external Ctrl+C, reported in #91. Fixes #92.

## Problem

`broker.run()` spawns detached background tasks (the `$SYS` publisher, TCP/TLS/WS/QUIC accept loops, resource monitor, storage, hot-reload) and parks itself on an internal shutdown broadcast. The examples raced `run()` in a `tokio::select!` and dropped its future on Ctrl+C, which never signals that broadcast, so the tasks kept running as orphans — `$SYS` kept publishing and the accept loops kept accepting new connections after the misleading "shutdown complete" line. It only appeared to work because the process exit tore the runtime down. Worse, `run()` had taken ownership of the shutdown sender, so `broker.shutdown()` was a no-op once the broker was running.

## Fix

- `MqttBroker` keeps its shutdown sender (clones instead of `take()`-ing it in `run()`); re-entrancy is still guarded by the drained listeners.
- New `MqttBroker::shutdown_handle() -> BrokerShutdownHandle` (cloneable, `Send`): obtain it before moving the broker into `run()`, then fire it from a signal handler to make `run()` return after a real graceful shutdown.
- Full teardown (abort `$SYS`, stop bridges, join accept loops with the 5s timeout, flush telemetry) moved into `run()`s post-signal path, where the tasks actually live.
- **BREAKING:** `shutdown()` is now `fn shutdown(&self)` (was `async fn -> Result<()>`); it just fires the signal, which is synchronous. Callers drop `.await?`.
- Fixed the 5 Ctrl+C examples and the broken `broker/mod.rs` doc example (it called `shutdown()` without ever calling `run()`).
- Bumped `mqtt5` 0.34.0 → 0.35.0 with lockstep cli/wasm version pins and a CHANGELOG entry.

## Testing

- New `tests/broker_graceful_shutdown.rs`: verifies the accept loop actually stops (new connections refused) and `run()` returns after signaling, plus that a second `run()` is rejected.
- Ran the full integration suite `--all-features` (bridges, all transports, client/persistence/auth/session/reconnection, CLI e2e, turmoil) — 0 failures.
- Manually confirmed `simple_broker` now exits cleanly on SIGINT with `$SYS` publishing stopped.
- clippy pedantic clean, fmt clean; pre-commit CI (incl. wasm32 target) passed.
