### PR TITLE
update outdated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.35.1] - 2026-07-06
+
+### Changed
+
+- Updated dependencies to their latest compatible versions: `bytes` 1.12, `rand` 0.10.2, `getrandom` 0.4.3, `quinn` 0.11.11, `rustls` 0.23.41, `rustls-pki-types` 1.15, `webpki-roots` 1.0.8, and dev-dependencies `anyhow`/`wasm-bindgen-test`. No API or behavior changes.
+
+## [mqtt5-protocol 0.14.1] - 2026-07-06
+
+### Changed
+
+- Updated `bytes` to 1.12. No API or behavior changes.
+
+## [mqttv5-cli 0.28.1] - 2026-07-06
+
+### Changed
+
+- Updated dependencies to their latest compatible versions: `anyhow` 1.0.103, `getrandom` 0.4.3, `humantime` 2.4, `time` 0.3.53, `quinn` 0.11.11, `rand` 0.10.2, `rustls` 0.23.41.
+
+## [mqtt5-wasm 1.4.1] - 2026-07-06
+
+### Changed
+
+- Updated dependencies to their latest compatible versions: `wasm-bindgen` 0.2.126, `wasm-bindgen-futures` 0.4.76, `js-sys`/`web-sys` 0.3.103, `getrandom` 0.4.3, `bytes` 1.12.
+
 ## [mqtt5 0.35.0] - 2026-07-04
 
 ### Added

--- a/crates/mqtt5-conformance-macros/Cargo.toml
+++ b/crates/mqtt5-conformance-macros/Cargo.toml
@@ -13,5 +13,5 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0.106"
-quote = "1.0.45"
-syn = { version = "2.0.117", features = ["full"] }
+quote = "1.0.46"
+syn = { version = "2.0.118", features = ["full"] }

--- a/crates/mqtt5-conformance/Cargo.toml
+++ b/crates/mqtt5-conformance/Cargo.toml
@@ -25,7 +25,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "1"
-bytes = "1.10"
+bytes = "1.12.0"
 ulid = "1.2.1"
 linkme = "0.3.35"
 mqtt5-conformance-macros = { version = "0.1.0", path = "../mqtt5-conformance-macros" }

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.14.0"
+version = "0.14.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -26,9 +26,7 @@ std = [
 
 [dependencies]
 bebytes = { version = "3.0.2", default-features = false }
-bytes = { version = "1.10", default-features = false, features = [
-    "extra-platforms",
-] }
+bytes = { version = "1.12", default-features = false, features = ["extra-platforms"] }
 thiserror = { version = "2.0", optional = true }
 serde = { version = "1.0", features = [
     "derive",

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -32,13 +32,13 @@ mqtt5 = { version = "0.35", optional = true, default-features = false, features 
     "tokio",
 ] }
 
-wasm-bindgen = { version = "0.2", optional = true }
-wasm-bindgen-futures = { version = "0.4", optional = true }
-js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2.126", optional = true }
+wasm-bindgen-futures = { version = "0.4.76", optional = true }
+js-sys = { version = "0.3.103", optional = true }
 console_error_panic_hook = "0.1"
-getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom = { version = "0.4.3", features = ["wasm_js"] }
 
-bytes = "1.10"
+bytes = "1.12.0"
 futures = "0.3"
 futures-util = "0.3"
 tracing = "0.1.41"
@@ -48,28 +48,9 @@ miniz_oxide = { version = "0.9", optional = true }
 sha2 = "0.11"
 
 [dependencies.web-sys]
-version = "0.3"
+version = "0.3.103"
 optional = true
-features = [
-    "BinaryType",
-    "Blob",
-    "BroadcastChannel",
-    "CloseEvent",
-    "ErrorEvent",
-    "Event",
-    "EventTarget",
-    "ExtendableMessageEvent",
-    "MessageChannel",
-    "MessageEvent",
-    "MessagePort",
-    "ServiceWorkerGlobalScope",
-    "WebSocket",
-    "Window",
-    "Navigator",
-    "AddEventListenerOptions",
-    "console",
-    "Performance",
-]
+features = ["BinaryType", "Blob", "BroadcastChannel", "CloseEvent", "ErrorEvent", "Event", "EventTarget", "ExtendableMessageEvent", "MessageChannel", "MessageEvent", "MessagePort", "ServiceWorkerGlobalScope", "WebSocket", "Window", "Navigator", "AddEventListenerOptions", "console", "Performance"]
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1.47", optional = true, features = ["sync"] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.35.0"
+version = "0.35.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -50,8 +50,8 @@ serde_json = "1.0.142"
 rand = "0.10"
 futures = "0.3.31"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-anyhow = "1.0"
-wasm-bindgen-test = "0.3"
+anyhow = "1.0.103"
+wasm-bindgen-test = "0.3.76"
 
 url = "2.5.4"
 tempfile = "3.12.0"
@@ -101,11 +101,11 @@ wasm-opt = ["-O0"]
 
 [dependencies]
 base64 = "0.22"
-bytes = "1.10"
+bytes = "1.12.0"
 futures = "0.3"
 futures-util = { version = "0.3", optional = true }
 hex = "0.4"
-rand = "0.10"
+rand = "0.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
@@ -123,7 +123,7 @@ tracing-opentelemetry = { version = "0.33", optional = true }
 opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
 mqtt5-protocol = "0.14.0"
 argon2 = "0.5"
-getrandom = "0.4"
+getrandom = "0.4.3"
 bebytes = { version = "3.0", features = ["bytes"] }
 regex = "1.12.2"
 flume = { version = "0.12.0", features = ["async"] }
@@ -144,16 +144,16 @@ http-body-util = "0.1.3"
 http = "1.4.0"
 humantime-serde = "1.1"
 ring = "0.17.14"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pki-types = "1.13.0"
+rustls = { version = "0.23.41", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-pki-types = "1.15.0"
 tokio = { version = "1.47", features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "rustls-tls-native-roots"], optional = true }
-quinn = { version = "0.11", default-features = false, features = ["rustls-ring", "runtime-tokio", "platform-verifier"], optional = true }
-webpki-roots = "1.0"
+quinn = { version = "0.11.11", default-features = false, features = ["rustls-ring", "runtime-tokio", "platform-verifier"], optional = true }
+webpki-roots = "1.0.8"
 
 [target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.4", features = ["wasm_js"] }
+getrandom = { version = "0.4.3", features = ["wasm_js"] }
 tokio = { version = "1.47", features = [
     "sync",
     "macros",

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.0"
+version = "0.28.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,17 +23,17 @@ codec = ["mqtt5/codec-all"]
 
 [dependencies]
 mqtt5 = { path = "../mqtt5", version = "0.35" }
-anyhow = "1.0"
+anyhow = "1.0.103"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.145"
 hex = "0.4.3"
-getrandom = "0.4"
-humantime = "2.3.0"
-time = { version = "0.3.44", features = ["local-offset", "parsing", "formatting", "macros"] }
+getrandom = "0.4.3"
+humantime = "2.4.0"
+time = { version = "0.3.53", features = ["local-offset", "parsing", "formatting", "macros"] }
 bebytes = "3.0.2"
 flate2 = "1.1.9"
-quinn = { version = "0.11.9", features = ["rustls-ring", "runtime-tokio"] }
+quinn = { version = "0.11.11", features = ["rustls-ring", "runtime-tokio"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clap = { version = "4.5", features = ["derive", "env"] }
@@ -41,7 +41,7 @@ tokio = { version = "1", features = ["full"] }
 dialoguer = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 toml = "1"
-rand = "0.10"
-rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+rand = "0.10.2"
+rustls = { version = "0.23.41", default-features = false, features = ["ring", "std", "tls12"] }
 rpassword = "7.4"
 argon2 = "0.5"


### PR DESCRIPTION
Refreshes all outdated workspace dependencies to their latest compatible versions and bumps the affected published crates.

## Dependency bumps

Done via `cargo add` (features / `optional` / `default-features` all preserved), plus a full `cargo update` for transitive deps.

- **mqtt5**: `bytes` 1.12, `rand` 0.10.2, `getrandom` 0.4.3 (+ wasm target), `quinn` 0.11.11, `rustls` 0.23.41, `rustls-pki-types` 1.15, `webpki-roots` 1.0.8, dev `anyhow`/`wasm-bindgen-test`
- **mqttv5-cli**: `anyhow` 1.0.103, `getrandom` 0.4.3, `humantime` 2.4, `time` 0.3.53, `quinn` 0.11.11, `rand` 0.10.2, `rustls` 0.23.41
- **mqtt5-wasm**: `wasm-bindgen` 0.2.126, `wasm-bindgen-futures` 0.4.76, `js-sys`/`web-sys` 0.3.103, `getrandom` 0.4.3, `bytes` 1.12
- **mqtt5-protocol / mqtt5-conformance**: `bytes` 1.12
- **mqtt5-conformance-macros**: `quote` 1.0.46, `syn` 2.0.118

OpenTelemetry stack was already at its latest minor versions; the one available patch (`opentelemetry_sdk` 0.32.1) is picked up by `cargo update`.

## Version bumps + CHANGELOG

Dependency-only changes, so patch bumps: `mqtt5` 0.35.1, `mqtt5-protocol` 0.14.1, `mqttv5-cli` 0.28.1, `mqtt5-wasm` 1.4.1, each with a CHANGELOG entry. The `mqtt5 = "0.35"` pins in cli/wasm still satisfy 0.35.1, so no lockstep pin changes.

## Notes

- `Cargo.lock` is gitignored here, so the diff is Cargo.toml + CHANGELOG only; the refreshed lock resolves to the versions above.
- No API or behavior changes.

## Testing

- clippy pedantic clean on host **and** the wasm32 target
- 447 lib tests + TLS/QUIC/transport/client/complete-flow integration all pass (QUIC especially, since rustls/quinn/rustls-platform-verifier 0.6→0.7 moved)
- pre-commit CI passed