### PR TITLE
gate broker behind cargo feature for client-only builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.36.0] - 2026-07-08
+
+### Added
+
+- **`broker` cargo feature (enabled by default)** gating the entire broker implementation and its dependency tree (`argon2`, `regex`, `toml`, `hyper`, `hyper-rustls`, `hyper-util`, `http-body-util`). Client-only consumers can now build without the broker's dependencies via `mqtt5 = { version = "0.36", default-features = false }`.
+
+### Changed
+
+- **BREAKING (only for `default-features = false` consumers): the broker is no longer compiled unless the `broker` feature is enabled.** Default builds are unaffected because `broker` is part of the default feature set; consumers who set `default-features = false` and use `mqtt5::broker` must add `features = ["broker"]`. The `turmoil-testing` feature now implies `broker`.
+
+## [mqttv5-cli 0.28.2] - 2026-07-08
+
+### Changed
+
+- Bumped the `mqtt5` dependency requirement to 0.36.
+
+## [mqtt5-wasm 1.4.2] - 2026-07-08
+
+### Changed
+
+- Bumped the `mqtt5` dependency requirement to 0.36; the crate's `broker` feature now enables `mqtt5/broker`.
+
 ## [mqtt5 0.35.1] - 2026-07-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,14 @@ A production-ready MQTT v5.0 and v3.1.1 platform that ships a client library, a 
 
 ```toml
 [dependencies]
-mqtt5 = "0.31"
+mqtt5 = "0.36"
+```
+
+For a lean client-only build (no broker, drops `argon2`/`hyper`/`regex`/`toml`/...):
+
+```toml
+[dependencies]
+mqtt5 = { version = "0.36", default-features = false }
 ```
 
 ### CLI Tool

--- a/crates/mqtt5-protocol/README.md
+++ b/crates/mqtt5-protocol/README.md
@@ -13,14 +13,14 @@ Platform-agnostic MQTT v5.0 and v3.1.1 protocol implementation covering packet p
 
 ```toml
 [dependencies]
-mqtt5-protocol = "0.12"
+mqtt5-protocol = "0.14"
 ```
 
 ### For Embedded (no_std)
 
 ```toml
 [dependencies]
-mqtt5-protocol = { version = "0.12", default-features = false }
+mqtt5-protocol = { version = "0.14", default-features = false }
 ```
 
 ### For Single-Core Embedded

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.4.1"
+version = "1.4.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,12 +23,12 @@ client = [
     "dep:web-sys",
     "dep:js-sys",
 ]
-broker = ["client", "dep:mqtt5", "dep:tokio"]
+broker = ["client", "dep:mqtt5", "mqtt5/broker", "dep:tokio"]
 codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
 mqtt5-protocol = "0.14.0"
-mqtt5 = { version = "0.35", optional = true, default-features = false, features = [
+mqtt5 = { version = "0.36", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,8 +23,17 @@ exclude = [
 ]
 
 [features]
-default = ["transport-websocket", "transport-quic"]
-turmoil-testing = ["turmoil"]
+default = ["broker", "transport-websocket", "transport-quic"]
+broker = [
+    "dep:argon2",
+    "dep:regex",
+    "dep:toml",
+    "dep:hyper",
+    "dep:hyper-rustls",
+    "dep:hyper-util",
+    "dep:http-body-util",
+]
+turmoil-testing = ["turmoil", "broker"]
 opentelemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
@@ -60,33 +69,57 @@ rcgen = "0.14.8"
 [[example]]
 name = "simple_broker"
 path = "examples/simple_broker.rs"
+required-features = ["broker"]
 
 [[example]]
 name = "broker_with_monitoring"
 path = "examples/broker_with_monitoring.rs"
+required-features = ["broker"]
 
 [[example]]
 name = "broker_with_tls"
 path = "examples/broker_with_tls.rs"
+required-features = ["broker"]
 
 [[example]]
 name = "broker_with_websocket"
 path = "examples/broker_with_websocket.rs"
-required-features = ["transport-websocket"]
+required-features = ["broker", "transport-websocket"]
 
 [[example]]
 name = "broker_all_transports"
 path = "examples/broker_all_transports.rs"
-required-features = ["transport-websocket", "transport-quic"]
+required-features = ["broker", "transport-websocket", "transport-quic"]
 
 [[example]]
 name = "broker_bridge_demo"
 path = "examples/broker_bridge_demo.rs"
+required-features = ["broker"]
 
 [[example]]
 name = "broker_with_opentelemetry"
 path = "examples/broker_with_opentelemetry.rs"
-required-features = ["opentelemetry"]
+required-features = ["broker", "opentelemetry"]
+
+[[example]]
+name = "broker_with_enhanced_auth"
+path = "examples/broker_with_enhanced_auth.rs"
+required-features = ["broker"]
+
+[[example]]
+name = "shared_subscription_demo"
+path = "examples/shared_subscription_demo.rs"
+required-features = ["broker"]
+
+[[example]]
+name = "simple_client"
+path = "examples/simple_client.rs"
+required-features = ["broker"]
+
+[[example]]
+name = "generate_acl_test_files"
+path = "examples/generate_acl_test_files.rs"
+required-features = ["broker"]
 
 [lib]
 name = "mqtt5"
@@ -110,7 +143,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.11"
 thiserror = "2.0"
-toml = "1"
+toml = { version = "1", optional = true }
 tracing = "0.1"
 url = "2.5"
 tracing-subscriber = { version = "0.3", features = [
@@ -122,25 +155,20 @@ opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic", "met
 tracing-opentelemetry = { version = "0.33", optional = true }
 opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
 mqtt5-protocol = "0.14.0"
-argon2 = "0.5"
+argon2 = { version = "0.5", optional = true }
 getrandom = "0.4.3"
 bebytes = { version = "3.0", features = ["bytes"] }
-regex = "1.12.2"
+regex = { version = "1.12.2", optional = true }
 flume = { version = "0.12.0", features = ["async"] }
 parking_lot = "0.12.5"
 flate2 = { version = "1.1.8", optional = true }
 zeroize = "1.8.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-hyper = { version = "1.8.1", features = ["http1", "client"] }
-hyper-rustls = { version = "0.27.7", default-features = false, features = ["http1", "ring", "native-tokio", "tls12"] }
-hyper-util = { version = "0.1.19", features = [
-    "client",
-    "client-legacy",
-    "http1",
-    "tokio",
-] }
-http-body-util = "0.1.3"
+hyper = { version = "1.8.1", features = ["http1", "client"], optional = true }
+hyper-rustls = { version = "0.27.7", default-features = false, features = ["http1", "ring", "native-tokio", "tls12"], optional = true }
+hyper-util = { version = "0.1.19", features = ["client", "client-legacy", "http1", "tokio"], optional = true }
+http-body-util = { version = "0.1.3", optional = true }
 http = "1.4.0"
 humantime-serde = "1.1"
 ring = "0.17.14"

--- a/crates/mqtt5/README.md
+++ b/crates/mqtt5/README.md
@@ -12,12 +12,22 @@ Full-featured MQTT v5.0 and v3.1.1 client and broker for native platforms (Linux
 - Configurable keepalive with timeout tolerance
 - Mock client for unit testing
 - OpenTelemetry distributed tracing (optional feature)
+- Broker gated behind the `broker` feature (on by default) for lean client-only builds
 
 ## Installation
 
 ```toml
 [dependencies]
-mqtt5 = "0.31"
+mqtt5 = "0.36"
+```
+
+### Client-only builds
+
+The broker is enabled by default via the `broker` feature. If you only need the client, disable default features to drop the broker and its dependencies (`argon2`, `regex`, `toml`, `hyper`, ...):
+
+```toml
+[dependencies]
+mqtt5 = { version = "0.36", default-features = false }
 ```
 
 ## Quick Start
@@ -416,7 +426,7 @@ Distributed tracing with OpenTelemetry support:
 
 ```toml
 [dependencies]
-mqtt5 = { version = "0.31", features = ["opentelemetry"] }
+mqtt5 = { version = "0.36", features = ["opentelemetry"] }
 ```
 
 - W3C trace context propagation via MQTT user properties

--- a/crates/mqtt5/src/lib.rs
+++ b/crates/mqtt5/src/lib.rs
@@ -181,6 +181,7 @@ pub use mqtt5_protocol::{
     validation,
 };
 
+#[cfg(feature = "broker")]
 pub mod broker;
 pub mod callback;
 #[cfg(not(target_arch = "wasm32"))]
@@ -194,7 +195,7 @@ pub mod tasks;
 pub mod telemetry;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod test_utils;
-#[cfg(any(test, feature = "turmoil-testing"))]
+#[cfg(all(feature = "broker", any(test, feature = "turmoil-testing")))]
 pub mod testing;
 pub mod transport;
 pub mod types;

--- a/crates/mqtt5/src/telemetry/mod.rs
+++ b/crates/mqtt5/src/telemetry/mod.rs
@@ -1,6 +1,6 @@
 pub mod propagation;
 
-#[cfg(feature = "opentelemetry")]
+#[cfg(all(feature = "opentelemetry", feature = "broker"))]
 pub mod metrics;
 
 #[cfg(feature = "opentelemetry")]

--- a/crates/mqtt5/src/transport/tcp.rs
+++ b/crates/mqtt5/src/transport/tcp.rs
@@ -175,6 +175,7 @@ impl Transport for TcpTransport {
 mod tests {
     use super::*;
     use std::net::{IpAddr, Ipv4Addr};
+    #[cfg(feature = "broker")]
     use tracing::{error, info};
 
     #[test]
@@ -232,6 +233,7 @@ mod tests {
         assert!(result.is_err(), "Expected connection to 192.0.2.1 to fail");
     }
 
+    #[cfg(feature = "broker")]
     #[tokio::test]
     async fn test_tcp_connect_real_broker() {
         use crate::broker::config::{BrokerConfig, StorageBackend, StorageConfig};

--- a/crates/mqtt5/tests/bridge_connection_tests.rs
+++ b/crates/mqtt5/tests/bridge_connection_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Comprehensive tests for bridge connection functionality
 
 use mqtt5::broker::bridge::{BridgeConfig, BridgeConnection, BridgeDirection};

--- a/crates/mqtt5/tests/bridge_end_to_end_test.rs
+++ b/crates/mqtt5/tests/bridge_end_to_end_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! End-to-end integration test for broker bridging
 //!
 //! This test demonstrates a real bridge scenario between two brokers

--- a/crates/mqtt5/tests/bridge_loop_prevention_tests.rs
+++ b/crates/mqtt5/tests/bridge_loop_prevention_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Comprehensive tests for bridge loop prevention
 
 use mqtt5::broker::bridge::LoopPrevention;

--- a/crates/mqtt5/tests/bridge_manager_tests.rs
+++ b/crates/mqtt5/tests/bridge_manager_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Comprehensive tests for bridge manager functionality
 
 use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection, BridgeManager};

--- a/crates/mqtt5/tests/bridge_quic_integration.rs
+++ b/crates/mqtt5/tests/bridge_quic_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-quic")]
 
 use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection, BridgeProtocol};

--- a/crates/mqtt5/tests/bridge_try_private_e2e.rs
+++ b/crates/mqtt5/tests/bridge_try_private_e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection};
 use mqtt5::broker::{BrokerConfig, MqttBroker, StorageConfig};
 use mqtt5::client::MqttClient;

--- a/crates/mqtt5/tests/bridge_try_private_test.rs
+++ b/crates/mqtt5/tests/bridge_try_private_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection};

--- a/crates/mqtt5/tests/broker_all_transports_integration.rs
+++ b/crates/mqtt5/tests/broker_all_transports_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-websocket")]
 
 //! Integration test for broker with all transport types

--- a/crates/mqtt5/tests/broker_bridge_integration.rs
+++ b/crates/mqtt5/tests/broker_bridge_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Integration tests for broker-to-broker bridging
 
 use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection, BridgeManager};

--- a/crates/mqtt5/tests/broker_graceful_shutdown.rs
+++ b/crates/mqtt5/tests/broker_graceful_shutdown.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::{BrokerConfig, MqttBroker};
 use mqtt5::MqttClient;
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/mqtt5/tests/broker_quic_integration.rs
+++ b/crates/mqtt5/tests/broker_quic_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-quic")]
 
 use mqtt5::broker::config::{BrokerConfig, QuicConfig, ServerDeliveryStrategy};

--- a/crates/mqtt5/tests/broker_tls_integration.rs
+++ b/crates/mqtt5/tests/broker_tls_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Integration test for broker TLS support
 
 use mqtt5::broker::config::{BrokerConfig, TlsConfig};

--- a/crates/mqtt5/tests/broker_websocket_integration.rs
+++ b/crates/mqtt5/tests/broker_websocket_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-websocket")]
 
 //! Integration test for broker WebSocket support

--- a/crates/mqtt5/tests/cert_auth_spoofing.rs
+++ b/crates/mqtt5/tests/cert_auth_spoofing.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 use mqtt5::broker::auth::CertificateAuthProvider;

--- a/crates/mqtt5/tests/change_only_delivery.rs
+++ b/crates/mqtt5/tests/change_only_delivery.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::router::MessageRouter;
 use mqtt5::broker::storage::ChangeOnlyState;
 use mqtt5::packet::publish::PublishPacket;

--- a/crates/mqtt5/tests/cli_e2e.rs
+++ b/crates/mqtt5/tests/cli_e2e.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::doc_markdown)]
 //! End-to-end CLI integration tests
 //!

--- a/crates/mqtt5/tests/cli_features.rs
+++ b/crates/mqtt5/tests/cli_features.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Comprehensive tests for CLI MQTT v5.0 features
 //!
 //! Tests all new features added to the CLI including:

--- a/crates/mqtt5/tests/cli_functionality.rs
+++ b/crates/mqtt5/tests/cli_functionality.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! CLI Functionality Integration Tests
 //!
 //! Tests that validate our mqttv5 CLI tool works correctly in real scenarios.

--- a/crates/mqtt5/tests/cli_server_redirect.rs
+++ b/crates/mqtt5/tests/cli_server_redirect.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 
 use common::cli_helpers::*;

--- a/crates/mqtt5/tests/cli_transports.rs
+++ b/crates/mqtt5/tests/cli_transports.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! CLI transport tests
 //!
 //! Tests different transport types: TCP, TLS

--- a/crates/mqtt5/tests/client_handler_resource_integration.rs
+++ b/crates/mqtt5/tests/client_handler_resource_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Integration tests for `ClientHandler` with `ResourceMonitor`
 
 mod common;

--- a/crates/mqtt5/tests/debug_connection.rs
+++ b/crates/mqtt5/tests/debug_connection.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/debug_tls_test.rs
+++ b/crates/mqtt5/tests/debug_tls_test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 // Debug test for mqtt-v5 TLS connection
 mod common;
 use common::TestBroker;

--- a/crates/mqtt5/tests/enhanced_auth.rs
+++ b/crates/mqtt5/tests/enhanced_auth.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::auth::{AuthProvider, AuthResult, EnhancedAuthResult};
 use mqtt5::broker::config::{StorageBackend, StorageConfig};
 use mqtt5::broker::{BrokerConfig, MqttBroker};

--- a/crates/mqtt5/tests/integration_complete_flow.rs
+++ b/crates/mqtt5/tests/integration_complete_flow.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::implicit_clone)]
 #![allow(clippy::large_futures)]
 

--- a/crates/mqtt5/tests/integration_mqtt5_features.rs
+++ b/crates/mqtt5/tests/integration_mqtt5_features.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/integration_mqtt5_features.rs
+++ b/crates/mqtt5/tests/integration_mqtt5_features.rs
@@ -766,7 +766,7 @@ async fn test_shared_subscriptions() {
     assert_eq!(total_messages, 9);
 
     // Each client should have received some messages (roughly balanced)
-    for (_client, messages) in msgs.iter() {
+    for messages in msgs.values() {
         assert!(!messages.is_empty());
         assert!(messages.len() <= 5); // No client should get all messages
     }

--- a/crates/mqtt5/tests/integration_no_local.rs
+++ b/crates/mqtt5/tests/integration_no_local.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::router::MessageRouter;
 use mqtt5::packet::publish::PublishPacket;
 use mqtt5::time::Duration;

--- a/crates/mqtt5/tests/integration_reconnection.rs
+++ b/crates/mqtt5/tests/integration_reconnection.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/integration_retain_as_published.rs
+++ b/crates/mqtt5/tests/integration_retain_as_published.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 use mqtt5::broker::router::MessageRouter;
 use mqtt5::packet::publish::PublishPacket;
 use mqtt5::time::Duration;

--- a/crates/mqtt5/tests/keepalive_handling.rs
+++ b/crates/mqtt5/tests/keepalive_handling.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 use common::TestBroker;
 

--- a/crates/mqtt5/tests/keepalive_negotiation.rs
+++ b/crates/mqtt5/tests/keepalive_negotiation.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 
 use common::TestBroker;

--- a/crates/mqtt5/tests/outbound_rate_limiting.rs
+++ b/crates/mqtt5/tests/outbound_rate_limiting.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 
 use common::TestBroker;

--- a/crates/mqtt5/tests/persistence.rs
+++ b/crates/mqtt5/tests/persistence.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/publish_action.rs
+++ b/crates/mqtt5/tests/publish_action.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 
 use bytes::Bytes;

--- a/crates/mqtt5/tests/qos_flow.rs
+++ b/crates/mqtt5/tests/qos_flow.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/quic_migration_tests.rs
+++ b/crates/mqtt5/tests/quic_migration_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-quic")]
 
 use mqtt5::broker::config::{BrokerConfig, QuicConfig, StorageBackend, StorageConfig};

--- a/crates/mqtt5/tests/quic_multistream_integration.rs
+++ b/crates/mqtt5/tests/quic_multistream_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![cfg(feature = "transport-quic")]
 
 use mqtt5::broker::config::{BrokerConfig, QuicConfig};

--- a/crates/mqtt5/tests/resource_monitoring_integration.rs
+++ b/crates/mqtt5/tests/resource_monitoring_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Integration tests for resource monitoring
 
 use mqtt5::broker::{BrokerConfig, MqttBroker};

--- a/crates/mqtt5/tests/retained_properties_preserved.rs
+++ b/crates/mqtt5/tests/retained_properties_preserved.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/separate_clients.rs
+++ b/crates/mqtt5/tests/separate_clients.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/server_redirect_tests.rs
+++ b/crates/mqtt5/tests/server_redirect_tests.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 
 use common::{MessageCollector, TestBroker};

--- a/crates/mqtt5/tests/session_security.rs
+++ b/crates/mqtt5/tests/session_security.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/shared_subscription_basic.rs
+++ b/crates/mqtt5/tests/shared_subscription_basic.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Basic test for shared subscriptions
 
 use bytes::Bytes;

--- a/crates/mqtt5/tests/subscription_options_persistence.rs
+++ b/crates/mqtt5/tests/subscription_options_persistence.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/test_minimal_connection.rs
+++ b/crates/mqtt5/tests/test_minimal_connection.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 use common::TestBroker;
 use mqtt5::MqttClient;

--- a/crates/mqtt5/tests/test_retained_cli.rs
+++ b/crates/mqtt5/tests/test_retained_cli.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 #![allow(clippy::large_futures)]
 
 mod common;

--- a/crates/mqtt5/tests/tls_direct_config.rs
+++ b/crates/mqtt5/tests/tls_direct_config.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 use common::TestBroker;
 use mqtt5::time::Duration;

--- a/crates/mqtt5/tests/tls_integration.rs
+++ b/crates/mqtt5/tests/tls_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 use common::TestBroker;
 use mqtt5::time::Duration;

--- a/crates/mqtt5/tests/turmoil_basic_connectivity.rs
+++ b/crates/mqtt5/tests/turmoil_basic_connectivity.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Basic connectivity tests using Turmoil
 //!
 //! These tests verify that the broker can accept connections and handle

--- a/crates/mqtt5/tests/turmoil_multi_client.rs
+++ b/crates/mqtt5/tests/turmoil_multi_client.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Multi-client interaction tests using Turmoil
 //!
 //! These tests verify complex interactions between multiple clients

--- a/crates/mqtt5/tests/turmoil_pubsub.rs
+++ b/crates/mqtt5/tests/turmoil_pubsub.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Comprehensive pub/sub tests using Turmoil
 //!
 //! These tests verify publish/subscribe functionality in a deterministic

--- a/crates/mqtt5/tests/turmoil_shared_subscriptions.rs
+++ b/crates/mqtt5/tests/turmoil_shared_subscriptions.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 //! Shared subscription tests using Turmoil
 //!
 //! These tests verify the shared subscription functionality using

--- a/crates/mqtt5/tests/wss_alpn_integration.rs
+++ b/crates/mqtt5/tests/wss_alpn_integration.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "broker")]
 mod common;
 use common::{find_workspace_root, TestBroker};
 use mqtt5::broker::config::{

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.1"
+version = "0.28.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.35" }
+mqtt5 = { path = "../mqtt5", version = "0.36" }
 anyhow = "1.0.103"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Closes #100.

Gates the broker implementation and its dependency tree behind a new `broker` cargo feature so client-only consumers can build without pulling `argon2`, `regex`, `toml`, `hyper`, `hyper-rustls`, `hyper-util`, and `http-body-util`.

## What changed

- **New `broker` feature, enabled by default** (`default = ["broker", "transport-websocket", "transport-quic"]`), so existing default-feature consumers are unaffected.
- The seven broker-only deps are now `optional` and pulled in only by `broker`.
- `pub mod broker` and the broker-coupled bits (`telemetry::metrics`, the turmoil `testing` module, one `transport::tcp` unit test) are `#[cfg(feature = "broker")]`.
- `turmoil-testing` now implies `broker` (it wraps `MqttBroker`).
- Broker examples gained `required-features = ["broker"]`; the ~53 broker-dependent integration tests are gated with `#![cfg(feature = "broker")]`.
- `mqtt5-wasm`'s `broker` feature now enables `mqtt5/broker`.

## Client-only usage

```toml
[dependencies]
mqtt5 = { version = "0.36", default-features = false }
```

`cargo tree -p mqtt5 --no-default-features` confirms `argon2`/`hyper`/`regex`/`toml` are dropped.

## Versioning

- `mqtt5` 0.35.1 → **0.36.0** — minor bump because the `default-features = false` surface changes (the broker was previously always compiled). Default builds are unchanged.
- Lockstep dep-req bumps: `mqttv5-cli` 0.28.1 → 0.28.2, `mqtt5-wasm` 1.4.1 → 1.4.2.

## Verification

| Config | Result |
|---|---|
| `--no-default-features` lib + `--all-targets` clippy (pedantic) | ✅ deps dropped |
| `--no-default-features --features turmoil-testing` | ✅ |
| default workspace clippy pedantic (CI path) | ✅ |
| wasm `--features broker` clippy + wasm default | ✅ |
| `cargo fmt --check` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
