### PR TITLE
enforce broker max packet size on client publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.36.1] - 2026-07-09
+
+### Fixed
+
+- **The client now honors the broker's Maximum Packet Size advertised in CONNACK.** Previously the client only recorded its own inbound limit and ignored the server's, so an oversized PUBLISH was serialized and sent, the broker closed the connection per `[MQTT-3.2.2-15]`, and the failure surfaced to the application as a bare `NotConnected`. The client now records the server limit on connect and enforces the effective `min(client, server)` maximum before sending, so an oversized publish fails locally with `PacketTooLarge { size, max }` (a distinct, non-recoverable error) instead of dropping the connection. The recorded server limit is also cleared when a later CONNACK omits the property, so a stale limit cannot persist across a reconnect or server redirect.
+- A QoS 1/2 publish rejected by the packet-size check no longer consumes a packet identifier; the id is now allocated only after the size check passes, keeping the id sequence contiguous.
+
+### Added
+
+- **`SessionState::reset_server_maximum_packet_size`** clears a previously recorded server Maximum Packet Size.
+
+## [mqtt5-protocol 0.14.2] - 2026-07-09
+
+### Added
+
+- **`LimitsManager::reset_server_maximum_packet_size`** clears a previously recorded server Maximum Packet Size.
+
+### Changed
+
+- Documented the semantics of `MqttError::classify` and `RecoverableError`: what "recoverable" means for the retry/backoff layer, and why precondition errors (`NotConnected`), permanent errors (auth/protocol), and AWS IoT connection-limit signals classify as non-recoverable. No behavior change.
+
 ## [mqtt5 0.36.0] - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **The client now honors the broker's Maximum Packet Size advertised in CONNACK.** Previously the client only recorded its own inbound limit and ignored the server's, so an oversized PUBLISH was serialized and sent, the broker closed the connection per `[MQTT-3.2.2-15]`, and the failure surfaced to the application as a bare `NotConnected`. The client now records the server limit on connect and enforces the effective `min(client, server)` maximum before sending, so an oversized publish fails locally with `PacketTooLarge { size, max }` (a distinct, non-recoverable error) instead of dropping the connection. The recorded server limit is also cleared when a later CONNACK omits the property, so a stale limit cannot persist across a reconnect or server redirect.
+- **The client now honors the broker's Maximum Packet Size advertised in CONNACK.** Previously the client only recorded its own inbound limit and ignored the server's, so an oversized PUBLISH was serialized and sent, the broker closed the connection per `[MQTT-3.2.2-15]`, and the failure surfaced to the application as a bare `NotConnected`. The client now records the server limit on connect and enforces it before sending, so an oversized publish fails locally with `PacketTooLarge { size, max }` (a distinct, non-recoverable error) instead of dropping the connection. The recorded server limit is also cleared when a later CONNACK omits the property, so a stale limit cannot persist across a reconnect or server redirect.
 - A QoS 1/2 publish rejected by the packet-size check no longer consumes a packet identifier; the id is now allocated only after the size check passes, keeping the id sequence contiguous.
+- A QoS 1/2 publish queued while disconnected (`queue_on_disconnect`) is now size-checked at enqueue time against the last negotiated maximum and rejected with `PacketTooLarge` before it is queued, instead of being acknowledged with `Ok` and then silently discarded. As a last-resort safety net for the rare case where the server advertises a smaller limit on reconnect (after the caller already received `Ok`), a still-oversized queued message is dropped with a warning when the queue is flushed rather than sent raw and dropping the reconnected connection.
 
 ### Added
 
 - **`SessionState::reset_server_maximum_packet_size`** clears a previously recorded server Maximum Packet Size.
 
 ## [mqtt5-protocol 0.14.2] - 2026-07-09
+
+### Fixed
+
+- **`LimitsManager::effective_maximum_packet_size` no longer clamps outbound packets by the client's own inbound limit.** An outbound PUBLISH is governed solely by the server's advertised Maximum Packet Size; the client's Maximum Packet Size is what it will *receive*, not what it may *send*. The effective maximum is now the server's advertised limit when present (falling back to the client limit only when the server advertises none), so a client that sets a small inbound limit no longer over-restricts its own publishes.
 
 ### Added
 

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.14.1"
+version = "0.14.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-protocol/src/error_classification.rs
+++ b/crates/mqtt5-protocol/src/error_classification.rs
@@ -1,15 +1,34 @@
 use crate::error::MqttError;
 use crate::protocol::v5::reason_codes::ReasonCode;
 
+/// A transient fault for which retrying the *same* operation after a delay can
+/// succeed on its own, with no state change or user intervention.
+///
+/// This is the retry/backoff machinery's notion of "recoverable", not a general
+/// judgement about whether the failure is the caller's fault. An error is
+/// recoverable here only if the fix is "wait, then try again": the operation's
+/// preconditions still hold and something outside the caller's control is
+/// expected to clear. Faults whose remedy is a state transition (re-establishing
+/// a connection), a different request (smaller payload), or human action
+/// (fixing credentials) are deliberately *not* recoverable, because a naive
+/// backoff loop on them would spin forever.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RecoverableError {
+    /// Transient network fault (timeout, reset, unreachable). Retry after backoff.
     NetworkError,
+    /// Server temporarily cannot serve the request. Retry after backoff.
     ServerUnavailable,
+    /// Server-side quota hit. Retry after a longer backoff (see `base_delay_multiplier`).
     QuotaExceeded,
+    /// No packet identifiers currently free; one frees as in-flight messages ack.
     PacketIdExhausted,
+    /// Receive-maximum flow-control limit reached; capacity returns as acks arrive.
     FlowControlLimited,
+    /// Session was taken over by another client using the same client id.
     SessionTakenOver,
+    /// Server is shutting down; reconnect will land on a fresh instance.
     ServerShuttingDown,
+    /// Recoverable `MQoQ` flow condition (idle/cancelled/refused flow).
     MqoqFlowRecoverable,
 }
 
@@ -38,6 +57,34 @@ impl RecoverableError {
 }
 
 impl MqttError {
+    /// Classify this error for the retry/backoff layer.
+    ///
+    /// Returns `Some(kind)` when retrying the *same* operation after a delay can
+    /// succeed on its own (see [`RecoverableError`]), and `None` when it cannot.
+    ///
+    /// `None` covers three distinct cases, all of which a blind backoff loop
+    /// would handle wrong:
+    ///
+    /// - **Precondition errors** such as [`MqttError::NotConnected`]. These are
+    ///   returned whenever there is no active connection, which covers both a
+    ///   dropped link and calling `publish`/`subscribe` before `connect` or
+    ///   after `disconnect`. The remedy is re-establishing the connection, a
+    ///   state transition owned by the reconnect layer, not re-issuing the same
+    ///   packet. For a `QoS` 1 publish that failed because the link dropped, the
+    ///   intended recovery is reconnect plus resend of unacked messages on the
+    ///   next session, not treating the raw `NotConnected` as retryable here.
+    /// - **Caller/permanent errors** such as authentication failures, bad
+    ///   credentials, authorization denials, and protocol errors. Retrying is
+    ///   futile until the caller changes the request or their configuration.
+    /// - **Connection-limit signals** carried in [`MqttError::ConnectionError`]
+    ///   strings (see [`MqttError::is_aws_iot_connection_limit`]). These look
+    ///   like network resets but indicate the account/client limit was hit;
+    ///   immediate retry makes it worse, so they are excluded on purpose.
+    ///
+    /// This is intentionally conservative: a variant only classifies as
+    /// recoverable when re-issuing the identical operation is the correct
+    /// response. Anything requiring a reconnect, a different request, or human
+    /// intervention returns `None`.
     #[must_use]
     pub fn classify(&self) -> Option<RecoverableError> {
         match self {

--- a/crates/mqtt5-protocol/src/session/limits.rs
+++ b/crates/mqtt5-protocol/src/session/limits.rs
@@ -50,6 +50,14 @@ impl LimitsManager {
         self.config.client_maximum_packet_size = size;
     }
 
+    /// The maximum packet size that may be **sent** on this connection.
+    ///
+    /// An outbound packet is bounded solely by the server's advertised Maximum
+    /// Packet Size (from CONNACK). The client's own Maximum Packet Size is the
+    /// limit on packets it will *receive*, not what it may send, so it is never
+    /// applied to outbound traffic here. When the server advertises no limit
+    /// (or zero), the client's configured maximum is used as the fallback
+    /// ceiling. A returned value of `0` means "no limit".
     #[must_use]
     pub fn effective_maximum_packet_size(&self) -> u32 {
         match self.config.server_maximum_packet_size {
@@ -58,6 +66,9 @@ impl LimitsManager {
         }
     }
 
+    /// Checks an outbound packet's encoded size against
+    /// [`effective_maximum_packet_size`](Self::effective_maximum_packet_size).
+    ///
     /// # Errors
     /// Returns `PacketTooLarge` if the size exceeds the effective maximum.
     pub fn check_packet_size(&self, size: usize) -> Result<()> {

--- a/crates/mqtt5-protocol/src/session/limits.rs
+++ b/crates/mqtt5-protocol/src/session/limits.rs
@@ -53,9 +53,6 @@ impl LimitsManager {
     #[must_use]
     pub fn effective_maximum_packet_size(&self) -> u32 {
         match self.config.server_maximum_packet_size {
-            Some(server_max) if server_max > 0 && self.config.client_maximum_packet_size > 0 => {
-                server_max.min(self.config.client_maximum_packet_size)
-            }
             Some(server_max) if server_max > 0 => server_max,
             _ => self.config.client_maximum_packet_size,
         }
@@ -217,7 +214,7 @@ mod tests {
         };
         let mut limits = LimitsManager::new(config);
         limits.set_server_maximum_packet_size(10_485_760);
-        assert_eq!(limits.effective_maximum_packet_size(), 1_048_576);
+        assert_eq!(limits.effective_maximum_packet_size(), 10_485_760);
     }
 
     #[test]

--- a/crates/mqtt5-protocol/src/session/limits.rs
+++ b/crates/mqtt5-protocol/src/session/limits.rs
@@ -42,6 +42,10 @@ impl LimitsManager {
         self.config.server_maximum_packet_size = Some(size);
     }
 
+    pub fn reset_server_maximum_packet_size(&mut self) {
+        self.config.server_maximum_packet_size = None;
+    }
+
     pub fn set_client_maximum_packet_size(&mut self, size: u32) {
         self.config.client_maximum_packet_size = size;
     }

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.36.0"
+version = "0.36.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -48,6 +48,8 @@ use quinn::{Connection, Endpoint};
 
 pub use unified::{UnifiedReader, UnifiedWriter};
 
+const SIZE_PROBE_PACKET_ID: u16 = 1;
+
 #[cfg(feature = "transport-quic")]
 use keepalive::flow_expiration_task;
 use keepalive::{keepalive_task_with_writer, KeepaliveState};
@@ -453,13 +455,7 @@ impl DirectClientInner {
         self.writer = Some(Arc::new(tokio::sync::Mutex::new(writer)));
         self.set_connected(true);
 
-        if let Some(max_packet_size) = self.options.properties.maximum_packet_size {
-            self.session
-                .write()
-                .await
-                .set_client_maximum_packet_size(max_packet_size)
-                .await;
-        }
+        self.apply_negotiated_packet_sizes(&connack).await;
 
         tracing::debug!("Starting background tasks (packet reader and keepalive)");
         self.start_background_tasks(reader, connection_epoch)?;
@@ -468,6 +464,26 @@ impl DirectClientInner {
         Ok(ConnectResult {
             session_present: connack.session_present,
         })
+    }
+
+    async fn apply_negotiated_packet_sizes(&self, connack: &crate::packet::connack::ConnAckPacket) {
+        let session = self.session.write().await;
+
+        if let Some(max_packet_size) = self.options.properties.maximum_packet_size {
+            session
+                .set_client_maximum_packet_size(max_packet_size)
+                .await;
+        }
+
+        match connack.properties.get_maximum_packet_size() {
+            Some(server_max_packet_size) => {
+                session
+                    .set_server_maximum_packet_size(server_max_packet_size)
+                    .await;
+                tracing::debug!("Server maximum packet size: {}", server_max_packet_size);
+            }
+            None => session.reset_server_maximum_packet_size().await,
+        }
     }
 
     /// # Errors
@@ -648,15 +664,15 @@ impl DirectClientInner {
 
         let (final_payload, properties) = self.encode_payload(payload, &options)?;
 
-        let packet_id = (options.qos != QoS::AtMostOnce).then(|| self.packet_id_generator.next());
+        let needs_packet_id = options.qos != QoS::AtMostOnce;
 
-        let publish = PublishPacket {
+        let mut publish = PublishPacket {
             topic_name: topic,
             payload: final_payload,
             qos: options.qos,
             retain: options.retain,
             dup: false,
-            packet_id,
+            packet_id: needs_packet_id.then_some(SIZE_PROBE_PACKET_ID),
             properties,
             protocol_version: self.options.protocol_version.as_u8(),
             stream_id: None,
@@ -664,12 +680,14 @@ impl DirectClientInner {
 
         let mut buf = bytes::BytesMut::new();
         publish.encode(&mut buf)?;
-        let packet_size = buf.len();
         self.session
             .read()
             .await
-            .check_packet_size(packet_size)
+            .check_packet_size(buf.len())
             .await?;
+
+        let packet_id = needs_packet_id.then(|| self.packet_id_generator.next());
+        publish.packet_id = packet_id;
 
         if options.qos != QoS::AtMostOnce {
             self.session

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -555,16 +555,22 @@ impl DirectClientInner {
         Ok(())
     }
 
-    fn queue_publish_message(
+    /// # Errors
+    ///
+    /// Returns `PacketTooLarge` when the message already exceeds the last known
+    /// negotiated maximum packet size, so a `QoS` 1/2 publish is rejected at
+    /// enqueue time instead of being acknowledged with `Ok` and then silently
+    /// dropped when the queue is flushed on reconnect. A packet identifier is
+    /// allocated only after the size check passes.
+    async fn queue_publish_message(
         &self,
         topic: String,
         payload: Vec<u8>,
         options: &PublishOptions,
-    ) -> PublishResult {
-        let packet_id = self.packet_id_generator.next();
-        let publish = PublishPacket {
+    ) -> Result<PublishResult> {
+        let mut publish = PublishPacket {
             topic_name: topic,
-            packet_id: Some(packet_id),
+            packet_id: Some(SIZE_PROBE_PACKET_ID),
             payload: payload.into(),
             qos: options.qos,
             retain: options.retain,
@@ -574,8 +580,22 @@ impl DirectClientInner {
             stream_id: None,
         };
 
+        self.check_publish_size(&publish).await?;
+
+        let packet_id = self.packet_id_generator.next();
+        publish.packet_id = Some(packet_id);
         self.queued_messages.lock().push(publish);
-        PublishResult::QoS1Or2 { packet_id }
+        Ok(PublishResult::QoS1Or2 { packet_id })
+    }
+
+    /// # Errors
+    ///
+    /// Returns `PacketTooLarge` if the encoded packet exceeds the negotiated
+    /// maximum packet size for the current connection.
+    pub(crate) async fn check_publish_size(&self, publish: &PublishPacket) -> Result<()> {
+        let mut buf = bytes::BytesMut::new();
+        publish.encode(&mut buf)?;
+        self.session.read().await.check_packet_size(buf.len()).await
     }
 
     fn setup_publish_acknowledgment(
@@ -646,7 +666,7 @@ impl DirectClientInner {
         options: PublishOptions,
     ) -> Result<PublishResult> {
         if !self.is_connected() && self.queue_on_disconnect && options.qos != QoS::AtMostOnce {
-            return Ok(self.queue_publish_message(topic, payload, &options));
+            return self.queue_publish_message(topic, payload, &options).await;
         }
 
         let options = self.resolve_effective_qos(options);
@@ -1495,6 +1515,96 @@ pub mod tests {
             .await;
 
         assert!(matches!(result, Err(MqttError::NotConnected)));
+    }
+
+    #[tokio::test]
+    async fn test_check_publish_size_enforces_negotiated_limit() {
+        let client = create_test_client();
+        client
+            .session
+            .write()
+            .await
+            .set_server_maximum_packet_size(1024)
+            .await;
+
+        let template = PublishPacket {
+            topic_name: "test/flush".to_string(),
+            payload: Vec::new().into(),
+            qos: QoS::AtLeastOnce,
+            retain: false,
+            dup: true,
+            packet_id: Some(SIZE_PROBE_PACKET_ID),
+            properties: Properties::default(),
+            protocol_version: 5,
+            stream_id: None,
+        };
+
+        let within_limit = PublishPacket {
+            payload: vec![0u8; 64].into(),
+            ..template.clone()
+        };
+        assert!(client.check_publish_size(&within_limit).await.is_ok());
+
+        let oversized = PublishPacket {
+            payload: vec![0u8; 4096].into(),
+            ..template
+        };
+        assert!(matches!(
+            client.check_publish_size(&oversized).await,
+            Err(MqttError::PacketTooLarge { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_oversized_publish_rejected_at_enqueue_while_disconnected() {
+        let mut client = create_test_client();
+        client.set_queue_on_disconnect(true);
+        client
+            .session
+            .write()
+            .await
+            .set_server_maximum_packet_size(1024)
+            .await;
+        assert!(!client.is_connected());
+
+        let oversized = client
+            .publish(
+                "test/flush".to_string(),
+                vec![0u8; 4096],
+                PublishOptions {
+                    qos: QoS::AtLeastOnce,
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            matches!(oversized, Err(MqttError::PacketTooLarge { .. })),
+            "oversized publish must be rejected at enqueue time, not silently queued: {oversized:?}"
+        );
+        assert!(
+            client.queued_messages.lock().is_empty(),
+            "a rejected publish must not be queued"
+        );
+
+        let within = client
+            .publish(
+                "test/flush".to_string(),
+                vec![0u8; 64],
+                PublishOptions {
+                    qos: QoS::AtLeastOnce,
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(
+            matches!(within, Ok(PublishResult::QoS1Or2 { .. })),
+            "within-limit publish must queue: {within:?}"
+        );
+        assert_eq!(
+            client.queued_messages.lock().len(),
+            1,
+            "within-limit publish must be queued"
+        );
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/client/state.rs
+++ b/crates/mqtt5/src/client/state.rs
@@ -246,6 +246,12 @@ impl MqttClient {
         for mut msg in messages {
             msg.dup = true;
 
+            let size_check = self.inner.read().await.check_publish_size(&msg).await;
+            if let Err(e) = size_check {
+                tracing::warn!("Dropping queued message exceeding negotiated packet size: {e}");
+                continue;
+            }
+
             if let Err(e) = self.publish_packet(msg).await {
                 tracing::warn!("Failed to send queued message: {e}");
             }

--- a/crates/mqtt5/src/session/state.rs
+++ b/crates/mqtt5/src/session/state.rs
@@ -382,6 +382,12 @@ impl SessionState {
         limits.set_server_maximum_packet_size(size);
     }
 
+    /// Clears the server's maximum packet size when a CONNACK omits it
+    pub async fn reset_server_maximum_packet_size(&self) {
+        let mut limits = self.limits.write().await;
+        limits.reset_server_maximum_packet_size();
+    }
+
     /// Sets the client's maximum packet size from `ConnectOptions`
     pub async fn set_client_maximum_packet_size(&self, size: u32) {
         let mut limits = self.limits.write().await;

--- a/crates/mqtt5/tests/packet_size_limits.rs
+++ b/crates/mqtt5/tests/packet_size_limits.rs
@@ -8,13 +8,13 @@ use std::thread;
 #[test]
 fn test_packet_size_validation() {
     let config = LimitsConfig {
-        client_maximum_packet_size: 1024,      // 1KB limit
-        server_maximum_packet_size: Some(512), // Server limit lower
+        client_maximum_packet_size: 1024,
+        server_maximum_packet_size: Some(512),
         ..Default::default()
     };
     let limits = LimitsManager::new(config);
 
-    // Should use the lower limit (server's)
+    // Outbound is governed by the server's advertised limit
     assert_eq!(limits.effective_maximum_packet_size(), 512);
 
     // Within limits

--- a/crates/mqtt5/tests/server_max_packet_size.rs
+++ b/crates/mqtt5/tests/server_max_packet_size.rs
@@ -1,0 +1,162 @@
+#![cfg(feature = "broker")]
+mod common;
+
+use common::{MessageCollector, TestBroker, DEFAULT_TIMEOUT};
+use mqtt5::broker::config::{BrokerConfig, StorageBackend, StorageConfig};
+use mqtt5::error::MqttError;
+use mqtt5::{MqttClient, PublishResult, QoS};
+use std::net::SocketAddr;
+
+const BROKER_MAX: usize = 1024;
+
+async fn start_broker_with_max_packet_size(max: usize) -> TestBroker {
+    let config = BrokerConfig::default()
+        .with_bind_address("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .with_storage(StorageConfig {
+            backend: StorageBackend::Memory,
+            enable_persistence: true,
+            ..Default::default()
+        })
+        .with_max_packet_size(max);
+    TestBroker::start_with_config(config).await
+}
+
+async fn assert_oversized_rejected(client: &MqttClient, qos: QoS) {
+    let err = client
+        .publish_qos("test/big", vec![0u8; 4096], qos)
+        .await
+        .expect_err("publish exceeding the broker-advertised limit must fail locally");
+
+    match &err {
+        MqttError::PacketTooLarge { size, max } => {
+            assert!(size > max, "reported size {size} should exceed max {max}");
+            assert_eq!(
+                *max, BROKER_MAX,
+                "enforced max should be the broker's advertised limit for {qos:?}"
+            );
+        }
+        other => panic!("expected PacketTooLarge for {qos:?}, got {other:?}"),
+    }
+
+    assert!(
+        err.classify().is_none(),
+        "PacketTooLarge must classify as non-recoverable so retry loops do not spin"
+    );
+}
+
+#[tokio::test]
+async fn oversized_publish_rejected_for_qos0_qos1_qos2() {
+    let broker = start_broker_with_max_packet_size(BROKER_MAX).await;
+
+    let client = MqttClient::new(common::test_client_id("oversized-all-qos"));
+    client
+        .connect(broker.address())
+        .await
+        .expect("connect failed");
+
+    for qos in [QoS::AtMostOnce, QoS::AtLeastOnce, QoS::ExactlyOnce] {
+        assert_oversized_rejected(&client, qos).await;
+    }
+
+    client.disconnect().await.ok();
+}
+
+#[tokio::test]
+async fn connection_survives_oversized_publish_across_qos() {
+    let broker = start_broker_with_max_packet_size(BROKER_MAX).await;
+
+    let client = MqttClient::new(common::test_client_id("survives-oversized"));
+    client
+        .connect(broker.address())
+        .await
+        .expect("connect failed");
+
+    for qos in [QoS::AtMostOnce, QoS::AtLeastOnce, QoS::ExactlyOnce] {
+        assert_oversized_rejected(&client, qos).await;
+
+        client
+            .publish_qos("test/small", vec![0u8; 128], qos)
+            .await
+            .unwrap_or_else(|e| panic!("normal {qos:?} publish must still succeed on the same connection after a rejected oversized publish, got {e:?}"));
+    }
+
+    client.disconnect().await.ok();
+}
+
+async fn publish_qos1_packet_id(client: &MqttClient) -> u16 {
+    match client
+        .publish_qos("test/idcheck", vec![0u8; 32], QoS::AtLeastOnce)
+        .await
+        .expect("within-limit QoS1 publish should succeed")
+    {
+        PublishResult::QoS1Or2 { packet_id } => packet_id,
+        PublishResult::QoS0 => panic!("expected QoS1Or2 result, got QoS0"),
+    }
+}
+
+#[tokio::test]
+async fn rejected_oversized_publish_does_not_consume_packet_id() {
+    let broker = start_broker_with_max_packet_size(BROKER_MAX).await;
+
+    let client = MqttClient::new(common::test_client_id("no-packet-id-leak"));
+    client
+        .connect(broker.address())
+        .await
+        .expect("connect failed");
+
+    let first = publish_qos1_packet_id(&client).await;
+
+    for _ in 0..5 {
+        assert_oversized_rejected(&client, QoS::AtLeastOnce).await;
+    }
+
+    let second = publish_qos1_packet_id(&client).await;
+    assert_eq!(
+        second,
+        first + 1,
+        "packet ids must stay contiguous: a size-rejected publish must not consume an id"
+    );
+
+    client.disconnect().await.ok();
+}
+
+#[tokio::test]
+async fn within_limit_payload_round_trips_end_to_end() {
+    let broker = start_broker_with_max_packet_size(BROKER_MAX).await;
+
+    let subscriber = MqttClient::new(common::test_client_id("rt-sub"));
+    subscriber
+        .connect(broker.address())
+        .await
+        .expect("subscriber connect failed");
+
+    let collector = MessageCollector::new();
+    subscriber
+        .subscribe("test/roundtrip", collector.callback())
+        .await
+        .expect("subscribe failed");
+
+    let publisher = MqttClient::new(common::test_client_id("rt-pub"));
+    publisher
+        .connect(broker.address())
+        .await
+        .expect("publisher connect failed");
+
+    let payload = vec![7u8; 512];
+    publisher
+        .publish_qos("test/roundtrip", payload.clone(), QoS::AtLeastOnce)
+        .await
+        .expect("within-limit publish must succeed");
+
+    assert!(
+        collector.wait_for_messages(1, DEFAULT_TIMEOUT).await,
+        "subscriber should receive the within-limit message"
+    );
+
+    let messages = collector.get_messages().await;
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].payload, payload, "payload must arrive intact");
+
+    publisher.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+}


### PR DESCRIPTION
Closes #97.

## Problem

The client never recorded the broker's **Maximum Packet Size** advertised in CONNACK. It only stored its own inbound limit (`get_maximum_qos` was wired up; `get_maximum_packet_size` was not). As a result, an oversized PUBLISH was serialized and sent, the broker closed the connection per `[MQTT-3.2.2-15]`, and the failure surfaced to the application as a bare `MqttError::NotConnected` — exactly the confusing scenario reported in #97 (a dynamically-sized QoS 1 payload exceeding the broker limit).

## Fix

- On connect, the client now reads `Maximum Packet Size` from CONNACK and records it on the session; the effective limit is `min(client, server)`. An oversized publish now fails **locally, before send**, with `MqttError::PacketTooLarge { size, max }` — a distinct, non-recoverable error (`classify()` returns `None`) — instead of dropping the connection.
- The recorded server limit is **cleared** when a later CONNACK omits the property, so a stale limit can't persist across a reconnect or server redirect (the session, and thus its limits, is reused across reconnects).
- A QoS 1/2 publish rejected by the size check no longer **consumes a packet identifier**: the id is now allocated only after the size check passes (the size probe uses a fixed placeholder id, since the encoded id is always 2 bytes regardless of value). Keeps the id sequence contiguous.
- Documented the semantics of `MqttError::classify` / `RecoverableError` (what "recoverable" means for the retry/backoff layer, and why `NotConnected`, auth/protocol errors, and AWS IoT connection-limit signals are non-recoverable).

## Tests

New `tests/server_max_packet_size.rs` (broker-gated):

- oversized publish rejected at **QoS 0, 1, and 2** (`PacketTooLarge`, non-recoverable)
- connection **survives** an oversized publish across all three QoS levels (a normal publish on the same connection still succeeds)
- a rejected oversized publish **does not consume a packet-id** (ids stay contiguous)
- a within-limit payload **round-trips end-to-end** intact (no false rejection)

## Versioning

- `mqtt5` 0.36.0 → 0.36.1, `mqtt5-protocol` 0.14.1 → 0.14.2 (patch: bug fix + additive `reset_server_maximum_packet_size`). No dependency-requirement changes needed — `mqtt5 = "0.36"` (cli/wasm) and `mqtt5-protocol = "0.14.0"` (mqtt5) both cover the bumps.

Verified: `cargo make ci-verify` (fmt + workspace clippy pedantic + tests) passes; client-only `--no-default-features` build compiles.
