### PR TITLE
make $SYS topic publishing configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`$SYS` topic publishing is now configurable via `BrokerConfig`.** Two new fields (with builders `with_sys_topics_enabled` and `with_sys_topics_interval`): `sys_topics_enabled` (default `true`) turns generation on or off entirely, and `sys_topics_interval` (default `10s`) sets the update cadence. When disabled, the broker skips starting the `$SYS` provider so no retained `$SYS` traffic is produced. Previously generation was always on with a hardcoded 10s interval, and the only lever was ACL to restrict reads.
+
 ## [mqtt5 0.36.1] - 2026-07-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [mqtt5 0.37.0] - 2026-07-11
 
 ### Added
 

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.4.2"
+version = "1.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
 mqtt5-protocol = "0.14.0"
-mqtt5 = { version = "0.36", optional = true, default-features = false, features = [
+mqtt5 = { version = "0.37", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.36.1"
+version = "0.37.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/README.md
+++ b/crates/mqtt5/README.md
@@ -312,6 +312,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+#### `$SYS` Monitoring Topics
+
+The broker publishes statistics (uptime, client counts, message and byte counters) to retained `$SYS/#` topics. Generation is on by default with a 10-second update interval. Both are configurable:
+
+```rust
+use mqtt5::broker::BrokerConfig;
+use std::time::Duration;
+
+// Slow the cadence down to once a minute
+let config = BrokerConfig::default()
+    .with_sys_topics_interval(Duration::from_secs(60));
+
+// Or disable $SYS generation entirely (no retained $SYS traffic is produced)
+let config = BrokerConfig::default()
+    .with_sys_topics_enabled(false);
+```
+
+The equivalent config-file keys are `sys_topics_enabled` (bool) and `sys_topics_interval` (duration, e.g. `"60s"`).
+
 ## Client
 
 The client library provides an async MQTT client designed for both IoT devices and cloud applications.

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -102,6 +102,9 @@ pub struct BrokerConfig {
     pub change_only_delivery_config: ChangeOnlyDeliveryConfig,
     #[serde(default)]
     pub echo_suppression_config: EchoSuppressionConfig,
+    pub sys_topics_enabled: bool,
+    #[cfg_attr(not(target_arch = "wasm32"), serde(with = "humantime_serde"))]
+    pub sys_topics_interval: Duration,
     #[serde(default)]
     pub max_outbound_rate_per_client: u32,
     #[serde(default)]
@@ -166,6 +169,8 @@ impl std::fmt::Debug for BrokerConfig {
                 &self.change_only_delivery_config,
             )
             .field("echo_suppression_config", &self.echo_suppression_config)
+            .field("sys_topics_enabled", &self.sys_topics_enabled)
+            .field("sys_topics_interval", &self.sys_topics_interval)
             .field(
                 "max_outbound_rate_per_client",
                 &self.max_outbound_rate_per_client,
@@ -218,6 +223,8 @@ impl Default for BrokerConfig {
             storage_config: StorageConfig::default(),
             change_only_delivery_config: ChangeOnlyDeliveryConfig::default(),
             echo_suppression_config: EchoSuppressionConfig::default(),
+            sys_topics_enabled: true,
+            sys_topics_interval: Duration::from_secs(10),
             max_outbound_rate_per_client: 0,
             max_message_rate_per_client: 0,
             max_bandwidth_per_client: 0,
@@ -365,6 +372,18 @@ impl BrokerConfig {
     }
 
     #[must_use]
+    pub fn with_sys_topics_enabled(mut self, enabled: bool) -> Self {
+        self.sys_topics_enabled = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn with_sys_topics_interval(mut self, interval: Duration) -> Self {
+        self.sys_topics_interval = interval;
+        self
+    }
+
+    #[must_use]
     pub fn with_max_outbound_rate_per_client(mut self, rate: u32) -> Self {
         self.max_outbound_rate_per_client = rate;
         self
@@ -496,6 +515,29 @@ mod tests {
         assert_eq!(config.max_clients, 5000);
         assert_eq!(config.maximum_qos, 1);
         assert!(!config.retain_available);
+    }
+
+    #[test]
+    fn test_sys_topics_defaults() {
+        let config = BrokerConfig::default();
+        assert!(config.sys_topics_enabled);
+        assert_eq!(config.sys_topics_interval, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_sys_topics_builder() {
+        let config = BrokerConfig::new()
+            .with_sys_topics_enabled(false)
+            .with_sys_topics_interval(Duration::from_secs(30));
+        assert!(!config.sys_topics_enabled);
+        assert_eq!(config.sys_topics_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn test_partial_config_sys_topics_default() {
+        let config: BrokerConfig = serde_json::from_str("{}").unwrap();
+        assert!(config.sys_topics_enabled);
+        assert_eq!(config.sys_topics_interval, Duration::from_secs(10));
     }
 
     #[test]

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -444,6 +444,12 @@ impl BrokerConfig {
             ));
         }
 
+        if self.sys_topics_enabled && self.sys_topics_interval.is_zero() {
+            return Err(crate::error::MqttError::Configuration(
+                "sys_topics_interval must be greater than zero".to_string(),
+            ));
+        }
+
         Ok(self)
     }
 }
@@ -555,6 +561,20 @@ mod tests {
         config.max_packet_size = 1024;
         config.maximum_qos = 3;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_zero_sys_topics_interval_rejected_when_enabled() {
+        let config = BrokerConfig::default().with_sys_topics_interval(Duration::ZERO);
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_zero_sys_topics_interval_allowed_when_disabled() {
+        let config = BrokerConfig::default()
+            .with_sys_topics_enabled(false)
+            .with_sys_topics_interval(Duration::ZERO);
+        assert!(config.validate().is_ok());
     }
 
     #[test]

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -1635,9 +1635,14 @@ impl MqttBroker {
             .await?;
         self.router.initialize().await?;
 
-        let sys_provider =
-            SysTopicsProvider::new(Arc::clone(&self.router), Arc::clone(&self.stats));
-        let sys_handle = sys_provider.start();
+        let sys_handle = if self.config.sys_topics_enabled {
+            let sys_provider =
+                SysTopicsProvider::new(Arc::clone(&self.router), Arc::clone(&self.stats))
+                    .with_update_interval(self.config.sys_topics_interval);
+            Some(sys_provider.start())
+        } else {
+            None
+        };
 
         info!("Router initialized, starting resource monitor cleanup task");
 
@@ -1710,7 +1715,9 @@ impl MqttBroker {
         shutdown_rx.recv().await.ok();
         info!("Broker shutting down");
 
-        sys_handle.abort();
+        if let Some(sys_handle) = sys_handle {
+            sys_handle.abort();
+        }
 
         if let Some(ref bridge_manager) = self.bridge_manager {
             info!("Stopping all bridges");

--- a/crates/mqtt5/tests/sys_topics_config_tests.rs
+++ b/crates/mqtt5/tests/sys_topics_config_tests.rs
@@ -1,0 +1,106 @@
+mod common;
+
+use common::TestBroker;
+use mqtt5::broker::config::{BrokerConfig, StorageBackend, StorageConfig};
+use mqtt5::MqttClient;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+fn base_config() -> BrokerConfig {
+    let storage = StorageConfig {
+        backend: StorageBackend::Memory,
+        enable_persistence: true,
+        ..Default::default()
+    };
+    BrokerConfig::default()
+        .with_bind_address("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .with_storage(storage)
+}
+
+async fn collect_sys_topics(address: &str, wait: Duration) -> Vec<String> {
+    let client = MqttClient::new("sys-sub");
+    client.connect(address).await.expect("connect");
+
+    let received: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    client
+        .subscribe("$SYS/#", move |msg| {
+            sink.lock().unwrap().push(msg.topic.clone());
+        })
+        .await
+        .expect("subscribe");
+
+    tokio::time::sleep(wait).await;
+    client.disconnect().await.ok();
+    let topics = received.lock().unwrap().clone();
+    topics
+}
+
+#[tokio::test]
+async fn sys_topics_enabled_publishes() {
+    let config = base_config().with_sys_topics_interval(Duration::from_millis(100));
+    let broker = TestBroker::start_with_config(config).await;
+
+    let topics = collect_sys_topics(broker.address(), Duration::from_millis(400)).await;
+
+    assert!(
+        topics.iter().any(|t| t == "$SYS/broker/version"),
+        "expected $SYS/broker/version, got {topics:?}"
+    );
+    assert!(
+        topics.iter().any(|t| t == "$SYS/broker/uptime"),
+        "expected $SYS/broker/uptime, got {topics:?}"
+    );
+}
+
+#[tokio::test]
+async fn sys_topics_interval_is_respected() {
+    let interval = Duration::from_millis(300);
+    let config = base_config().with_sys_topics_interval(interval);
+    let broker = TestBroker::start_with_config(config).await;
+
+    let client = MqttClient::new("sys-interval-sub");
+    client.connect(broker.address()).await.expect("connect");
+
+    let arrivals: Arc<Mutex<Vec<Instant>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&arrivals);
+    client
+        .subscribe("$SYS/broker/uptime", move |_msg| {
+            sink.lock().unwrap().push(Instant::now());
+        })
+        .await
+        .expect("subscribe");
+
+    tokio::time::sleep(interval * 5).await;
+    client.disconnect().await.ok();
+
+    let times = arrivals.lock().unwrap().clone();
+    assert!(
+        times.len() >= 3,
+        "expected at least 3 uptime republishes, got {}",
+        times.len()
+    );
+
+    let gaps: Vec<Duration> = times.windows(2).map(|w| w[1] - w[0]).collect();
+    let steady = &gaps[1..];
+    for gap in steady {
+        assert!(
+            *gap >= interval / 2 && *gap <= interval * 2,
+            "republish gap {gap:?} not near configured interval {interval:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn sys_topics_disabled_publishes_nothing() {
+    let config = base_config().with_sys_topics_enabled(false);
+    let broker = TestBroker::start_with_config(config).await;
+
+    let topics = collect_sys_topics(broker.address(), Duration::from_millis(400)).await;
+
+    assert!(
+        topics.is_empty(),
+        "expected no $SYS topics when disabled, got {topics:?}"
+    );
+}

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.2"
+version = "0.28.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.36" }
+mqtt5 = { path = "../mqtt5", version = "0.37" }
 anyhow = "1.0.103"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mqttv5-cli/src/commands/broker_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/broker_cmd.rs
@@ -345,6 +345,8 @@ fn build_example_config() -> BrokerConfig {
         },
         change_only_delivery_config: ChangeOnlyDeliveryConfig::default(),
         echo_suppression_config: mqtt5::broker::config::EchoSuppressionConfig::default(),
+        sys_topics_enabled: true,
+        sys_topics_interval: std::time::Duration::from_secs(10),
         max_outbound_rate_per_client: 0,
         max_message_rate_per_client: 0,
         max_bandwidth_per_client: 0,


### PR DESCRIPTION
Closes #96

## Summary

Makes `$SYS` topic publishing configurable via `BrokerConfig`, so deployments can disable the extra retained traffic entirely or adjust its cadence. Previously generation was always on with a hardcoded 10s interval, and the only lever was ACL to restrict who could read the topics.

## Changes

- `BrokerConfig` gains two fields with builders:
  - `sys_topics_enabled: bool` (default `true`) — turns generation on/off
  - `sys_topics_interval: Duration` (default `10s`) — update cadence
- `run()` skips starting the `$SYS` provider entirely when disabled, and passes the configured interval through `with_update_interval()`. `sys_handle` is now `Option` and the shutdown `abort()` is guarded.
- CLI `build_example_config` and the `CHANGELOG` updated.

Note: the bool field intentionally does not carry `#[serde(default)]` — that would resolve a missing key to `false` (the type default) instead of the container default `true`. The struct-level `#[serde(default)]` handles missing keys correctly.

## Verification

- `cargo clippy --all-targets --workspace --all-features -D warnings -W clippy::pedantic` — clean; pre-commit `ci-verify` passed
- New integration tests (`sys_topics_config_tests.rs`): enabled publishes, disabled publishes nothing, interval-is-respected
- Live brokers via the `mqttv5` CLI:
  - enabled → `sub '$SYS/#'` received `version`, `uptime`, client/byte counters
  - disabled → subscribed OK, zero `$SYS` messages after 5s
  - `"2s"` interval → `$SYS/broker/uptime` arrived every ~2s, values incrementing by exactly 2, confirming the configured cadence is honored