### PR TITLE
support tls-only broker without plaintext listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`$SYS` topic publishing is now configurable via `BrokerConfig`.** Two new fields (with builders `with_sys_topics_enabled` and `with_sys_topics_interval`): `sys_topics_enabled` (default `true`) turns generation on or off entirely, and `sys_topics_interval` (default `10s`) sets the update cadence. When disabled, the broker skips starting the `$SYS` provider so no retained `$SYS` traffic is produced. Previously generation was always on with a hardcoded 10s interval, and the only lever was ACL to restrict reads.
+- **The broker can now run without a plaintext TCP listener, enabling TLS-only (or WebSocket/QUIC-only) deployments.** Previously `bind_addresses` was mandatory, so a broker always bound plaintext MQTT. Clearing `bind_addresses` (e.g. `with_bind_addresses(Vec::new())`) now skips the plaintext listener; the broker binds only the transports you configure (`tls_config`, `websocket_config`, `websocket_tls_config`, `quic_config`). `with_config` validates that at least one client-facing listener exists and errors otherwise (inter-node cluster listeners do not count), so the broker can never start listening on nothing — including the case where a configured TLS/WS/QUIC port silently failed to bind. Default behavior is unchanged: the default `bind_addresses` still binds `0.0.0.0:1883` + `[::]:1883`.
+- **`MqttBroker::tls_local_addr()`** returns the bound TLS listener address, mirroring the existing `local_addr()` and `ws_local_addr()`. Useful for connecting to a TLS-only broker bound to an ephemeral port.
 
 ## [mqtt5 0.36.1] - 2026-07-09
 

--- a/crates/mqtt5/README.md
+++ b/crates/mqtt5/README.md
@@ -312,6 +312,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+For a TLS-only deployment with no plaintext listener, clear `bind_addresses` and configure only the encrypted transports:
+
+```rust
+let config = BrokerConfig::default()
+    .with_bind_addresses(Vec::new()) // no plaintext MQTT
+    .with_tls(
+        TlsConfig::new("certs/server.pem".into(), "certs/server.key".into())
+            .with_bind_address("0.0.0.0:8883".parse()?),
+    );
+```
+
+The broker requires at least one client-facing listener (TCP, TLS, WebSocket, WSS, or QUIC); building with none configured returns an error.
+
 #### `$SYS` Monitoring Topics
 
 The broker publishes statistics (uptime, client counts, message and byte counters) to retained `$SYS/#` topics. Generation is on by default with a 10-second update interval. Both are configurable:

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -319,14 +319,7 @@ impl MqttBroker {
     pub async fn with_config(config: BrokerConfig) -> Result<Self> {
         config.validate()?;
 
-        let bind_result = bind_tcp_addresses(&config.bind_addresses, "TCP").await;
-        if bind_result.is_empty() {
-            let error_msg =
-                format_binding_error("TCP", &bind_result.failures, &config.bind_addresses);
-            return Err(MqttError::Configuration(error_msg));
-        }
-        bind_result.warn_partial_failures("TCP");
-        let listeners = bind_result.successful;
+        let listeners = Self::bind_plaintext_listeners(&config).await?;
 
         #[cfg(feature = "transport-websocket")]
         let (ws_listeners, ws_config) = Self::setup_websocket(&config).await?;
@@ -381,7 +374,7 @@ impl MqttBroker {
         let (config_watch_tx, config_watch_rx) = watch::channel(Arc::clone(&config));
         let (auth_watch_tx, auth_watch_rx) = watch::channel(Arc::clone(&auth_provider));
 
-        Ok(Self {
+        let broker = Self {
             config,
             router,
             auth_provider,
@@ -418,7 +411,42 @@ impl MqttBroker {
             hot_reload_manager: None,
             reload_tx: None,
             reload_rx: None,
-        })
+        };
+
+        if broker.client_listener_count() == 0 {
+            return Err(MqttError::Configuration(
+                "broker has no listeners; configure at least one of bind_addresses, tls_config, websocket_config, websocket_tls_config, or quic_config".to_string(),
+            ));
+        }
+
+        Ok(broker)
+    }
+
+    async fn bind_plaintext_listeners(config: &BrokerConfig) -> Result<Vec<TcpListener>> {
+        if config.bind_addresses.is_empty() {
+            return Ok(Vec::new());
+        }
+        let bind_result = bind_tcp_addresses(&config.bind_addresses, "TCP").await;
+        if bind_result.is_empty() {
+            let error_msg =
+                format_binding_error("TCP", &bind_result.failures, &config.bind_addresses);
+            return Err(MqttError::Configuration(error_msg));
+        }
+        bind_result.warn_partial_failures("TCP");
+        Ok(bind_result.successful)
+    }
+
+    fn client_listener_count(&self) -> usize {
+        let tcp = self.listeners.len() + self.tls_listeners.len();
+        #[cfg(feature = "transport-websocket")]
+        let websocket = self.ws_listeners.len() + self.ws_tls_listeners.len();
+        #[cfg(not(feature = "transport-websocket"))]
+        let websocket = 0;
+        #[cfg(feature = "transport-quic")]
+        let quic = self.quic_endpoints.len();
+        #[cfg(not(feature = "transport-quic"))]
+        let quic = 0;
+        tcp + websocket + quic
     }
 
     #[cfg(feature = "transport-websocket")]
@@ -1601,7 +1629,7 @@ impl MqttBroker {
     pub async fn run(&mut self) -> Result<()> {
         info!("Starting MQTT broker");
 
-        if self.listeners.is_empty() {
+        if self.client_listener_count() == 0 {
             return Err(MqttError::InvalidState(
                 "Broker already running".to_string(),
             ));

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -1631,7 +1631,7 @@ impl MqttBroker {
 
         if self.client_listener_count() == 0 {
             return Err(MqttError::InvalidState(
-                "Broker already running".to_string(),
+                "broker has already been started; run() consumes its listeners and cannot be called again".to_string(),
             ));
         }
 
@@ -1821,6 +1821,11 @@ impl MqttBroker {
     #[must_use]
     pub fn local_addr(&self) -> Option<std::net::SocketAddr> {
         self.listeners.first()?.local_addr().ok()
+    }
+
+    #[must_use]
+    pub fn tls_local_addr(&self) -> Option<std::net::SocketAddr> {
+        self.tls_listeners.first()?.local_addr().ok()
     }
 
     #[cfg(feature = "transport-websocket")]

--- a/crates/mqtt5/tests/broker_tls_integration.rs
+++ b/crates/mqtt5/tests/broker_tls_integration.rs
@@ -1,10 +1,13 @@
 #![cfg(feature = "broker")]
 //! Integration test for broker TLS support
 
-use mqtt5::broker::config::{BrokerConfig, TlsConfig};
+use mqtt5::broker::config::{BrokerConfig, StorageConfig, TlsConfig};
 use mqtt5::broker::MqttBroker;
 use mqtt5::time::Duration;
+use mqtt5::{ConnectOptions, MqttClient};
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::time::timeout;
 
 #[tokio::test]
 async fn test_broker_tls_creation() {
@@ -46,6 +49,7 @@ async fn test_broker_tls_creation() {
 async fn test_broker_tls_only_no_plaintext() {
     let config = BrokerConfig::default()
         .with_bind_addresses(Vec::new())
+        .with_storage(StorageConfig::new().with_persistence(false))
         .with_tls(
             TlsConfig::new(
                 PathBuf::from("../../test_certs/server.pem"),
@@ -54,17 +58,64 @@ async fn test_broker_tls_only_no_plaintext() {
             .with_bind_address(([127, 0, 0, 1], 0)),
         );
 
-    let broker = MqttBroker::with_config(config).await;
+    let mut broker = MqttBroker::with_config(config)
+        .await
+        .expect("TLS-only broker should build");
 
-    if broker.is_err() {
-        eprintln!("Skipping TLS-only test - certificates not found");
-        return;
-    }
+    let tls_addr = broker
+        .tls_local_addr()
+        .expect("TLS-only broker should have a bound TLS listener");
+    assert!(
+        broker.local_addr().is_none(),
+        "TLS-only broker must not bind a plaintext listener"
+    );
 
-    let mut broker = broker.unwrap();
+    let mut ready_rx = broker.ready_receiver();
     let broker_handle = tokio::spawn(async move { broker.run().await });
+    ready_rx
+        .wait_for(|&ready| ready)
+        .await
+        .expect("broker ready signal should fire");
+
+    let mut tls_config =
+        mqtt5::transport::tls::TlsConfig::new(tls_addr, "localhost").with_verify_server_cert(false);
+    tls_config
+        .load_ca_cert_pem("../../test_certs/ca.pem")
+        .expect("failed to load CA cert");
+
+    let client = MqttClient::new("tls-only-client");
+    timeout(
+        Duration::from_secs(5),
+        client.connect_with_tls_and_options(tls_config, ConnectOptions::default()),
+    )
+    .await
+    .expect("TLS connection timed out")
+    .expect("TLS connection failed");
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let received_clone = Arc::clone(&received);
+    client
+        .subscribe("test/tls-only", move |msg| {
+            received_clone.lock().unwrap().push(msg);
+        })
+        .await
+        .expect("subscribe failed");
+
+    client
+        .publish("test/tls-only", b"tls-only roundtrip")
+        .await
+        .expect("publish failed");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
+
+    {
+        let msgs = received.lock().unwrap();
+        assert_eq!(msgs.len(), 1, "expected exactly one delivered message");
+        assert_eq!(msgs[0].topic, "test/tls-only");
+        assert_eq!(&msgs[0].payload[..], b"tls-only roundtrip");
+    }
+
+    client.disconnect().await.expect("disconnect failed");
     broker_handle.abort();
 }
 

--- a/crates/mqtt5/tests/broker_tls_integration.rs
+++ b/crates/mqtt5/tests/broker_tls_integration.rs
@@ -13,7 +13,7 @@ async fn test_broker_tls_creation() {
         .with_bind_address(([127, 0, 0, 1], 0)) // Use random port
         .with_tls(
             TlsConfig::new(
-                PathBuf::from("../../test_certs/server.crt"), // Using test certs from client tests
+                PathBuf::from("../../test_certs/server.pem"), // Using test certs from client tests
                 PathBuf::from("../../test_certs/server.key"),
             )
             .with_bind_address(([127, 0, 0, 1], 0)), // Use random port for TLS too
@@ -43,16 +43,54 @@ async fn test_broker_tls_creation() {
 }
 
 #[tokio::test]
+async fn test_broker_tls_only_no_plaintext() {
+    let config = BrokerConfig::default()
+        .with_bind_addresses(Vec::new())
+        .with_tls(
+            TlsConfig::new(
+                PathBuf::from("../../test_certs/server.pem"),
+                PathBuf::from("../../test_certs/server.key"),
+            )
+            .with_bind_address(([127, 0, 0, 1], 0)),
+        );
+
+    let broker = MqttBroker::with_config(config).await;
+
+    if broker.is_err() {
+        eprintln!("Skipping TLS-only test - certificates not found");
+        return;
+    }
+
+    let mut broker = broker.unwrap();
+    let broker_handle = tokio::spawn(async move { broker.run().await });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    broker_handle.abort();
+}
+
+#[tokio::test]
+async fn test_broker_no_listeners_errors() {
+    let config = BrokerConfig::default().with_bind_addresses(Vec::new());
+
+    let broker = MqttBroker::with_config(config).await;
+
+    assert!(
+        broker.is_err(),
+        "broker with no listeners should fail to build"
+    );
+}
+
+#[tokio::test]
 async fn test_broker_tls_with_client_certs() {
     // Test broker with client certificate verification
     let config = BrokerConfig::default()
         .with_bind_address(([127, 0, 0, 1], 0))
         .with_tls(
             TlsConfig::new(
-                PathBuf::from("../../test_certs/server.crt"),
+                PathBuf::from("../../test_certs/server.pem"),
                 PathBuf::from("../../test_certs/server.key"),
             )
-            .with_ca_file(PathBuf::from("../../test_certs/ca.crt"))
+            .with_ca_file(PathBuf::from("../../test_certs/ca.pem"))
             .with_require_client_cert(true)
             .with_bind_address(([127, 0, 0, 1], 0)),
         );
@@ -80,7 +118,7 @@ async fn test_broker_default_tls_port() {
         .with_bind_address(([127, 0, 0, 1], 1883))
         .with_tls(
             TlsConfig::new(
-                PathBuf::from("../../test_certs/server.crt"),
+                PathBuf::from("../../test_certs/server.pem"),
                 PathBuf::from("../../test_certs/server.key"),
             ), // Note: not setting bind_address, should default to 8883
         );


### PR DESCRIPTION
Closes #99

## Summary

Allows the broker to run with no plaintext TCP listener, enabling a TLS-only deployment. Previously `bind_addresses` was mandatory, so the TLS-only case was unreachable.

## Changes (`crates/mqtt5/src/broker/server.rs`)

1. **Empty `bind_addresses` → no plaintext listener.** Extracted TCP binding into `bind_plaintext_listeners`, which returns an empty listener set when `bind_addresses` is empty and only errors when addresses were configured but all binds failed.
2. **`client_listener_count()`** helper counting client-facing listeners across TCP, TLS, WebSocket, WSS, and QUIC (cluster listeners are inter-node and excluded).
3. **Startup validation** — `with_config` now errors if zero client-facing listeners exist, so the broker can never start listening on nothing.
4. **Relaxed `run()` guard** — keys off `client_listener_count()` instead of `self.listeners.is_empty()`, so a TLS/WS/QUIC-only broker starts. The zero-listener message now reads "broker has already been started; run() consumes its listeners and cannot be called again", which correctly describes the only reachable cause (a prior `run()` consumed the listeners) instead of the misleading "Broker already running".
5. **`tls_local_addr()` accessor** — symmetric with the existing `local_addr()`/`ws_local_addr()`, exposing the bound TLS listener address (needed to drive a real TLS client against a random-port TLS-only broker).

Default behavior is unchanged: the default `bind_addresses` still binds `0.0.0.0:1883` + `[::]:1883`. TLS-only is opt-in by clearing `bind_addresses` and setting `tls_config`.

## Tests (`crates/mqtt5/tests/broker_tls_integration.rs`)

- `test_broker_tls_only_no_plaintext` — empty `bind_addresses` + TLS. Now a real end-to-end test: asserts no plaintext listener (`local_addr().is_none()`), waits on the ready signal, connects a real `mqtts://` client, and asserts a full publish→subscribe roundtrip delivers the exact payload. The build is `.expect()`ed rather than skipped on error, so a regression that breaks TLS-only fails the test instead of silently passing. Persistence is disabled to avoid the shared `./mqtt_storage` collision that made `run()` fail under concurrent tests.
- `test_broker_no_listeners_errors` — empty `bind_addresses` with no other transport fails to build.
- Fixed stale cert paths (`.crt`/`ca.crt` → `.pem`/`ca.pem`) that were causing every TLS integration test to silently skip via the `broker.is_err()` guard.

## Verification

- `cargo make ci-verify` passes (fmt, clippy pedantic, tests) under `--all-features` and `--no-default-features --features broker`.
- End-to-end tested against a real `mqttv5` broker process with real network clients:
  - TLS-only: real `mqtts://` pub/sub roundtrip; plaintext port refused; plaintext client rejected at the TLS port.
  - WebSocket-only: real `ws://` roundtrip; plaintext port refused.
  - TCP+TLS regression: both listen; cross-transport publish (plaintext) → receive (TLS) delivered.
  - No-listeners config and cert-load failure both refused with clear errors.
  - TLS-only whose TLS port is already occupied (silent bind failure → 0 listeners) refused by the new validation instead of starting on nothing.
