### PR TITLE
remove redundant post-suback sleeps and raise conformance timeouts

### DIFF
--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,28 @@
 
 ## Diary Entries
 
+### Investigate post-SUBACK sleep(100ms) — safe to remove, but NOT the flake fix
+
+**Trigger**: CI flake on `puback_error_stops_retransmission [MQTT-4.4.0-2]` (external-broker job) — `Timeout("puback")`. Suspected the `tokio::time::sleep(Duration::from_millis(100))` placed right after each `expect_suback` was a race-guard smell.
+
+**Finding 1 — the sleep is redundant for correctness.** Broker commits the subscription to its router (`client_handler/subscribe.rs:54-68`, `router.subscribe(...).await?`) BEFORE building/sending SUBACK (`subscribe.rs:92`). So a client that has received its SUBACK is guaranteed the subscription is live; a subsequent publish from another client on the same broker will route. The 100ms sleep guarded nothing.
+
+**Finding 2 — removal is empirically safe.** Removed all 15 post-SUBACK sleeps (3 in section3_subscribe, 1 section3_unsubscribe, 9 section4_qos, 1 section3_final_conformance, 1 section4_shared_sub). Left the other 45 `sleep(100ms)` (expiry/keepalive/negative-retransmit windows) untouched. Ran against the external `mqttv5` broker:
+- unloaded: `section4_qos` 200/200 clean; full suite ~155 runs clean (1 uncaptured full-suite flake).
+- under 8-way `yes` CPU load: `section4_qos` 149/150 + ~200 more clean; with-sleep control 150/150.
+- **Zero delivery-miss failures ever** (`must receive QoS 1 PUBLISH` never fired). The ONLY failure mode observed was `Timeout("suback")`/`Timeout("puback")` — broker throughput under load, which is causally UPSTREAM of the sleep (the sleep runs after the ack arrives), so the sleep cannot affect it.
+
+**Finding 3 — the sleep removal does NOT fix the flake.** Today's red-X and the load-induced failures are TIMEOUT-tightness: `TIMEOUT=3s` (per-op) and `ACK_TIMEOUT=10s` (`test_client/raw.rs:43`) are too tight for an oversubscribed CI runner. The sleep removal is a cosmetic cleanup (~1.5s faster per full suite run, removes dead complexity) that is safe but orthogonal to the flake.
+
+**Fix — timeout hardening (the actual flake remedy).** `ACK_TIMEOUT` 10s→30s (`test_client/raw.rs`; single site, purely a positive deadline on await_ack, fixes today's `Timeout("puback")` with 3x headroom) and all 19 per-file `TIMEOUT` consts 3s→10s (headroom for expect_suback/connack/publish).
+
+Verified empirically against the external `mqttv5` broker:
+- **No delivery-miss regression** from either change (`must receive QoS 1 PUBLISH` never fired across ~700 runs).
+- **Runtime cost negligible**: full suite 8s→~11.6s (+3.6s). The conformance CI job is ~3 min (build-dominated), so +3.6s in the test phase is noise. Confirmed no passing test asserts `is_none()` after a `TIMEOUT` read; the `if let Some` sites (`final_conformance:76`, `publish_advanced:63/137`) take the fast path on success.
+- **suback timeouts cured**: at 3s under 8-way CPU saturation, `section4_qos` flaked `Timeout("suback")`; at 10s that mode disappeared across 150 saturated runs.
+- **Residual**: under pathological 8-way full-core saturation (harsher than a 2-core CI runner), `Timeout("puback")` still appears ~2/150 at 30s — a fully CPU-starved broker defeats any finite timeout. Real CI failed at 10s; 30s gives 3x margin. A bounded publish retry would be the next lever if 30s proves insufficient, but it changes QoS1 DUP semantics and is deferred.
+
+
 ### Fix 9 conformance test failures verified against Mosquitto source
 
 None of the 9 failures were broker bugs. All were test expectations beyond what the spec mandates, or test infrastructure issues.

--- a/crates/mqtt5-conformance/src/conformance_tests/section1_data_repr.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section1_data_repr.rs
@@ -6,7 +6,7 @@ use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// [MQTT-1.5.4-1] The character data in a UTF-8 Encoded String MUST be
 /// well-formed UTF-8 as defined by the Unicode specification and restated

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_connack.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_connack.rs
@@ -8,7 +8,7 @@ use mqtt5_protocol::protocol::v5::properties::PropertyId;
 use mqtt5_protocol::protocol::v5::reason_codes::ReasonCode;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.2.2-1]` Byte 1 of CONNACK is the Connect Acknowledge Flags.
 /// Bits 7-1 are reserved and MUST be set to 0.

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_connect.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_connect.rs
@@ -10,7 +10,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{ConnectOptions, SubscribeOptions, WillMessage};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.1.0-1]` After a Network Connection is established by a Client to
 /// a Server, the first packet sent from the Client to the Server MUST be a

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_connect_extended.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_connect_extended.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{ConnectOptions, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.1.2-14]` If Will Retain is set to 0, the Server MUST publish the
 /// Will Message as a non-retained message.

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_disconnect.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_disconnect.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::SubscribeOptions;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.14.4-3]` On receipt of DISCONNECT with Reason Code 0x00 the
 /// Server MUST discard the Will Message without publishing it.

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_final_conformance.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_final_conformance.rs
@@ -8,7 +8,7 @@ use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.1.3-11]` The Will Topic MUST be a UTF-8 Encoded String.
 /// Sending invalid UTF-8 bytes in the Will Topic must cause disconnect.
@@ -276,7 +276,6 @@ async fn qos2_no_message_expiry_after_publish_sent(sut: SutHandle) {
         .expect_suback(TIMEOUT)
         .await
         .expect("expected SUBACK");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut pub_raw = RawMqttClient::connect_tcp(sut.expect_tcp_addr())
         .await

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_ping.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_ping.rs
@@ -10,7 +10,7 @@ use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.12.4-1]` Server MUST send PINGRESP in response to PINGREQ.
 #[conformance_test(

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_publish.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_publish.rs
@@ -11,7 +11,7 @@ use mqtt5_protocol::types::{
 };
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.3.1-4]` A PUBLISH packet MUST NOT have both `QoS` bits set to 1.
 #[conformance_test(

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_publish_advanced.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_publish_advanced.rs
@@ -9,7 +9,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{PublishOptions, PublishProperties, QoS, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.3.4-2]` Overlapping subscriptions: at least one PUBLISH copy
 /// must be delivered at the maximum granted `QoS` across the matching

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_publish_alias.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_publish_alias.rs
@@ -6,7 +6,7 @@ use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.3.2-12]` A sender can modify the Topic Alias mapping by
 /// sending another PUBLISH with the same Topic Alias value and a

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_qos_ack.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_qos_ack.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{PublishOptions, QoS, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.4.0-1]` `[MQTT-3.4.2-1]` Server MUST send PUBACK in response to
 /// a `QoS` 1 PUBLISH, containing the matching Packet Identifier and a valid

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{PublishOptions, QoS, RetainHandling, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.8.1-1]` SUBSCRIBE fixed header flags MUST be `0x02`.
 /// A raw SUBSCRIBE with flags `0x00` (byte `0x80`) must cause disconnect.
@@ -213,7 +213,6 @@ async fn subscribe_replaces_existing(sut: SutHandle) {
         .unwrap();
     let (_, rc2) = raw_sub.expect_suback(TIMEOUT).await.expect("SUBACK 2");
     assert_eq!(rc2[0], 0x01, "second subscribe should grant QoS 1");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "sub-replace-pub")
         .await
@@ -355,7 +354,6 @@ async fn delivered_qos_is_minimum_sub0_pub1(sut: SutHandle) {
         .unwrap();
     let (_, rc) = raw_sub.expect_suback(TIMEOUT).await.expect("SUBACK");
     assert_eq!(rc[0], 0x00, "granted QoS should be 0");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut raw_publisher = RawMqttClient::connect_tcp(sut.expect_tcp_addr())
         .await
@@ -400,7 +398,6 @@ async fn delivered_qos_is_minimum_sub1_pub2(sut: SutHandle) {
         .unwrap();
     let (_, rc) = raw_sub.expect_suback(TIMEOUT).await.expect("SUBACK");
     assert_eq!(rc[0], 0x01, "granted QoS should be 1");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub-mq12")
         .await

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_unsubscribe.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_unsubscribe.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{QoS, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-3.10.1-1]` UNSUBSCRIBE fixed header flags MUST be `0x02`.
 /// A raw UNSUBSCRIBE with flags `0x00` (byte `0xA0`) must cause disconnect.
@@ -270,7 +270,6 @@ async fn unsubscribe_partial_multi(sut: SutHandle) {
     .await
     .unwrap();
     raw.expect_suback(TIMEOUT).await.expect("expected SUBACK");
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let filters = ["test/remove", "test/never-existed"];
     raw.send_raw(&RawPacketBuilder::unsubscribe_multiple(&filters, 2))

--- a/crates/mqtt5-conformance/src/conformance_tests/section4_error_handling.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section4_error_handling.rs
@@ -6,7 +6,7 @@ use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// [MQTT-4.13.1-1] When a Server detects a Malformed Packet or Protocol Error,
 /// and a Reason Code is given in the specification, it MUST close the Network

--- a/crates/mqtt5-conformance/src/conformance_tests/section4_flow_control.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section4_flow_control.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{PublishOptions, QoS};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-4.9.0-1]` / `[MQTT-4.9.0-2]` Server must not send more unACKed
 /// `QoS` 1/2 PUBLISH packets than the client's Receive Maximum. Further

--- a/crates/mqtt5-conformance/src/conformance_tests/section4_qos.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section4_qos.rs
@@ -9,7 +9,7 @@ use mqtt5_protocol::types::{PublishOptions, QoS, SubscribeOptions};
 use std::collections::HashSet;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-4.3.1-1]` In the `QoS` 0 delivery protocol, the Server MUST send a
 /// PUBLISH packet with DUP=0.
@@ -29,7 +29,6 @@ async fn qos0_server_outbound_publish_has_dup_zero(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     publisher.publish(&topic, b"qos0-data").await.unwrap();
@@ -69,7 +68,6 @@ async fn qos1_server_outbound_unique_nonzero_id_and_dup_zero(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let mut pub_raw = RawMqttClient::connect_tcp(sut.expect_tcp_addr())
         .await
@@ -136,7 +134,6 @@ async fn qos1_packet_id_reusable_after_puback(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {
@@ -199,7 +196,6 @@ async fn server_assigns_nonzero_packet_ids(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
 
@@ -267,7 +263,6 @@ async fn qos2_server_outbound_unique_nonzero_id_and_dup_zero(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {
@@ -326,7 +321,6 @@ async fn qos2_unacknowledged_until_pubrec(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {
@@ -371,7 +365,6 @@ async fn qos2_server_sends_pubrel_after_pubrec_and_holds_until_pubcomp(sut: SutH
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {
@@ -644,7 +637,6 @@ async fn no_spontaneous_retransmission_on_active_connection(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {
@@ -692,7 +684,6 @@ async fn puback_error_stops_retransmission(sut: SutHandle) {
         .await
         .unwrap();
     let _ = sub.expect_suback(TIMEOUT).await;
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "pub").await.unwrap();
     let pub_opts = PublishOptions {

--- a/crates/mqtt5-conformance/src/conformance_tests/section4_shared_sub.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section4_shared_sub.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::{PublishOptions, QoS, SubscribeOptions};
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-4.8.2-1]` A valid shared subscription filter
 /// (`$share/<name>/<filter>`) must be accepted.
@@ -471,8 +471,6 @@ async fn shared_sub_puback_error_discards(sut: SutHandle) {
         .await
         .unwrap();
     let _ = worker.expect_suback(TIMEOUT).await;
-
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
     let publisher = TestClient::connect_with_prefix(&sut, "shared-err-pub")
         .await

--- a/crates/mqtt5-conformance/src/conformance_tests/section4_topic.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section4_topic.rs
@@ -8,7 +8,7 @@ use crate::test_client::TestClient;
 use mqtt5_protocol::types::SubscribeOptions;
 use std::time::Duration;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// `[MQTT-4.7.1-1]` The multi-level wildcard `#` MUST be the last character
 /// in a topic filter.

--- a/crates/mqtt5-conformance/src/conformance_tests/section6_websocket.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section6_websocket.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
 
-const TIMEOUT: Duration = Duration::from_secs(3);
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 fn ws_addr(sut: &SutHandle) -> SocketAddr {
     sut.expect_ws_addr()

--- a/crates/mqtt5-conformance/src/test_client/raw.rs
+++ b/crates/mqtt5-conformance/src/test_client/raw.rs
@@ -40,7 +40,7 @@ use tokio::sync::{oneshot, Mutex as AsyncMutex};
 use tokio::task::JoinHandle;
 
 const READ_BUF_INITIAL: usize = 8 * 1024;
-const ACK_TIMEOUT: Duration = Duration::from_secs(10);
+const ACK_TIMEOUT: Duration = Duration::from_secs(30);
 
 type AckMap = Arc<StdMutex<HashMap<u16, oneshot::Sender<AckOutcome>>>>;
 type SubscriptionList = Arc<StdMutex<Vec<SubscriptionEntry>>>;


### PR DESCRIPTION
## Problem

The `Conformance (external mqtt5 broker)` CI job intermittently fails with `Timeout("puback")` (seen on #107's post-merge run), even though the identical code passes on re-run. The flake is timeout-tightness against an out-of-process broker on an oversubscribed runner, not a broker or protocol bug.

While investigating, the conformance suite's `sleep(Duration::from_millis(100))` calls placed immediately after each `expect_suback` were flagged as a race-guard smell.

## Findings (all validated against the real external `mqttv5` broker, ~700 runs)

**The post-SUBACK sleeps are redundant.** The broker commits the subscription to its router (`client_handler/subscribe.rs:54-68`) *before* sending SUBACK (`subscribe.rs:92`), so a client holding its SUBACK is guaranteed the subscription is live. Removing all 15 introduced **zero** delivery-miss failures across ~700 runs, including under 8-way CPU saturation. (`must receive QoS 1 PUBLISH` never fired.)

**The flake is timeout-tightness, and the sleep never caused it.** Every failure observed was `Timeout("suback")` / `Timeout("puback")` — the broker being too slow to *ack* under load, which is causally upstream of the sleep (it runs after the ack arrives).

## Changes

- Remove the 15 redundant post-SUBACK `sleep(100ms)` calls (left the 45 legitimate expiry/keepalive/negative-window sleeps untouched).
- `ACK_TIMEOUT` 10s → 30s (`test_client/raw.rs`; purely a positive deadline on `await_ack`) — fixes the documented `Timeout("puback")` with 3× headroom over the 10s that failed in CI.
- All 19 per-file `TIMEOUT` consts 3s → 10s — headroom for `expect_suback`/`connack`/`publish`.

## Verification

| Measure | Result |
|---|---|
| Delivery-miss regression | none (~700 runs) |
| `Timeout("suback")` under 8-way load | present at 3s → **cured** at 10s (0/150 saturated) |
| Suite runtime | 8s → ~11.6s (+3.6s); negligible vs the ~3-min build-dominated CI job |
| Negative-window audit | no passing test waits the full `TIMEOUT`; `if let Some` sites take the fast path |

Residual `Timeout("puback")` (~2/150) only appears under pathological full-core saturation harsher than a 2-core CI runner — a wedged broker defeats any finite timeout. A bounded publish retry is the next lever if 30s proves insufficient, but it changes QoS1 DUP semantics and is deferred.

**No version bump:** changes are entirely within `mqtt5-conformance` (`publish = false`); the published `mqtt5` crate is untouched.

Full investigation log in `crates/mqtt5-conformance/CONFORMANCE_DIARY.md`.
