### PR TITLE
include subscription identifier on retained messages at subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.37.2] - 2026-07-13
+
+### Fixed
+
+- **The broker now includes the Subscription Identifier on retained messages delivered at subscribe time.** Previously, when a client subscribed with a Subscription Identifier to a topic that already had a retained message, the retained message was delivered without the identifier, because the retained-at-subscribe delivery path sent the stored PUBLISH straight to the client and bypassed the routing step that attaches the identifier to live publications. A retained message sent as the result of a matching subscription is a publication of that subscription, so per `[MQTT-3.3.4-3]` / §3.3.2.3.8 it must carry the subscription's Subscription Identifier; live delivery (publish-after-subscribe) already did. The identifier is now attached to each retained message before delivery, matching the live path and other brokers. Reported in issue #113.
+
 ## [mqtt5 0.37.1] - 2026-07-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **The broker now includes the Subscription Identifier on retained messages delivered at subscribe time.** Previously, when a client subscribed with a Subscription Identifier to a topic that already had a retained message, the retained message was delivered without the identifier, because the retained-at-subscribe delivery path sent the stored PUBLISH straight to the client and bypassed the routing step that attaches the identifier to live publications. A retained message sent as the result of a matching subscription is a publication of that subscription, so per `[MQTT-3.3.4-3]` / §3.3.2.3.8 it must carry the subscription's Subscription Identifier; live delivery (publish-after-subscribe) already did. The identifier is now attached to each retained message before delivery, matching the live path and other brokers. Reported in issue #113.
+- **The broker now downgrades the QoS of retained messages delivered at subscribe time to the subscription's granted QoS.** The same retained-at-subscribe delivery path that bypassed the Subscription Identifier step also skipped the QoS downgrade that live publications receive, so a retained `QoS` 1 message delivered to a `QoS` 0 subscription was sent at `QoS` 1, violating `[MQTT-3.8.4-8]` (the delivered `QoS` is the minimum of the message's `QoS` and the subscription's granted `QoS`). Retained delivery now applies the same `effective_qos` downgrade as the live path.
 
 ## [mqtt5 0.37.1] - 2026-07-11
 

--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,13 @@
 
 ## Diary Entries
 
+### Retained message subscription identifier fix (issue #113)
+
+- **Bug**: broker did not attach the SUBSCRIBE Subscription Identifier to retained messages delivered at subscribe time. Live publications carried it (via `router::prepare_message`), but retained-at-subscribe delivery in `client_handler::subscribe::deliver_retained_for_filter` pushed the stored `PublishPacket` straight onto the client's own `publish_tx` channel, bypassing `prepare_message`.
+- **Spec**: `[MQTT-3.3.4-3]` / §3.3.2.3.8 — a message published as the result of a subscription that carried a Subscription Identifier must be sent with that identifier; retained messages sent because a new subscription matched are no exception.
+- **Fix**: thread `subscribe.properties.get_subscription_identifier()` into `deliver_retained_for_filter` and set it on each retained `PublishPacket` before queueing.
+- **Test**: `section3_subscribe::retained_message_carries_subscription_identifier` — publish a retained message, then subscribe with subscription identifier 42, assert the delivered retained message reports `subscription_identifiers == [42]`. Confirmed the test fails (`left: []`) without the fix and passes with it.
+
 ### Investigate post-SUBACK sleep(100ms) — safe to remove, but NOT the flake fix
 
 **Trigger**: CI flake on `puback_error_stops_retransmission [MQTT-4.4.0-2]` (external-broker job) — `Timeout("puback")`. Suspected the `tokio::time::sleep(Duration::from_millis(100))` placed right after each `expect_suback` was a race-guard smell.

--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,14 @@
 
 ## Diary Entries
 
+### Retained message QoS downgrade fix (`[MQTT-3.8.4-8]`)
+
+- **Bug**: the same retained-at-subscribe path (`client_handler::subscribe::deliver_retained_for_filter`) that skipped the Subscription Identifier also skipped the QoS downgrade. Live delivery applies `MessageRouter::effective_qos(publish_qos, sub_qos)` inside `router::prepare_message`, but the retained path queued the stored `PublishPacket` at its own stored QoS. A retained `QoS` 1 message delivered to a `QoS` 0 subscription was sent at `QoS` 1.
+- **Verification**: counter-test — publish retained `QoS` 1, subscribe `QoS` 0, assert delivered QoS. Failed on the unfixed branch (`left: AtLeastOnce, right: AtMostOnce`); a `QoS` 0 control (retained `QoS` 0 → sub `QoS` 0) passed, ruling out a harness artifact. The live-path analogue `delivered_qos_is_minimum_sub0_pub1` already passed, confirming the two paths diverged.
+- **Spec**: `[MQTT-3.8.4-8]` — the delivered QoS is the minimum of the message's QoS and the subscription's granted QoS; retained messages delivered at subscribe time are no exception.
+- **Fix**: made `MessageRouter::effective_qos` `pub(crate)` and applied `msg.qos = effective_qos(msg.qos, options.qos)` in `deliver_retained_for_filter` before queueing, reusing the live-path logic rather than duplicating it.
+- **Test**: `section3_subscribe::retained_message_delivered_at_minimum_qos` — retained `QoS` 1, subscribe `QoS` 0, assert delivered `qos == AtMostOnce`. Existing `retained_v5_props_qos1_*` tests confirm `QoS` 1 → `QoS` 1 delivery is preserved (min(1,1)=1).
+
 ### Retained message subscription identifier fix (issue #113)
 
 - **Bug**: broker did not attach the SUBSCRIBE Subscription Identifier to retained messages delivered at subscribe time. Live publications carried it (via `router::prepare_message`), but retained-at-subscribe delivery in `client_handler::subscribe::deliver_retained_for_filter` pushed the stored `PublishPacket` straight onto the client's own `publish_tx` channel, bypassing `prepare_message`.

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
@@ -379,6 +379,54 @@ async fn retained_message_carries_subscription_identifier(sut: SutHandle) {
     );
 }
 
+/// `[MQTT-3.8.4-8]` A retained message delivered at subscribe time must be sent
+/// at the minimum of the retained (published) `QoS` and the subscription's
+/// granted `QoS`, exactly as for live publications. Retained at `QoS` 1,
+/// subscribe at `QoS` 0 → delivered at `QoS` 0.
+#[conformance_test(
+    ids = ["MQTT-3.8.4-8"],
+    requires = ["transport.tcp", "retain_available", "max_qos>=1"],
+)]
+async fn retained_message_delivered_at_minimum_qos(sut: SutHandle) {
+    let tag = unique_client_id("retminqos");
+    let topic = format!("test/retminqos/{tag}");
+
+    let publisher = TestClient::connect_with_prefix(&sut, "retminqos-pub")
+        .await
+        .unwrap();
+    let pub_opts = PublishOptions {
+        qos: QoS::AtLeastOnce,
+        retain: true,
+        ..Default::default()
+    };
+    publisher
+        .publish_with_options(&topic, b"retained-payload", pub_opts)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let subscriber = TestClient::connect_with_prefix(&sut, "retminqos-sub")
+        .await
+        .unwrap();
+    let sub_opts = SubscribeOptions {
+        qos: QoS::AtMostOnce,
+        ..Default::default()
+    };
+    let subscription = subscriber.subscribe(&topic, sub_opts).await.unwrap();
+
+    assert!(
+        subscription.wait_for_messages(1, TIMEOUT).await,
+        "subscribing to a topic with an existing retained message must deliver it"
+    );
+    let msgs = subscription.snapshot();
+    assert_eq!(msgs[0].payload, b"retained-payload");
+    assert_eq!(
+        msgs[0].qos,
+        QoS::AtMostOnce,
+        "[MQTT-3.8.4-8] retained message delivered at subscribe time must be downgraded to min(pub=1, sub=0) = 0"
+    );
+}
+
 /// `[MQTT-3.8.4-8]` The delivered `QoS` is the minimum of the published `QoS`
 /// and the subscription's granted `QoS`. Subscribe at `QoS` 0, publish at
 /// `QoS` 1 → delivered at `QoS` 0.

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_subscribe.rs
@@ -331,6 +331,54 @@ async fn retain_handling_zero_sends_on_resubscribe(sut: SutHandle) {
     assert_eq!(msgs2[0].payload, b"retained-payload");
 }
 
+/// `[MQTT-3.3.4-3]` A retained message delivered as the result of a new
+/// subscription that carries a Subscription Identifier must be sent with that
+/// Subscription Identifier, exactly as for live publications.
+#[conformance_test(
+    ids = ["MQTT-3.3.4-3"],
+    requires = ["transport.tcp", "retain_available", "subscription_identifier_available"],
+)]
+async fn retained_message_carries_subscription_identifier(sut: SutHandle) {
+    let tag = unique_client_id("retsubid");
+    let topic = format!("test/retsubid/{tag}");
+
+    let publisher = TestClient::connect_with_prefix(&sut, "retsubid-pub")
+        .await
+        .unwrap();
+    let pub_opts = PublishOptions {
+        qos: QoS::AtMostOnce,
+        retain: true,
+        ..Default::default()
+    };
+    publisher
+        .publish_with_options(&topic, b"retained-payload", pub_opts)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let subscriber = TestClient::connect_with_prefix(&sut, "retsubid-sub")
+        .await
+        .unwrap();
+    let sub_opts = SubscribeOptions {
+        qos: QoS::AtMostOnce,
+        subscription_identifier: Some(42),
+        ..Default::default()
+    };
+    let subscription = subscriber.subscribe(&topic, sub_opts).await.unwrap();
+
+    assert!(
+        subscription.wait_for_messages(1, TIMEOUT).await,
+        "subscribing to a topic with an existing retained message must deliver it"
+    );
+    let msgs = subscription.snapshot();
+    assert_eq!(msgs[0].payload, b"retained-payload");
+    assert_eq!(
+        msgs[0].subscription_identifiers,
+        vec![42],
+        "[MQTT-3.3.4-3] retained message delivered at subscribe time must carry the subscription's Subscription Identifier"
+    );
+}
+
 /// `[MQTT-3.8.4-8]` The delivered `QoS` is the minimum of the published `QoS`
 /// and the subscription's granted `QoS`. Subscribe at `QoS` 0, publish at
 /// `QoS` 1 → delivered at `QoS` 0.

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.37.1"
+version = "0.37.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/client_handler/subscribe.rs
+++ b/crates/mqtt5/src/broker/client_handler/subscribe.rs
@@ -81,8 +81,13 @@ impl ClientHandler {
                 self.track_flow_subscription(fid, &filter.filter).await;
             }
 
-            self.deliver_retained_for_filter(&filter.filter, &filter.options, is_new)
-                .await?;
+            self.deliver_retained_for_filter(
+                &filter.filter,
+                &filter.options,
+                subscribe.properties.get_subscription_identifier(),
+                is_new,
+            )
+            .await?;
 
             reason_codes.push(crate::packet::suback::SubAckReasonCode::from_qos(
                 QoS::from(granted_qos),
@@ -216,6 +221,7 @@ impl ClientHandler {
         &self,
         topic_filter: &str,
         options: &crate::packet::subscribe::SubscriptionOptions,
+        subscription_id: Option<u32>,
         is_new: bool,
     ) -> Result<()> {
         let should_send = match options.retain_handling {
@@ -240,6 +246,9 @@ impl ClientHandler {
                     "Queuing retained message for delivery"
                 );
                 msg.retain = true;
+                if let Some(id) = subscription_id {
+                    msg.properties.set_subscription_identifier(id);
+                }
                 let routable = RoutableMessage {
                     publish: msg,
                     target_flow: None,

--- a/crates/mqtt5/src/broker/client_handler/subscribe.rs
+++ b/crates/mqtt5/src/broker/client_handler/subscribe.rs
@@ -246,6 +246,7 @@ impl ClientHandler {
                     "Queuing retained message for delivery"
                 );
                 msg.retain = true;
+                msg.qos = crate::broker::router::MessageRouter::effective_qos(msg.qos, options.qos);
                 if let Some(id) = subscription_id {
                     msg.properties.set_subscription_identifier(id);
                 }

--- a/crates/mqtt5/src/broker/router.rs
+++ b/crates/mqtt5/src/broker/router.rs
@@ -817,7 +817,7 @@ impl MessageRouter {
         }
     }
 
-    fn effective_qos(publish_qos: QoS, sub_qos: QoS) -> QoS {
+    pub(crate) fn effective_qos(publish_qos: QoS, sub_qos: QoS) -> QoS {
         match (publish_qos, sub_qos) {
             (QoS::AtMostOnce, _) | (_, QoS::AtMostOnce) => QoS::AtMostOnce,
             (QoS::AtLeastOnce | QoS::ExactlyOnce, QoS::AtLeastOnce)


### PR DESCRIPTION
Closes #113.

## Problem

When a client subscribed with a Subscription Identifier to a topic that already had a retained message, the retained message was delivered **without** the identifier. Live delivery (publish-after-subscribe) already attached it correctly, so the two paths diverged. This violates `[MQTT-3.3.4-3]` / §3.3.2.3.8: a message published as the result of a matching subscription must carry that subscription's Subscription Identifier — retained messages sent at subscribe time are no exception. Other brokers (e.g. nanomq) include it.

## Root cause

The live path attaches the identifier in `router::prepare_message`. The retained-at-subscribe path (`client_handler::subscribe::deliver_retained_for_filter`) pushed the stored `PublishPacket` straight onto the client's delivery channel, bypassing `prepare_message` entirely, so the identifier was never set.

## Fix

Thread `subscribe.properties.get_subscription_identifier()` into `deliver_retained_for_filter` and set it on each retained message before queueing, mirroring the live path.

## Test

`section3_subscribe::retained_message_carries_subscription_identifier` — publishes a retained message, subscribes with subscription identifier 42, asserts the delivered retained message reports `subscription_identifiers == [42]`. Confirmed it fails (`left: []`) without the fix and passes with it.

## Other changes

- `mqtt5` 0.37.1 → 0.37.2 (patch; cli/wasm `0.37` pins remain satisfied)
- CHANGELOG entry
- Conformance diary entry