### PR TITLE
validate deferred-ack end-to-end against real brokers

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -98,6 +98,52 @@ jobs:
           path: conformance-report.json
           if-no-files-found: error
 
+  mosquitto-interop:
+    name: Conformance (Mosquitto interop)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build conformance CLI
+        run: cargo build --profile conformance -p mqtt5-conformance-cli
+
+      - name: Start Mosquitto
+        run: |
+          mkdir -p mosquitto-config
+          printf 'listener 1883 0.0.0.0\nallow_anonymous true\n' > mosquitto-config/mosquitto.conf
+          docker run -d --name mosquitto-interop -p 1883:1883 \
+            -v "$PWD/mosquitto-config:/mosquitto/config" \
+            eclipse-mosquitto:2
+          sleep 3
+
+      - name: Run deferred-ack conformance against Mosquitto
+        run: |
+          ./target/conformance/mqtt5-conformance \
+            --sut crates/mqtt5-conformance/tests/fixtures/mosquitto-2.x.toml \
+            --report conformance-report-mosquitto.json \
+            deferred_qos2
+
+      - name: Mosquitto log
+        if: always()
+        run: docker logs mosquitto-interop || true
+
+      - name: Stop Mosquitto
+        if: always()
+        run: docker rm -f mosquitto-interop || true
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-report-mosquitto
+          path: conformance-report-mosquitto.json
+          if-no-files-found: error
+
   fixtures:
     name: Validate fixtures and profiles
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -120,7 +120,16 @@ jobs:
           docker run -d --name mosquitto-interop -p 1883:1883 \
             -v "$PWD/mosquitto-config:/mosquitto/config" \
             eclipse-mosquitto:2
-          sleep 3
+          for i in $(seq 1 30); do
+            if timeout 1 bash -c '</dev/tcp/127.0.0.1/1883' 2>/dev/null; then
+              echo "mosquitto ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "mosquitto did not become ready in time" >&2
+          docker logs mosquitto-interop || true
+          exit 1
 
       - name: Run deferred-ack conformance against Mosquitto
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     strategy:
       fail-fast: false
       matrix:

--- a/crates/mqtt5-conformance/src/conformance_tests/deferred_ack.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/deferred_ack.rs
@@ -77,7 +77,6 @@ async fn deferred_qos2_slot_held_until_pubcomp(sut: SutHandle) {
         "[MQTT-4.9.0-2] the second message must be withheld while the PUBREC is deferred (quota=1)"
     );
 
-    // Complete the deferred handshake; the slot frees only at PUBCOMP.
     sub.send_raw(&RawPacketBuilder::pubrec(first_pid))
         .await
         .unwrap();
@@ -141,7 +140,6 @@ async fn deferred_qos2_zero_quota_still_serves_control_plane(sut: SutHandle) {
         .await
         .expect("broker delivers the first QoS 2 PUBLISH");
     assert_eq!(qos, 2, "delivered message must be QoS 2");
-    // Deliberately do NOT send PUBREC — the quota stays at zero.
 
     sub.send_raw(&RawPacketBuilder::pingreq()).await.unwrap();
     assert!(

--- a/crates/mqtt5-conformance/src/conformance_tests/deferred_ack.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/deferred_ack.rs
@@ -1,0 +1,159 @@
+//! Broker behaviour that the client-side deferred-acknowledgement feature relies on.
+//!
+//! Deferred ack works by withholding the PUBREC/PUBACK for an inbound message until the application
+//! has processed it. That only provides backpressure (rather than silent unbounded buffering) if the
+//! broker keeps the Receive-Maximum slot occupied for the whole time the acknowledgement is withheld
+//! — for `QoS` 2, across the entire PUBREC/PUBREL/PUBCOMP handshake, not just until PUBREC. These
+//! tests drive a raw subscriber that defers its `QoS` 2 acknowledgement and assert the broker
+//! behaves accordingly. They are broker-agnostic, so they run against the in-process fixture, the
+//! external `mqttv5` broker, and any third-party broker with `QoS` 2 support.
+
+use crate::conformance_test;
+use crate::harness::unique_client_id;
+use crate::raw_client::{RawMqttClient, RawPacketBuilder};
+use crate::sut::SutHandle;
+use crate::test_client::TestClient;
+use mqtt5_protocol::types::{PublishOptions, QoS};
+use std::time::Duration;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+const QUIET: Duration = Duration::from_millis(600);
+
+async fn publish_qos2(sut: &SutHandle, topic: &str, payloads: &[&[u8]]) {
+    let publisher = TestClient::connect_with_prefix(sut, "def-pub")
+        .await
+        .unwrap();
+    for payload in payloads {
+        publisher
+            .publish_with_options(
+                topic,
+                payload,
+                PublishOptions {
+                    qos: QoS::ExactlyOnce,
+                    ..PublishOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+    }
+    publisher.disconnect().await.ok();
+}
+
+/// `[MQTT-4.9.0-1]` `[MQTT-4.9.0-2]` A withheld `QoS` 2 PUBREC keeps the Receive-Maximum slot
+/// occupied: the broker delivers only `receive_maximum` messages and releases the next one only
+/// after the full PUBREC/PUBREL/PUBCOMP handshake completes — the guarantee deferred ack depends on.
+#[conformance_test(
+    ids = ["MQTT-4.9.0-1", "MQTT-4.9.0-2"],
+    requires = ["transport.tcp", "max_qos>=2"],
+)]
+async fn deferred_qos2_slot_held_until_pubcomp(sut: SutHandle) {
+    let topic = format!("deferred-q2/{}", unique_client_id("t"));
+
+    let mut sub = RawMqttClient::connect_tcp(sut.expect_tcp_addr())
+        .await
+        .unwrap();
+    let sub_id = unique_client_id("def-sub");
+    sub.send_raw(&RawPacketBuilder::connect_with_receive_maximum(&sub_id, 1))
+        .await
+        .unwrap();
+    let (_, reason) = sub.expect_connack(TIMEOUT).await.expect("CONNACK");
+    assert_eq!(reason, 0x00, "CONNACK must be Success");
+
+    sub.send_raw(&RawPacketBuilder::subscribe(&topic, 2))
+        .await
+        .unwrap();
+    let _ = sub.expect_suback(TIMEOUT).await.expect("SUBACK");
+
+    publish_qos2(&sut, &topic, &[b"first", b"second"]).await;
+
+    let (_, first_pid, qos, _t, _p) = sub
+        .expect_publish_with_id(TIMEOUT)
+        .await
+        .expect("broker delivers the first QoS 2 PUBLISH");
+    assert_eq!(qos, 2, "delivered message must be QoS 2");
+
+    assert!(
+        sub.expect_publish_with_id(QUIET).await.is_none(),
+        "[MQTT-4.9.0-2] the second message must be withheld while the PUBREC is deferred (quota=1)"
+    );
+
+    // Complete the deferred handshake; the slot frees only at PUBCOMP.
+    sub.send_raw(&RawPacketBuilder::pubrec(first_pid))
+        .await
+        .unwrap();
+    let (_, rel_pid, _) = sub
+        .expect_pubrel_raw(TIMEOUT)
+        .await
+        .expect("broker answers PUBREC with PUBREL");
+    assert_eq!(rel_pid, first_pid, "PUBREL must carry the same packet id");
+    sub.send_raw(&RawPacketBuilder::pubcomp(first_pid))
+        .await
+        .unwrap();
+
+    let (_, second_pid, qos2, _t, _p) = sub.expect_publish_with_id(TIMEOUT).await.expect(
+        "[MQTT-4.9.0-1] the second message flows once the handshake completes and frees the slot",
+    );
+    assert_eq!(qos2, 2, "second delivered message must be QoS 2");
+    assert_ne!(
+        second_pid, 0,
+        "the second delivery must carry a valid non-zero packet id (reuse of a freed id is allowed)"
+    );
+
+    sub.send_raw(&RawPacketBuilder::pubrec(second_pid))
+        .await
+        .unwrap();
+    let _ = sub.expect_pubrel_raw(TIMEOUT).await;
+    sub.send_raw(&RawPacketBuilder::pubcomp(second_pid))
+        .await
+        .unwrap();
+}
+
+/// `[MQTT-4.9.0-3]` With the `QoS` 2 quota fully consumed by a withheld PUBREC, the broker must
+/// still service control packets — PINGREQ and SUBSCRIBE — so a deferring client's control plane is
+/// never blocked.
+#[conformance_test(
+    ids = ["MQTT-4.9.0-3"],
+    requires = ["transport.tcp", "max_qos>=2"],
+)]
+async fn deferred_qos2_zero_quota_still_serves_control_plane(sut: SutHandle) {
+    let topic = format!("deferred-q2-zero/{}", unique_client_id("t"));
+    let topic2 = format!("deferred-q2-zero2/{}", unique_client_id("t"));
+
+    let mut sub = RawMqttClient::connect_tcp(sut.expect_tcp_addr())
+        .await
+        .unwrap();
+    let sub_id = unique_client_id("def-sub0");
+    sub.send_raw(&RawPacketBuilder::connect_with_receive_maximum(&sub_id, 1))
+        .await
+        .unwrap();
+    let (_, reason) = sub.expect_connack(TIMEOUT).await.expect("CONNACK");
+    assert_eq!(reason, 0x00, "CONNACK must be Success");
+
+    sub.send_raw(&RawPacketBuilder::subscribe(&topic, 2))
+        .await
+        .unwrap();
+    let _ = sub.expect_suback(TIMEOUT).await.expect("SUBACK");
+
+    publish_qos2(&sut, &topic, &[b"fill", b"queued"]).await;
+
+    let (_, _pid, qos, _t, _p) = sub
+        .expect_publish_with_id(TIMEOUT)
+        .await
+        .expect("broker delivers the first QoS 2 PUBLISH");
+    assert_eq!(qos, 2, "delivered message must be QoS 2");
+    // Deliberately do NOT send PUBREC — the quota stays at zero.
+
+    sub.send_raw(&RawPacketBuilder::pingreq()).await.unwrap();
+    assert!(
+        sub.expect_pingresp(TIMEOUT).await,
+        "[MQTT-4.9.0-3] PINGREQ must be answered while the QoS 2 quota is fully withheld"
+    );
+
+    sub.send_raw(&RawPacketBuilder::subscribe_with_packet_id(&topic2, 0, 7))
+        .await
+        .unwrap();
+    assert!(
+        sub.expect_suback(TIMEOUT).await.is_some(),
+        "[MQTT-4.9.0-3] SUBSCRIBE must be processed while the QoS 2 quota is fully withheld"
+    );
+}

--- a/crates/mqtt5-conformance/src/conformance_tests/mod.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/mod.rs
@@ -16,6 +16,7 @@
 //! broader migration pulls the rest of the existing `tests/section*.rs`
 //! files in alongside it.
 
+pub mod deferred_ack;
 pub mod section1_data_repr;
 pub mod section3_connack;
 pub mod section3_connect;

--- a/crates/mqtt5/tests/deferred_ack_matrix.rs
+++ b/crates/mqtt5/tests/deferred_ack_matrix.rs
@@ -1,0 +1,397 @@
+#![cfg(feature = "broker")]
+#![allow(clippy::large_futures)]
+
+mod common;
+
+use common::TestBroker;
+use mqtt5::protocol::v5::reason_codes::ReasonCode;
+use mqtt5::time::Duration;
+use mqtt5::{AckToken, ConnectOptions, MqttClient, PublishOptions, QoS, SubscribeOptions};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use ulid::Ulid;
+
+fn client_id(name: &str) -> String {
+    format!("test-{name}-{}", Ulid::new())
+}
+
+fn deferred_options(id: &str, receive_maximum: u16) -> ConnectOptions {
+    ConnectOptions::new(id)
+        .with_deferred_ack(true)
+        .with_clean_start(false)
+        .with_session_expiry_interval(3600)
+        .with_receive_maximum(receive_maximum)
+        .with_keep_alive(Duration::from_secs(5))
+}
+
+fn subscribe(qos: QoS) -> SubscribeOptions {
+    SubscribeOptions {
+        qos,
+        ..Default::default()
+    }
+}
+
+fn publish(qos: QoS) -> PublishOptions {
+    PublishOptions {
+        qos,
+        ..Default::default()
+    }
+}
+
+async fn wait_until(cond: impl Fn() -> bool) -> bool {
+    for _ in 0..200 {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    cond()
+}
+
+async fn publish_n(broker_address: &str, topic: &str, qos: QoS, count: u32) {
+    let publisher = MqttClient::new(client_id("def-pub"));
+    publisher.connect(broker_address).await.unwrap();
+    publish_n_with(&publisher, topic, qos, count).await;
+    publisher.disconnect().await.ok();
+}
+
+async fn publish_n_with(publisher: &MqttClient, topic: &str, qos: QoS, count: u32) {
+    for i in 0..count {
+        publisher
+            .publish_with_options(topic, format!("msg-{i}").into_bytes(), publish(qos))
+            .await
+            .unwrap();
+    }
+}
+
+struct Recorder {
+    count: Arc<AtomicU32>,
+    tokens: Arc<Mutex<Vec<AckToken>>>,
+}
+
+impl Recorder {
+    fn new() -> Self {
+        Self {
+            count: Arc::new(AtomicU32::new(0)),
+            tokens: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn received(&self) -> u32 {
+        self.count.load(Ordering::SeqCst)
+    }
+
+    fn pop_token(&self) -> AckToken {
+        self.tokens.lock().unwrap().pop().expect("a token was held")
+    }
+}
+
+async fn subscribe_collecting(client: &MqttClient, filter: &str, qos: QoS, rec: &Recorder) {
+    let count = Arc::clone(&rec.count);
+    let tokens = Arc::clone(&rec.tokens);
+    client
+        .subscribe_with_ack(filter, subscribe(qos), move |_publish, token| {
+            count.fetch_add(1, Ordering::SeqCst);
+            tokens.lock().unwrap().push(token);
+        })
+        .await
+        .unwrap();
+}
+
+// Q1 (the untested gap): QoS1 deferred ack. Holding the token withholds the PUBACK, which
+// keeps the Receive-Maximum slot full and throttles the broker; acking frees the slot.
+#[tokio::test]
+async fn qos1_deferred_puback_withheld_throttles_then_ack_frees_slot() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("q1"), 1));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::AtLeastOnce, &rec).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::AtLeastOnce, 2).await;
+
+    assert!(
+        wait_until(|| rec.received() == 1).await,
+        "first QoS1 message delivered"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        rec.received(),
+        1,
+        "the second message is withheld while the PUBACK is deferred (window full)"
+    );
+
+    rec.pop_token().ack();
+
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "acking the first frees the slot and the second QoS1 message flows"
+    );
+
+    subscriber.disconnect().await.ok();
+}
+
+// Q2 + B1/B2: QoS2 deferred PUBREC withheld throttles the window; ack frees it.
+#[tokio::test]
+async fn qos2_deferred_pubrec_withheld_throttles_then_ack_frees_slot() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("q2"), 1));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::ExactlyOnce, 2).await;
+
+    assert!(
+        wait_until(|| rec.received() == 1).await,
+        "first QoS2 message delivered"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        rec.received(),
+        1,
+        "the second message is withheld while the PUBREC is deferred (window full)"
+    );
+
+    rec.pop_token().ack();
+
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "acking completes the handshake, frees the slot, and the second QoS2 message flows"
+    );
+
+    subscriber.disconnect().await.ok();
+}
+
+// Q3: rejecting a QoS2 message is terminal and frees the slot (next message flows).
+#[tokio::test]
+async fn qos2_reject_frees_the_slot() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("q3"), 1));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::ExactlyOnce, 2).await;
+    assert!(wait_until(|| rec.received() == 1).await, "first delivered");
+
+    rec.pop_token().reject(ReasonCode::UnspecifiedError);
+
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "rejecting frees the slot and the next message flows"
+    );
+
+    subscriber.disconnect().await.ok();
+}
+
+// Q5 + obligation 7: dropping an armed token auto-acks, freeing the slot (no wedge).
+#[tokio::test]
+async fn qos2_dropped_token_auto_acks_and_frees_the_slot() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("q5"), 1));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::ExactlyOnce, 2).await;
+    assert!(wait_until(|| rec.received() == 1).await, "first delivered");
+
+    drop(rec.pop_token());
+
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "dropping the token auto-acks, frees the slot, and the next message flows (no wedge)"
+    );
+
+    subscriber.disconnect().await.ok();
+}
+
+// R1 (obligation 4): with the window saturated by held tokens, the reader is not blocked —
+// the control plane still services a fresh SUBSCRIBE and the connection stays alive.
+#[tokio::test]
+async fn saturated_window_does_not_block_the_control_plane() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("r1"), 2));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::ExactlyOnce, 4).await;
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "the window fills at receive_maximum=2 with tokens held"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(rec.received(), 2, "no further delivery while saturated");
+
+    let ping = MqttClient::with_options(deferred_options(&client_id("r1-probe"), 2));
+    ping.connect(broker.address()).await.unwrap();
+    ping.subscribe_with_ack("other/#", subscribe(QoS::AtLeastOnce), |_p, _t| {})
+        .await
+        .expect("a SUBSCRIBE must still succeed while another client's window is saturated");
+    assert!(
+        subscriber.is_connected().await,
+        "the saturated subscriber stays connected (reader not blocked)"
+    );
+
+    ping.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+}
+
+// RC2 (_crash regime): a fresh client process resumes the session on a still-running broker;
+// the unacked QoS2 message is re-delivered (at-least-once processing) with no wedge.
+#[tokio::test]
+async fn crash_regime_fresh_client_resumes_and_redelivers() {
+    let broker = TestBroker::start().await;
+    let id = client_id("rc2");
+
+    let first = MqttClient::with_options(deferred_options(&id, 8));
+    first.connect(broker.address()).await.unwrap();
+    let rec1 = Recorder::new();
+    subscribe_collecting(&first, "jobs/#", QoS::ExactlyOnce, &rec1).await;
+
+    publish_n(broker.address(), "jobs/a", QoS::ExactlyOnce, 1).await;
+    assert!(
+        wait_until(|| rec1.received() == 1).await,
+        "the first client receives the message"
+    );
+
+    // Simulate a crash: drop the client without acking and without a graceful DISCONNECT.
+    drop(rec1);
+    drop(first);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // A fresh client with the same id resumes the persistent session.
+    let second = MqttClient::with_options(deferred_options(&id, 8));
+    let result = second
+        .connect_with_options(broker.address(), deferred_options(&id, 8))
+        .await
+        .unwrap();
+    assert!(
+        result.session_present,
+        "the still-running broker resumes the persistent session"
+    );
+
+    let rec2 = Recorder::new();
+    subscribe_collecting(&second, "jobs/#", QoS::ExactlyOnce, &rec2).await;
+
+    assert!(
+        wait_until(|| rec2.received() == 1).await,
+        "the unacked message is re-delivered to the resumed session (at-least-once, no wedge)"
+    );
+    rec2.pop_token().ack();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(rec2.received(), 1, "no further re-delivery after the ack");
+
+    second.disconnect().await.ok();
+}
+
+async fn connect_tls(
+    client: &MqttClient,
+    broker: &TestBroker,
+    options: ConnectOptions,
+) -> mqtt5::ConnectResult {
+    use mqtt5::transport::tls::TlsConfig;
+    let addr: std::net::SocketAddr = broker
+        .address()
+        .strip_prefix("mqtts://")
+        .expect("tls broker address")
+        .parse()
+        .expect("socket addr");
+    let mut tls = TlsConfig::new(addr, "localhost").with_verify_server_cert(false);
+    tls.load_ca_cert_pem("../../test_certs/ca.pem")
+        .expect("load test CA cert");
+    client
+        .connect_with_tls_and_options(tls, options)
+        .await
+        .expect("tls connect")
+}
+
+// TLS smoke: the deferred QoS2 path (deliver, backpressure, ack) works under encryption.
+#[tokio::test]
+async fn tls_deferred_qos2_delivers_backpressures_and_acks() {
+    let broker = TestBroker::start_with_tls().await;
+
+    let sub_opts = deferred_options(&client_id("tls-sub"), 1);
+    let subscriber = MqttClient::with_options(sub_opts.clone());
+    connect_tls(&subscriber, &broker, sub_opts).await;
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    let publisher = MqttClient::with_options(ConnectOptions::new(client_id("tls-pub")));
+    connect_tls(
+        &publisher,
+        &broker,
+        ConnectOptions::new(client_id("tls-pub")),
+    )
+    .await;
+    publish_n_with(&publisher, "jobs/a", QoS::ExactlyOnce, 2).await;
+
+    assert!(
+        wait_until(|| rec.received() == 1).await,
+        "first message delivered over TLS"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        rec.received(),
+        1,
+        "second withheld while the window is full"
+    );
+
+    rec.pop_token().ack();
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "acking over TLS frees the slot and the second message flows"
+    );
+
+    publisher.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+}
+
+// WebSocket smoke: the deferred QoS2 path works over the WebSocket framing layer.
+#[cfg(feature = "transport-websocket")]
+#[tokio::test]
+async fn websocket_deferred_qos2_delivers_backpressures_and_acks() {
+    let broker = TestBroker::start_with_websocket().await;
+
+    let sub_opts = deferred_options(&client_id("ws-sub"), 1);
+    let subscriber = MqttClient::with_options(sub_opts.clone());
+    subscriber
+        .connect_with_options(broker.address(), sub_opts)
+        .await
+        .unwrap();
+
+    let rec = Recorder::new();
+    subscribe_collecting(&subscriber, "jobs/#", QoS::ExactlyOnce, &rec).await;
+
+    let publisher = MqttClient::new(client_id("ws-pub"));
+    publisher.connect(broker.address()).await.unwrap();
+    publish_n_with(&publisher, "jobs/a", QoS::ExactlyOnce, 2).await;
+
+    assert!(
+        wait_until(|| rec.received() == 1).await,
+        "first message delivered over WebSocket"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        rec.received(),
+        1,
+        "second withheld while the window is full"
+    );
+
+    rec.pop_token().ack();
+    assert!(
+        wait_until(|| rec.received() == 2).await,
+        "acking over WebSocket frees the slot and the second message flows"
+    );
+
+    publisher.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+}

--- a/crates/mqtt5/tests/deferred_ack_matrix.rs
+++ b/crates/mqtt5/tests/deferred_ack_matrix.rs
@@ -98,8 +98,6 @@ async fn subscribe_collecting(client: &MqttClient, filter: &str, qos: QoS, rec: 
         .unwrap();
 }
 
-// Q1 (the untested gap): QoS1 deferred ack. Holding the token withholds the PUBACK, which
-// keeps the Receive-Maximum slot full and throttles the broker; acking frees the slot.
 #[tokio::test]
 async fn qos1_deferred_puback_withheld_throttles_then_ack_frees_slot() {
     let broker = TestBroker::start().await;
@@ -132,7 +130,6 @@ async fn qos1_deferred_puback_withheld_throttles_then_ack_frees_slot() {
     subscriber.disconnect().await.ok();
 }
 
-// Q2 + B1/B2: QoS2 deferred PUBREC withheld throttles the window; ack frees it.
 #[tokio::test]
 async fn qos2_deferred_pubrec_withheld_throttles_then_ack_frees_slot() {
     let broker = TestBroker::start().await;
@@ -165,7 +162,6 @@ async fn qos2_deferred_pubrec_withheld_throttles_then_ack_frees_slot() {
     subscriber.disconnect().await.ok();
 }
 
-// Q3: rejecting a QoS2 message is terminal and frees the slot (next message flows).
 #[tokio::test]
 async fn qos2_reject_frees_the_slot() {
     let broker = TestBroker::start().await;
@@ -188,7 +184,6 @@ async fn qos2_reject_frees_the_slot() {
     subscriber.disconnect().await.ok();
 }
 
-// Q5 + obligation 7: dropping an armed token auto-acks, freeing the slot (no wedge).
 #[tokio::test]
 async fn qos2_dropped_token_auto_acks_and_frees_the_slot() {
     let broker = TestBroker::start().await;
@@ -211,8 +206,6 @@ async fn qos2_dropped_token_auto_acks_and_frees_the_slot() {
     subscriber.disconnect().await.ok();
 }
 
-// R1 (obligation 4): with the window saturated by held tokens, the reader is not blocked —
-// the control plane still services a fresh SUBSCRIBE and the connection stays alive.
 #[tokio::test]
 async fn saturated_window_does_not_block_the_control_plane() {
     let broker = TestBroker::start().await;
@@ -230,6 +223,19 @@ async fn saturated_window_does_not_block_the_control_plane() {
     tokio::time::sleep(Duration::from_millis(200)).await;
     assert_eq!(rec.received(), 2, "no further delivery while saturated");
 
+    let own_subscribe = tokio::time::timeout(
+        Duration::from_secs(5),
+        subscriber.subscribe_with_ack("control-probe/#", subscribe(QoS::AtLeastOnce), |_p, _t| {}),
+    )
+    .await;
+    assert!(
+        own_subscribe.is_ok(),
+        "the saturated subscriber's own SUBSCRIBE must complete (its reader is not blocked)"
+    );
+    own_subscribe
+        .unwrap()
+        .expect("the saturated subscriber's own SUBSCRIBE succeeds while its window is full");
+
     let ping = MqttClient::with_options(deferred_options(&client_id("r1-probe"), 2));
     ping.connect(broker.address()).await.unwrap();
     ping.subscribe_with_ack("other/#", subscribe(QoS::AtLeastOnce), |_p, _t| {})
@@ -244,8 +250,6 @@ async fn saturated_window_does_not_block_the_control_plane() {
     subscriber.disconnect().await.ok();
 }
 
-// RC2 (_crash regime): a fresh client process resumes the session on a still-running broker;
-// the unacked QoS2 message is re-delivered (at-least-once processing) with no wedge.
 #[tokio::test]
 async fn crash_regime_fresh_client_resumes_and_redelivers() {
     let broker = TestBroker::start().await;
@@ -262,13 +266,11 @@ async fn crash_regime_fresh_client_resumes_and_redelivers() {
         "the first client receives the message"
     );
 
-    // Simulate a crash: drop the client without acking and without a graceful DISCONNECT.
     drop(rec1);
     drop(first);
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    // A fresh client with the same id resumes the persistent session.
-    let second = MqttClient::with_options(deferred_options(&id, 8));
+    let second = MqttClient::new(&id);
     let result = second
         .connect_with_options(broker.address(), deferred_options(&id, 8))
         .await
@@ -313,7 +315,6 @@ async fn connect_tls(
         .expect("tls connect")
 }
 
-// TLS smoke: the deferred QoS2 path (deliver, backpressure, ack) works under encryption.
 #[tokio::test]
 async fn tls_deferred_qos2_delivers_backpressures_and_acks() {
     let broker = TestBroker::start_with_tls().await;
@@ -355,7 +356,6 @@ async fn tls_deferred_qos2_delivers_backpressures_and_acks() {
     subscriber.disconnect().await.ok();
 }
 
-// WebSocket smoke: the deferred QoS2 path works over the WebSocket framing layer.
 #[cfg(feature = "transport-websocket")]
 #[tokio::test]
 async fn websocket_deferred_qos2_delivers_backpressures_and_acks() {

--- a/crates/mqtt5/tests/deferred_ack_quic.rs
+++ b/crates/mqtt5/tests/deferred_ack_quic.rs
@@ -1,0 +1,200 @@
+#![cfg(all(feature = "broker", feature = "transport-quic"))]
+#![allow(clippy::large_futures)]
+
+//! Deferred acknowledgement over MQTT-over-QUIC (`MQoQ`).
+//!
+//! These run in the `DataPerTopic` stream strategy, so an inbound PUBLISH arrives on a per-topic
+//! data flow while the deferred PUBREC is written on the shared (control-stream) writer. The tests
+//! prove the broker still correlates that acknowledgement by packet id and completes the `QoS` 2
+//! handshake: delivery, Receive-Maximum backpressure, and both `ack()` and `reject()` behave as
+//! they do over TCP.
+
+use mqtt5::broker::config::{BrokerConfig, QuicConfig};
+use mqtt5::broker::MqttBroker;
+use mqtt5::protocol::v5::reason_codes::ReasonCode;
+use mqtt5::time::Duration;
+use mqtt5::transport::StreamStrategy;
+use mqtt5::{AckToken, ConnectOptions, MqttClient, PublishOptions, QoS, SubscribeOptions};
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use ulid::Ulid;
+
+fn cid(prefix: &str) -> String {
+    format!("{prefix}-{}", Ulid::new())
+}
+
+async fn start_quic_broker() -> (mqtt5::broker::BrokerShutdownHandle, SocketAddr) {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let cert_dir = manifest_dir.join("../../test_certs");
+    let quic_bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_quic(
+            QuicConfig::new(cert_dir.join("server.pem"), cert_dir.join("server.key"))
+                .with_bind_address(quic_bind),
+        );
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let quic_addr = broker.quic_local_addr().expect("QUIC endpoint bound");
+    let mut ready = broker.ready_receiver();
+    let shutdown = broker.shutdown_handle();
+    tokio::spawn(async move {
+        let _ = broker.run().await;
+    });
+    let _ = ready.wait_for(|&v| v).await;
+    (shutdown, quic_addr)
+}
+
+fn deferred_options(id: &str, receive_maximum: u16) -> ConnectOptions {
+    ConnectOptions::new(id)
+        .with_deferred_ack(true)
+        .with_clean_start(false)
+        .with_session_expiry_interval(3600)
+        .with_receive_maximum(receive_maximum)
+        .with_keep_alive(Duration::from_secs(5))
+}
+
+fn qos2_sub() -> SubscribeOptions {
+    SubscribeOptions {
+        qos: QoS::ExactlyOnce,
+        ..Default::default()
+    }
+}
+
+fn qos2_pub() -> PublishOptions {
+    PublishOptions {
+        qos: QoS::ExactlyOnce,
+        ..Default::default()
+    }
+}
+
+async fn wait_until(cond: impl Fn() -> bool) -> bool {
+    for _ in 0..200 {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    cond()
+}
+
+struct QuicFixture {
+    shutdown: mqtt5::broker::BrokerShutdownHandle,
+    subscriber: MqttClient,
+    publisher: MqttClient,
+    received: Arc<AtomicU32>,
+    tokens: Arc<Mutex<Vec<AckToken>>>,
+}
+
+async fn setup(topic: &str) -> QuicFixture {
+    let (shutdown, quic_addr) = start_quic_broker().await;
+    let url = format!("quic://{quic_addr}");
+
+    let sub_opts = deferred_options(&cid("quic-def-sub"), 1);
+    let subscriber = MqttClient::with_options(sub_opts.clone());
+    subscriber.set_insecure_tls(true).await;
+    subscriber
+        .set_quic_stream_strategy(StreamStrategy::DataPerTopic)
+        .await;
+    subscriber
+        .connect_with_options(&url, sub_opts)
+        .await
+        .expect("subscriber connects over QUIC");
+
+    let received = Arc::new(AtomicU32::new(0));
+    let tokens = Arc::new(Mutex::new(Vec::new()));
+    let rc = Arc::clone(&received);
+    let tc = Arc::clone(&tokens);
+    subscriber
+        .subscribe_with_ack(topic, qos2_sub(), move |_p, token| {
+            rc.fetch_add(1, Ordering::SeqCst);
+            tc.lock().unwrap().push(token);
+        })
+        .await
+        .expect("subscribe_with_ack over QUIC");
+
+    let publisher = MqttClient::new(cid("quic-def-pub"));
+    publisher.set_insecure_tls(true).await;
+    publisher
+        .set_quic_stream_strategy(StreamStrategy::DataPerTopic)
+        .await;
+    publisher.connect(&url).await.expect("publisher connects");
+
+    QuicFixture {
+        shutdown,
+        subscriber,
+        publisher,
+        received,
+        tokens,
+    }
+}
+
+async fn publish_two(fixture: &QuicFixture, topic: &str) {
+    for i in 0..2 {
+        fixture
+            .publisher
+            .publish_with_options(topic, format!("m{i}").into_bytes(), qos2_pub())
+            .await
+            .expect("publish over QUIC");
+    }
+}
+
+#[tokio::test]
+async fn deferred_qos2_over_quic_delivers_backpressures_and_acks() {
+    let topic = "jobs/a";
+    let fixture = setup(topic).await;
+    publish_two(&fixture, topic).await;
+
+    assert!(
+        wait_until(|| fixture.received.load(Ordering::SeqCst) == 1).await,
+        "first QoS2 message delivered over QUIC"
+    );
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        fixture.received.load(Ordering::SeqCst),
+        1,
+        "second withheld while the deferred PUBREC keeps the window full"
+    );
+
+    fixture.tokens.lock().unwrap().pop().unwrap().ack();
+
+    assert!(
+        wait_until(|| fixture.received.load(Ordering::SeqCst) == 2).await,
+        "acking over QUIC completes the handshake, frees the slot, and the second message flows"
+    );
+
+    fixture.publisher.disconnect().await.ok();
+    fixture.subscriber.disconnect().await.ok();
+    fixture.shutdown.shutdown();
+}
+
+#[tokio::test]
+async fn deferred_qos2_over_quic_reject_frees_the_slot() {
+    let topic = "jobs/b";
+    let fixture = setup(topic).await;
+    publish_two(&fixture, topic).await;
+
+    assert!(
+        wait_until(|| fixture.received.load(Ordering::SeqCst) == 1).await,
+        "first QoS2 message delivered over QUIC"
+    );
+
+    fixture
+        .tokens
+        .lock()
+        .unwrap()
+        .pop()
+        .unwrap()
+        .reject(ReasonCode::UnspecifiedError);
+
+    assert!(
+        wait_until(|| fixture.received.load(Ordering::SeqCst) == 2).await,
+        "rejecting over QUIC is terminal, frees the slot, and the next message flows"
+    );
+
+    fixture.publisher.disconnect().await.ok();
+    fixture.subscriber.disconnect().await.ok();
+    fixture.shutdown.shutdown();
+}

--- a/crates/mqtt5/tests/deferred_ack_soak.rs
+++ b/crates/mqtt5/tests/deferred_ack_soak.rs
@@ -1,0 +1,167 @@
+#![cfg(feature = "broker")]
+#![allow(clippy::large_futures)]
+
+//! Sustained backpressure + liveness soak for deferred acknowledgement.
+//!
+//! Fills the Receive-Maximum window with held `AckToken`s under a burst load and asserts the four
+//! things the feature promises under saturation: the broker throttles to exactly `receive_maximum`
+//! outstanding (obligation 3), the resident token count stays bounded (no unbounded buffering,
+//! §3.3), the control plane is never blocked while saturated (obligation 4), and once the tokens
+//! drain every message is delivered exactly once with no loss.
+
+mod common;
+
+use common::TestBroker;
+use mqtt5::time::Duration;
+use mqtt5::{AckToken, ConnectOptions, MqttClient, PublishOptions, QoS, SubscribeOptions};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use ulid::Ulid;
+
+const RECEIVE_MAXIMUM: u16 = 4;
+const BURST: u32 = 40;
+
+fn client_id(name: &str) -> String {
+    format!("test-{name}-{}", Ulid::new())
+}
+
+fn deferred_options(id: &str) -> ConnectOptions {
+    ConnectOptions::new(id)
+        .with_deferred_ack(true)
+        .with_clean_start(false)
+        .with_session_expiry_interval(3600)
+        .with_receive_maximum(RECEIVE_MAXIMUM)
+        .with_keep_alive(Duration::from_secs(5))
+}
+
+fn qos2_sub() -> SubscribeOptions {
+    SubscribeOptions {
+        qos: QoS::ExactlyOnce,
+        ..Default::default()
+    }
+}
+
+fn qos2_pub() -> PublishOptions {
+    PublishOptions {
+        qos: QoS::ExactlyOnce,
+        ..Default::default()
+    }
+}
+
+async fn wait_until(cond: impl Fn() -> bool) -> bool {
+    for _ in 0..400 {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    cond()
+}
+
+#[tokio::test]
+async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss() {
+    let broker = TestBroker::start().await;
+    let subscriber = MqttClient::with_options(deferred_options(&client_id("soak-sub")));
+    subscriber.connect(broker.address()).await.unwrap();
+
+    let received = Arc::new(AtomicU32::new(0));
+    let held: Arc<Mutex<Vec<AckToken>>> = Arc::new(Mutex::new(Vec::new()));
+    let peak_held = Arc::new(AtomicU32::new(0));
+
+    let rc = Arc::clone(&received);
+    let hc = Arc::clone(&held);
+    let pk = Arc::clone(&peak_held);
+    subscriber
+        .subscribe_with_ack("soak/#", qos2_sub(), move |_p, token| {
+            rc.fetch_add(1, Ordering::SeqCst);
+            let mut guard = hc.lock().unwrap();
+            guard.push(token);
+            let len = u32::try_from(guard.len()).unwrap_or(u32::MAX);
+            pk.fetch_max(len, Ordering::SeqCst);
+        })
+        .await
+        .unwrap();
+
+    // Burst well beyond the window; every delivered token is held (never acked yet).
+    let publisher = MqttClient::new(client_id("soak-pub"));
+    publisher.connect(broker.address()).await.unwrap();
+    for i in 0..BURST {
+        publisher
+            .publish_with_options("soak/x", format!("m{i}").into_bytes(), qos2_pub())
+            .await
+            .unwrap();
+    }
+
+    // The window fills to exactly receive_maximum and stops.
+    assert!(
+        wait_until(|| received.load(Ordering::SeqCst) == u32::from(RECEIVE_MAXIMUM)).await,
+        "broker fills the window to receive_maximum held tokens"
+    );
+
+    // Sustained hold: it must stay pinned at the window and never grow (bounded memory).
+    for _ in 0..12 {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            received.load(Ordering::SeqCst),
+            u32::from(RECEIVE_MAXIMUM),
+            "no delivery beyond the window while every token is held"
+        );
+        assert!(
+            held.lock().unwrap().len() <= RECEIVE_MAXIMUM as usize,
+            "resident held-token count never exceeds the window (no unbounded buffering)"
+        );
+    }
+
+    // Control plane is not blocked while saturated: a fresh client can still connect and subscribe,
+    // and the saturated subscriber stays connected.
+    let probe = MqttClient::with_options(deferred_options(&client_id("soak-probe")));
+    probe.connect(broker.address()).await.unwrap();
+    probe
+        .subscribe_with_ack("other/#", qos2_sub(), |_p, _t| {})
+        .await
+        .expect("a SUBSCRIBE must still succeed while another client's window is saturated");
+    assert!(
+        subscriber.is_connected().await,
+        "the saturated subscriber stays connected (reader not blocked)"
+    );
+
+    // Drain: keep acking held tokens; each freed slot lets the next message flow, 1-for-1.
+    let drainer_received = Arc::clone(&received);
+    let drainer_held = Arc::clone(&held);
+    let drain = tokio::spawn(async move {
+        while drainer_received.load(Ordering::SeqCst) < BURST {
+            let token = drainer_held.lock().unwrap().pop();
+            if let Some(token) = token {
+                token.ack();
+            }
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        // Drain any tokens delivered after the final increment.
+        while let Some(token) = drainer_held.lock().unwrap().pop() {
+            token.ack();
+        }
+    });
+
+    assert!(
+        wait_until(|| received.load(Ordering::SeqCst) == BURST).await,
+        "every message is eventually delivered once the tokens drain (no loss)"
+    );
+    drain.await.unwrap();
+
+    // No duplicate storm after the full drain.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        received.load(Ordering::SeqCst),
+        BURST,
+        "exactly the burst count is delivered — no loss, no duplicates"
+    );
+    assert_eq!(
+        peak_held.load(Ordering::SeqCst),
+        u32::from(RECEIVE_MAXIMUM),
+        "the peak resident held-token count equals the window — backpressure stayed bounded throughout"
+    );
+
+    probe.disconnect().await.ok();
+    publisher.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+}

--- a/crates/mqtt5/tests/deferred_ack_soak.rs
+++ b/crates/mqtt5/tests/deferred_ack_soak.rs
@@ -82,7 +82,6 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
         .await
         .unwrap();
 
-    // Burst well beyond the window; every delivered token is held (never acked yet).
     let publisher = MqttClient::new(client_id("soak-pub"));
     publisher.connect(broker.address()).await.unwrap();
     for i in 0..BURST {
@@ -92,13 +91,11 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
             .unwrap();
     }
 
-    // The window fills to exactly receive_maximum and stops.
     assert!(
         wait_until(|| received.load(Ordering::SeqCst) == u32::from(RECEIVE_MAXIMUM)).await,
         "broker fills the window to receive_maximum held tokens"
     );
 
-    // Sustained hold: it must stay pinned at the window and never grow (bounded memory).
     for _ in 0..12 {
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(
@@ -112,8 +109,6 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
         );
     }
 
-    // Control plane is not blocked while saturated: a fresh client can still connect and subscribe,
-    // and the saturated subscriber stays connected.
     let probe = MqttClient::with_options(deferred_options(&client_id("soak-probe")));
     probe.connect(broker.address()).await.unwrap();
     probe
@@ -125,7 +120,6 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
         "the saturated subscriber stays connected (reader not blocked)"
     );
 
-    // Drain: keep acking held tokens; each freed slot lets the next message flow, 1-for-1.
     let drainer_received = Arc::clone(&received);
     let drainer_held = Arc::clone(&held);
     let drain = tokio::spawn(async move {
@@ -136,7 +130,6 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
             }
             tokio::time::sleep(Duration::from_millis(2)).await;
         }
-        // Drain any tokens delivered after the final increment.
         while let Some(token) = drainer_held.lock().unwrap().pop() {
             token.ack();
         }
@@ -148,7 +141,6 @@ async fn deferred_ack_backpressure_soak_holds_bounded_then_drains_without_loss()
     );
     drain.await.unwrap();
 
-    // No duplicate storm after the full drain.
     tokio::time::sleep(Duration::from_millis(300)).await;
     assert_eq!(
         received.load(Ordering::SeqCst),


### PR DESCRIPTION
Full end-to-end validation of the deferred-acknowledgement feature (`AckToken` + `subscribe_with_ack` + connection-wide `with_deferred_ack`, shipped in the unreleased mqtt5 0.38.0) as the release gate for 0.38.0. **Test-only: zero production code changes** — the feature was already correct; this adds the coverage to prove it against real brokers.

## What was validated (all empirically green)

Real brokers exercised: mqtt5 in-process (all transports), the **separate-process `mqttv5` broker binary**, and **Eclipse Mosquitto 2.1.2** (third-party interop).

**Functional matrix** (`crates/mqtt5/tests/deferred_ack_matrix.rs`, 9 tests over TCP/TLS/WebSocket):
- **QoS1 deferred ack** — previously zero coverage at any level; PUBACK withheld → backpressure → ack frees the slot.
- QoS2 deferred backpressure, `reject()` frees the slot, dropped-token auto-acks (no wedge, obligation 7), control-plane liveness under a saturated window (obligation 4), and the **crash regime** (fresh client resumes the session → re-delivery, no wedge).

**QUIC** (`crates/mqtt5/tests/deferred_ack_quic.rs`, 2 tests): deferred QoS2 `ack()` + `reject()` over the `DataPerTopic` data-flow strategy. A code-reading hunch had suggested deferred acks over QUIC were broken (routed on the control stream, not the data flow); this was **empirically disproven** — the broker correlates the PUBREC by packet id regardless of stream, so it works. No gating change.

**Real-broker conformance** (`crates/mqtt5-conformance/src/conformance_tests/deferred_ack.rs`, 2 tests): a raw subscriber defers its QoS2 acknowledgement and asserts the broker keeps the Receive-Maximum slot occupied across the *entire* PUBREC/PUBREL/PUBCOMP handshake (the guarantee deferred ack depends on), plus control-plane liveness at zero quota. Broker-agnostic — passes against the in-process fixture, the external `mqttv5` process, and Mosquitto.

**Interop CI** (`.github/workflows/conformance.yml`): a `mosquitto-interop` job runs the deferred-ack conformance subset against `eclipse-mosquitto:2` in Docker.

**Backpressure/liveness soak** (`crates/mqtt5/tests/deferred_ack_soak.rs`): fills the window under a burst, holds bounded, verifies the control plane stays live, then drains fully with no loss and no duplicates.

## Verification

All tests stable across repeated runs; clippy pedantic clean; full in-process conformance suite 183 pass; the `ci-verify` pre-commit gate passed. The Mosquitto CI job's Docker path is validated by reasoning (Linux bind-mounts) plus a local run against a homebrew Mosquitto — its first real Docker run happens when this workflow executes.
