### PR TITLE
add cli message-properties and $SYS control flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqttv5-cli 0.28.5] - 2026-07-24
+
+### Added
+
+- **`mqttv5 sub --show-properties` (`-s`)** prints the MQTT v5 properties of each received message alongside its payload, not just the payload. When set, the subscriber renders the delivered `QoS`, the retain flag, and every present property — payload format indicator, message expiry interval, content type, response topic, correlation data (hex), subscription identifiers, and user properties — one per line, followed by the payload. Without the flag the output is unchanged (payload only, or `topic: payload` under `--verbose`).
+- **`mqttv5 broker --no-sys-topics` and `--sys-interval <DUR>`** expose the broker's `$SYS` statistics publishing on the command line. `--no-sys-topics` disables `$SYS` publishing (enabled by default); `--sys-interval` sets the publish interval and accepts a bare number of seconds or a duration such as `10s` or `1m` (default `10`). Both map to the existing `BrokerConfig` fields, so an interval of zero while `$SYS` is enabled is still rejected at config validation. Addresses issue #115.
+
 ## [mqtt5 0.38.0] - 2026-07-20
 
 ### Added

--- a/crates/mqtt5/tests/cli_functionality.rs
+++ b/crates/mqtt5/tests/cli_functionality.rs
@@ -267,3 +267,90 @@ async fn test_cli_flag_formats() {
 
     println!("✅ CLI ergonomics verified - all flag formats work");
 }
+
+/// Test `sub --show-properties` renders MQTT v5 message properties
+#[tokio::test]
+async fn test_cli_sub_show_properties() {
+    let broker = TestBroker::start().await;
+    let broker_url = broker.address();
+
+    let sub_handle = run_cli_sub_async(
+        broker_url,
+        "test/props",
+        1,
+        &["--show-properties", "--qos", "1"],
+    );
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let pub_result = run_cli_command(&[
+        "pub",
+        "--url",
+        broker_url,
+        "--topic",
+        "test/props",
+        "--message",
+        "payload-body",
+        "--qos",
+        "1",
+        "--message-expiry-interval",
+        "3600",
+        "--response-topic",
+        "reply/here",
+        "--non-interactive",
+    ])
+    .await;
+    assert!(pub_result.success, "Publish with properties should succeed");
+
+    let sub_result = tokio::time::timeout(Duration::from_secs(3), sub_handle)
+        .await
+        .expect("Timeout")
+        .expect("Subscribe failed");
+
+    assert!(
+        sub_result.stdout_contains("qos: 1"),
+        "Should show QoS. Stdout: {}",
+        sub_result.stdout
+    );
+    assert!(
+        sub_result.stdout_contains("message-expiry-interval: 3600"),
+        "Should show message expiry. Stdout: {}",
+        sub_result.stdout
+    );
+    assert!(
+        sub_result.stdout_contains("response-topic: reply/here"),
+        "Should show response topic. Stdout: {}",
+        sub_result.stdout
+    );
+    assert!(
+        sub_result.stdout_contains("payload: payload-body"),
+        "Should show payload. Stdout: {}",
+        sub_result.stdout
+    );
+
+    println!("✅ CLI sub --show-properties verified");
+}
+
+/// Test broker $SYS control flags are exposed on the command line
+#[tokio::test]
+async fn test_cli_broker_sys_flags() {
+    let help_result = run_cli_command(&["broker", "--help"]).await;
+    assert!(help_result.success, "Broker help should succeed");
+    assert!(
+        help_result.stdout_contains("--no-sys-topics"),
+        "Should expose --no-sys-topics"
+    );
+    assert!(
+        help_result.stdout_contains("--sys-interval"),
+        "Should expose --sys-interval"
+    );
+
+    let sub_help = run_cli_command(&["sub", "--help"]).await;
+    assert!(sub_help.success, "Sub help should succeed");
+    assert!(
+        sub_help.stdout_contains("--show-properties"),
+        "Should expose --show-properties"
+    );
+
+    println!("✅ CLI broker $SYS and sub property flags verified");
+}

--- a/crates/mqttv5-cli/CLI_USAGE.md
+++ b/crates/mqttv5-cli/CLI_USAGE.md
@@ -131,6 +131,8 @@ mqttv5 broker generate-config [--output FILE] [--format json|toml]
 | `--response-information <STR>` | Response information sent to clients that request it | None |
 | `--no-retain` | Disable retained messages | `false` |
 | `--no-wildcards` | Disable wildcard subscriptions | `false` |
+| `--no-sys-topics` | Disable `$SYS` topic publishing (broker statistics) | `false` |
+| `--sys-interval <DUR>` | `$SYS` topic publish interval (e.g., `10`, `10s`, `1m`) | `10` |
 | `--non-interactive` | Skip interactive prompts | `false` |
 
 ##### Broker JWT Auth Flags
@@ -256,6 +258,16 @@ mqttv5 broker \
   --quic-host 0.0.0.0:14567 \
   --tls-cert server.pem \
   --tls-key server-key.pem
+```
+
+Broker with adjusted `$SYS` statistics publishing:
+
+```bash
+# Publish $SYS topics every 30 seconds instead of the default 10
+mqttv5 broker --allow-anonymous --sys-interval 30s
+
+# Disable $SYS statistics entirely
+mqttv5 broker --allow-anonymous --no-sys-topics
 ```
 
 Broker with OpenTelemetry tracing:
@@ -556,6 +568,7 @@ Subscribe to one or more MQTT topics and print received messages. The subscriber
 | `--port, -p <PORT>` | Broker port | `1883` |
 | `--qos, -q <0\|1\|2>` | Subscription QoS level | `0` |
 | `--verbose, -v` | Include topic names in output | `false` |
+| `--show-properties, -s` | Print MQTT v5 message properties (QoS, retain, expiry, content type, response topic, user properties, subscription IDs) | `false` |
 | `--count, -n <N>` | Exit after receiving N messages | `0` (infinite) |
 | `--no-local` | Don't receive own published messages | `false` |
 | `--retain-handling <0\|1\|2>` | Retain handling: 0=send, 1=send if new, 2=don't send | `0` |
@@ -611,12 +624,6 @@ Basic subscribe:
 mqttv5 sub -t test/topic
 ```
 
-Multiple topics:
-
-```bash
-mqttv5 sub -t sensors/# -t status/#
-```
-
 Subscribe with QoS 1:
 
 ```bash
@@ -627,6 +634,12 @@ Verbose output:
 
 ```bash
 mqttv5 sub -t test/# -v
+```
+
+Show MQTT v5 message properties:
+
+```bash
+mqttv5 sub -t test/# --show-properties
 ```
 
 No-local subscription:

--- a/crates/mqttv5-cli/CLI_USAGE.md
+++ b/crates/mqttv5-cli/CLI_USAGE.md
@@ -660,7 +660,7 @@ mqttv5 sub -t sensors/# \
 Subscribe over QUIC with per-subscription streams:
 
 ```bash
-mqttv5 sub -t sensors/# -t commands/# \
+mqttv5 sub -t sensors/# \
   --url quic://broker.example.com:14567 \
   --ca-cert ca.pem \
   --quic-stream-strategy per-subscription \

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.4"
+version = "0.28.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqttv5-cli/README.md
+++ b/crates/mqttv5-cli/README.md
@@ -45,6 +45,9 @@ mqttv5 sub --topic "sensors/+"
 # Verbose mode shows topic names
 mqttv5 sub -t "sensors/#" --verbose
 
+# Show MQTT v5 message properties (QoS, expiry, content type, user properties, ...)
+mqttv5 sub -t "sensors/#" --show-properties
+
 # Subscribe for specific message count
 mqttv5 sub -t "test/topic" --count 5
 
@@ -93,6 +96,10 @@ mqttv5 broker --auth-password-file passwd.txt --acl-file acl.txt
 
 # In-memory storage (no persistence)
 mqttv5 broker --allow-anonymous --storage-backend memory
+
+# Adjust $SYS statistics publishing (default: enabled, every 10s)
+mqttv5 broker --allow-anonymous --sys-interval 30s
+mqttv5 broker --allow-anonymous --no-sys-topics
 ```
 
 ### Managing Passwords

--- a/crates/mqttv5-cli/src/commands/broker_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/broker_cmd.rs
@@ -231,6 +231,14 @@ pub struct RunArgs {
     #[arg(long, env = "MQTT5_NO_WILDCARDS")]
     pub no_wildcards: bool,
 
+    /// Disable $SYS topic publishing (broker statistics)
+    #[arg(long, env = "MQTT5_NO_SYS_TOPICS")]
+    pub no_sys_topics: bool,
+
+    /// $SYS topic publish interval (e.g., 10, 10s, 1m)
+    #[arg(long, default_value = "10", value_parser = parse_duration_secs, env = "MQTT5_SYS_INTERVAL")]
+    pub sys_interval: u64,
+
     /// Skip prompts and use defaults
     #[arg(long, env = "MQTT5_NON_INTERACTIVE")]
     pub non_interactive: bool,
@@ -1030,6 +1038,8 @@ async fn create_interactive_config(cmd: &mut RunArgs) -> Result<BrokerConfig> {
     config.maximum_qos = cmd.max_qos;
     config.retain_available = !cmd.no_retain;
     config.wildcard_subscription_available = !cmd.no_wildcards;
+    config.sys_topics_enabled = !cmd.no_sys_topics;
+    config.sys_topics_interval = std::time::Duration::from_secs(cmd.sys_interval);
 
     if let Some(keep_alive) = cmd.keep_alive {
         config.server_keep_alive = Some(std::time::Duration::from_secs(keep_alive));

--- a/crates/mqttv5-cli/src/commands/sub_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/sub_cmd.rs
@@ -436,15 +436,6 @@ fn configure_codec(options: &mut ConnectOptions, cmd: &SubCommand) -> Result<()>
     Ok(())
 }
 
-fn hex_encode(data: &[u8]) -> String {
-    use std::fmt::Write;
-    data.iter()
-        .fold(String::with_capacity(data.len() * 2), |mut acc, byte| {
-            let _ = write!(acc, "{byte:02x}");
-            acc
-        })
-}
-
 fn print_message(message: &mqtt5::Message, verbose: bool, show_properties: bool) {
     let payload = String::from_utf8_lossy(&message.payload);
 
@@ -477,7 +468,7 @@ fn print_message(message: &mqtt5::Message, verbose: bool, show_properties: bool)
         println!("  response-topic: {response_topic}");
     }
     if let Some(ref correlation_data) = props.correlation_data {
-        println!("  correlation-data: {}", hex_encode(correlation_data));
+        println!("  correlation-data: {}", hex::encode(correlation_data));
     }
     for id in &props.subscription_identifiers {
         println!("  subscription-identifier: {id}");

--- a/crates/mqttv5-cli/src/commands/sub_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/sub_cmd.rs
@@ -64,6 +64,10 @@ pub struct SubCommand {
     #[arg(long, short)]
     pub verbose: bool,
 
+    /// Print message properties (`QoS`, retain, expiry, content type, response topic, user properties, subscription IDs)
+    #[arg(long = "show-properties", short = 's', env = "MQTT5_SHOW_PROPERTIES")]
+    pub show_properties: bool,
+
     /// Skip prompts and use defaults/fail if required args missing
     #[arg(long, env = "MQTT5_NON_INTERACTIVE")]
     pub non_interactive: bool,
@@ -432,6 +436,58 @@ fn configure_codec(options: &mut ConnectOptions, cmd: &SubCommand) -> Result<()>
     Ok(())
 }
 
+fn hex_encode(data: &[u8]) -> String {
+    use std::fmt::Write;
+    data.iter()
+        .fold(String::with_capacity(data.len() * 2), |mut acc, byte| {
+            let _ = write!(acc, "{byte:02x}");
+            acc
+        })
+}
+
+fn print_message(message: &mqtt5::Message, verbose: bool, show_properties: bool) {
+    let payload = String::from_utf8_lossy(&message.payload);
+
+    if !show_properties {
+        if verbose {
+            println!("{}: {payload}", message.topic);
+        } else {
+            println!("{payload}");
+        }
+        return;
+    }
+
+    let props = &message.properties;
+    println!("topic: {}", message.topic);
+    println!("  qos: {}", message.qos as u8);
+    println!("  retain: {}", message.retain);
+    if let Some(format) = props.payload_format_indicator {
+        println!(
+            "  payload-format: {}",
+            if format { "utf-8" } else { "bytes" }
+        );
+    }
+    if let Some(expiry) = props.message_expiry_interval {
+        println!("  message-expiry-interval: {expiry}");
+    }
+    if let Some(ref content_type) = props.content_type {
+        println!("  content-type: {content_type}");
+    }
+    if let Some(ref response_topic) = props.response_topic {
+        println!("  response-topic: {response_topic}");
+    }
+    if let Some(ref correlation_data) = props.correlation_data {
+        println!("  correlation-data: {}", hex_encode(correlation_data));
+    }
+    for id in &props.subscription_identifiers {
+        println!("  subscription-identifier: {id}");
+    }
+    for (key, value) in &props.user_properties {
+        println!("  user-property: {key}={value}");
+    }
+    println!("  payload: {payload}");
+}
+
 async fn subscribe_and_print(
     client: &MqttClient,
     topic: &str,
@@ -440,6 +496,7 @@ async fn subscribe_and_print(
 ) -> Result<Arc<Notify>> {
     let target_count = cmd.count;
     let verbose = cmd.verbose;
+    let show_properties = cmd.show_properties;
 
     info!("Subscribing to '{}' (QoS {})...", topic, qos as u8);
 
@@ -467,15 +524,7 @@ async fn subscribe_and_print(
         .subscribe_with_options(topic, subscribe_options.clone(), move |message| {
             let count = message_count_clone.fetch_add(1, Ordering::Relaxed) + 1;
 
-            if verbose {
-                println!(
-                    "{}: {}",
-                    message.topic,
-                    String::from_utf8_lossy(&message.payload)
-                );
-            } else {
-                println!("{}", String::from_utf8_lossy(&message.payload));
-            }
+            print_message(&message, verbose, show_properties);
 
             if target_count > 0 && count >= target_count {
                 println!("✓ Received {target_count} messages, exiting");


### PR DESCRIPTION
Adds the three CLI options requested in #115.

## `mqttv5 sub --show-properties` (`-s`)

Prints the MQTT v5 properties of each received message alongside its payload. When set, the subscriber renders the delivered QoS, the retain flag, and every present property (payload format indicator, message expiry interval, content type, response topic, correlation data as hex, subscription identifiers, and user properties), one per line, followed by the payload. Without the flag the output is unchanged (payload only, or `topic: payload` under `--verbose`).

```
topic: sensors/temp
  qos: 1
  message-expiry-interval: 3600
  content-type: application/json
  user-property: x-mqtt-client-id=sensor-01
  payload: 21.4
```

## `mqttv5 broker --no-sys-topics` and `--sys-interval <DUR>`

Expose the broker's `$SYS` statistics publishing on the command line. `--no-sys-topics` disables `$SYS` publishing (enabled by default); `--sys-interval` sets the publish interval and accepts a bare number of seconds or a duration such as `10s` or `1m` (default `10`). Both map to the existing `BrokerConfig` fields, so an interval of zero while `$SYS` is enabled is still rejected at config validation.

## Notes

- `mqttv5-cli` bumped 0.28.4 -> 0.28.5 (additive), CHANGELOG updated
- Docs updated (`README.md`, `CLI_USAGE.md`); also removed a stale `sub -t a -t b` "multiple topics" example that the command rejects
- Tests added to `cli_functionality.rs`: `test_cli_sub_show_properties` (real pub -> sub asserting rendered properties) and `test_cli_broker_sys_flags` (help exposes the flags)

Closes #115
