### PR TITLE
strip publisher topic alias before delivery to subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.38.2] - 2026-08-04
+
+### Fixed
+
+- **The broker no longer forwards a publisher's Topic Alias to subscribers.** When a PUBLISH carried a Topic Alias, the broker resolved it to a topic name but left the Topic Alias property on the packet, so live delivery carried it through to subscribers — including subscribers that advertised no Topic Alias Maximum, whose value is therefore zero. This violates `[MQTT-3.1.2-26]`, `[MQTT-3.1.2-27]` and `[MQTT-3.3.2-11]`: a Topic Alias mapping is scoped to a single Network Connection and to the server-to-client direction, so a publisher's alias has no meaning on a subscriber's connection and must not be sent to a client that did not offer to receive one. A subscriber advertising Topic Alias Maximum 2 could receive a delivered PUBLISH carrying Topic Alias 9. Retained, queued and inflight deliveries were unaffected because they rebuild the packet from an explicit field list; only live delivery leaked. `resolve_topic_alias` now strips the Topic Alias property once the topic name is resolved. Reported in issue #130.
+
+## [mqtt5-protocol 0.14.3] - 2026-08-04
+
+### Added
+
+- **`Properties::remove_topic_alias`** removes the Topic Alias property from a property set. The broker uses it to strip a publisher's inbound Topic Alias after resolving it to a topic name, so the alias is not carried into the message routed to subscribers (see mqtt5 0.38.2).
+
 ## [mqttv5-cli 0.28.5] - 2026-07-24
 
 ### Added

--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,24 @@
 
 ## Diary Entries
 
+### Fix #130 — publisher Topic Alias stripped before delivery (2026-08-04)
+
+`resolve_topic_alias` (`broker/client_handler/publish.rs`) resolved an inbound Topic Alias to a topic
+name but never removed the `0x23` property, so it propagated to subscribers — including subscribers
+that advertised no Topic Alias Maximum. Violates `[MQTT-3.1.2-26]`, `[MQTT-3.1.2-27]` and
+`[MQTT-3.3.2-11]`.
+
+Fix: added `Properties::remove_topic_alias` (the `mqtt5-protocol` HashMap is `pub(crate)`, so the
+broker needs a public accessor) and call it once the topic name is resolved.
+
+Manifest: `MQTT-3.1.2-26`, `MQTT-3.1.2-27`, `MQTT-3.3.2-11` moved Untested→Tested. The existing
+`topic_alias_stripped_before_delivery` test only checked the delivered topic *name* (which was always
+correct — the leak was the surviving property), and was mis-tagged `[MQTT-3.3.2-8]` (the audit
+retargeted that ID to the alias-value-0 rule). Retargeted it to the three real IDs and strengthened it
+to parse the delivered PUBLISH with `ParsedPublish` and assert `topic_alias.is_none()`. Verified it
+fails without the fix (`found Some(2)`) and passes with it. Removed the now-reconciled
+`topic_alias_stripped_before_delivery MQTT-3.3.2-8` line from `known-citation-drift.txt`.
+
 ### Bulk heuristic corrections REVERTED after adversarial review (2026-08-03)
 
 A four-reviewer adversarial quorum audited the same day's rework. It found that the bulk corrections,

--- a/crates/mqtt5-conformance/conformance.toml
+++ b/crates/mqtt5-conformance/conformance.toml
@@ -431,18 +431,18 @@ id = "MQTT-3.1.2-26"
 level = "MustNot"
 applies_to = "Both"
 text = "The Server MUST NOT send a Topic Alias in a PUBLISH packet to the Client greater than Topic Alias Maximum"
-status = "Untested"
-test_names = []
-note = "Re-reviewed: the previous NotApplicable rested on a FALSE premise. resolve_topic_alias (publish.rs:139) never strips the Topic Alias property, so it propagates to subscribers. Reproduced"
+status = "Tested"
+test_names = ["topic_alias_stripped_before_delivery"]
+note = "Fixed (#130): resolve_topic_alias now strips the inbound Topic Alias once the topic name is resolved, so a publisher's alias no longer propagates to subscribers"
 
 [[sections."3.1".statements]]
 id = "MQTT-3.1.2-27"
 level = "MustNot"
 applies_to = "Both"
 text = "If Topic Alias Maximum is absent or zero, the Server MUST NOT send any Topic Aliases to the Client"
-status = "Untested"
-test_names = []
-note = "Re-reviewed: the previous NotApplicable rested on a FALSE premise. resolve_topic_alias (publish.rs:139) never strips the Topic Alias property, so it propagates to subscribers. Reproduced"
+status = "Tested"
+test_names = ["topic_alias_stripped_before_delivery"]
+note = "Fixed (#130): a subscriber advertising no Topic Alias Maximum now receives no Topic Alias property, since resolve_topic_alias strips the inbound alias before delivery"
 
 [[sections."3.1".statements]]
 id = "MQTT-3.1.2-28"
@@ -957,9 +957,9 @@ id = "MQTT-3.3.2-11"
 level = "Must"
 applies_to = "Server"
 text = "A Server MUST NOT send a PUBLISH packet with a Topic Alias greater than the Topic Alias Maximum value sent by the Client in the CONNECT packet."
-status = "Untested"
-test_names = []
-note = "Corrected: previously carried connection-scoped-mapping text. REPRODUCED AS VIOLATED - a subscriber advertising Topic Alias Maximum 2 received a delivered PUBLISH carrying Topic Alias 9, because resolve_topic_alias never strips the publisher's alias. Its former tests exercise connection-scoped mapping, a different requirement"
+status = "Tested"
+test_names = ["topic_alias_stripped_before_delivery"]
+note = "Fixed (#130): resolve_topic_alias strips the publisher's inbound alias before delivery, so no Topic Alias reaches a subscriber. topic_alias_not_shared_across_connections and topic_alias_cleared_on_reconnect additionally exercise connection-scoped mapping"
 
 [[sections."3.3".statements]]
 id = "MQTT-3.3.2-12"

--- a/crates/mqtt5-conformance/known-citation-drift.txt
+++ b/crates/mqtt5-conformance/known-citation-drift.txt
@@ -34,7 +34,6 @@ subscribe_replaces_existing MQTT-3.8.4-3
 tcp_drop_publishes_will MQTT-3.1.4-5
 topic_alias_cleared_on_reconnect MQTT-3.3.2-11
 topic_alias_not_shared_across_connections MQTT-3.3.2-11
-topic_alias_stripped_before_delivery MQTT-3.3.2-8
 unsuback_no_subscription_existed MQTT-3.11.3-2
 unsuback_success_for_existing MQTT-3.11.3-2
 unsubscribe_idempotent MQTT-3.11.3-2

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_publish_alias.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_publish_alias.rs
@@ -2,6 +2,7 @@
 
 use crate::conformance_test;
 use crate::harness::unique_client_id;
+use crate::packet_parser::ParsedPublish;
 use crate::raw_client::{RawMqttClient, RawPacketBuilder};
 use crate::sut::SutHandle;
 use std::time::Duration;
@@ -211,9 +212,13 @@ async fn topic_alias_cleared_on_reconnect(sut: SutHandle) {
     );
 }
 
-/// `[MQTT-3.3.2-8]` Topic Alias is stripped before delivery to subscribers.
+/// `[MQTT-3.1.2-26]` `[MQTT-3.1.2-27]` `[MQTT-3.3.2-11]` A publisher's Topic
+/// Alias is an inbound, per-connection encoding detail. Once resolved to a topic
+/// name it must be stripped: the subscriber here advertises no Topic Alias
+/// Maximum, so its value is zero and the delivered PUBLISH must carry no Topic
+/// Alias property at all.
 #[conformance_test(
-    ids = ["MQTT-3.3.2-8"],
+    ids = ["MQTT-3.1.2-26", "MQTT-3.1.2-27", "MQTT-3.3.2-11"],
     requires = ["transport.tcp"],
 )]
 async fn topic_alias_stripped_before_delivery(sut: SutHandle) {
@@ -241,16 +246,20 @@ async fn topic_alias_stripped_before_delivery(sut: SutHandle) {
         .await
         .unwrap();
 
-    let msg = sub.expect_publish(TIMEOUT).await;
-    assert!(msg.is_some(), "Subscriber must receive the message");
-    let (_, recv_topic, _) = msg.unwrap();
-    assert!(
-        !recv_topic.is_empty(),
-        "Subscriber must receive non-empty topic name, not alias reference"
-    );
+    let data = sub
+        .read_packet_bytes(TIMEOUT)
+        .await
+        .expect("subscriber must receive the forwarded PUBLISH");
+    let parsed = ParsedPublish::parse(&data).expect("delivered packet must be a PUBLISH");
     assert_eq!(
-        recv_topic, topic,
-        "Subscriber must receive the full topic name"
+        parsed.topic, topic,
+        "Subscriber must receive the full topic name, not an alias reference"
+    );
+    assert!(
+        parsed.properties.topic_alias.is_none(),
+        "[MQTT-3.1.2-27] Subscriber advertised no Topic Alias Maximum, so the delivered PUBLISH \
+         must not carry a Topic Alias property (found {:?})",
+        parsed.properties.topic_alias
     );
 }
 

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.14.2"
+version = "0.14.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
+++ b/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
@@ -52,6 +52,10 @@ impl Properties {
             })
     }
 
+    pub fn remove_topic_alias(&mut self) {
+        self.properties.remove(&PropertyId::TopicAlias);
+    }
+
     pub fn set_response_topic(&mut self, topic: String) {
         self.properties
             .entry(PropertyId::ResponseTopic)

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.38.1"
+version = "0.38.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/client_handler/publish.rs
+++ b/crates/mqtt5/src/broker/client_handler/publish.rs
@@ -156,6 +156,7 @@ impl ClientHandler {
             } else {
                 self.topic_aliases.insert(alias, publish.topic_name.clone());
             }
+            publish.properties.remove_topic_alias();
         } else if publish.topic_name.is_empty() {
             return Err(MqttError::ProtocolError(
                 "Empty topic name without topic alias".to_string(),


### PR DESCRIPTION
Fixes #130.

## Problem

`resolve_topic_alias` (`broker/client_handler/publish.rs`) resolved an inbound Topic Alias to a topic name but never removed the `0x23` property, so it was forwarded to subscribers — including subscribers that advertised no Topic Alias Maximum. Violates `[MQTT-3.1.2-26]`, `[MQTT-3.1.2-27]` and `[MQTT-3.3.2-11]`.

## Fix

- Add `Properties::remove_topic_alias` (the `mqtt5-protocol` properties HashMap is `pub(crate)`, so the broker needs a public accessor).
- Call it in `resolve_topic_alias` once the topic name is resolved, in both the resolve-existing and register-new branches.

## Test

The existing `topic_alias_stripped_before_delivery` conformance test only checked the delivered topic *name* (always correct — the leak was the surviving property) and was mis-tagged `[MQTT-3.3.2-8]` (which the manifest audit retargeted to the alias-value-0 rule). Retargeted it to the three real IDs and strengthened it to parse the delivered PUBLISH with `ParsedPublish` and assert `topic_alias.is_none()`.

Verified it **fails without the fix** (`found Some(2)`) and **passes with it**.

## Conformance manifest

- `MQTT-3.1.2-26`, `MQTT-3.1.2-27`, `MQTT-3.3.2-11` moved Untested→Tested.
- Removed the now-reconciled `topic_alias_stripped_before_delivery MQTT-3.3.2-8` line from `known-citation-drift.txt`.
- Diary entry added.

## Verification

- 6 topic-alias conformance tests pass; 11 manifest drift guards pass; 326 protocol unit tests pass.
- `cargo make ci-verify` (pre-commit) passed.