### PR TITLE
set TCP_NODELAY on broker accepted sockets

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -123,7 +123,7 @@ The client validates acknowledgment reason codes: PUBACK (QoS 1) returns `MqttEr
 
 ### Core Components
 
-**MqttBroker** manages configuration and lifecycle, spawning one listening task per transport. **Server listeners** accept connections over TCP (direct `accept()` loop), TLS (rustls with certificate validation), WebSocket (HTTP upgrade with tokio-tungstenite, path enforcement, Origin validation), and QUIC (quinn endpoint with multistream).
+**MqttBroker** manages configuration and lifecycle, spawning one listening task per transport. **Server listeners** accept connections over TCP (direct `accept()` loop), TLS (rustls with certificate validation), WebSocket (HTTP upgrade with tokio-tungstenite, path enforcement, Origin validation), and QUIC (quinn endpoint with multistream). Every TCP-based accept path (TCP, TLS, WebSocket, WebSocket-over-TLS, cluster) sets `TCP_NODELAY` on the accepted socket, disabling Nagle's algorithm so latency-sensitive MQTT delivery is not held by the peer's delayed-ACK timer; QUIC is unaffected.
 
 Each accepted connection spawns a **ClientHandler** that directly reads and writes packets, manages client session state, and handles the MQTT protocol. The **MessageRouter** performs subscription matching using MQTT-compliant topic wildcards (`+`, `#`), protects system topics (`$SYS/#` excluded from `#`), and supports shared subscriptions (`$share/group/topic`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [mqtt5 0.38.3] - 2026-08-04
-
-### Fixed
-
-- **The broker now sets `TCP_NODELAY` on every accepted TCP connection.** None of the broker's accept paths — plain TCP, TLS, WebSocket, WebSocket over TLS, and cluster — disabled Nagle's algorithm on the socket returned by `accept()`, so broker-to-subscriber delivery ran with Nagle enabled while the client side already set the option. Interacting with the peer's delayed-ACK timer, this added roughly 5 ms to median delivery latency and pinned the tail at the Linux 40 ms delayed-ACK boundary; QUIC was unaffected because it does not run over TCP. MQTT delivery is a stream of small, latency-sensitive writes, which is exactly the case Nagle harms, so the broker now disables it on each accepted socket before wrapping it in a transport. Reported in issue #128.
-
 ## [mqtt5 0.38.2] - 2026-08-04
 
 ### Fixed
 
 - **The broker no longer forwards a publisher's Topic Alias to subscribers.** When a PUBLISH carried a Topic Alias, the broker resolved it to a topic name but left the Topic Alias property on the packet, so live delivery carried it through to subscribers — including subscribers that advertised no Topic Alias Maximum, whose value is therefore zero. This violates `[MQTT-3.1.2-26]`, `[MQTT-3.1.2-27]` and `[MQTT-3.3.2-11]`: a Topic Alias mapping is scoped to a single Network Connection and to the server-to-client direction, so a publisher's alias has no meaning on a subscriber's connection and must not be sent to a client that did not offer to receive one. A subscriber advertising Topic Alias Maximum 2 could receive a delivered PUBLISH carrying Topic Alias 9. Retained, queued and inflight deliveries were unaffected because they rebuild the packet from an explicit field list; only live delivery leaked. `resolve_topic_alias` now strips the Topic Alias property once the topic name is resolved. Reported in issue #130.
+- **The broker now sets `TCP_NODELAY` on every accepted TCP connection.** None of the broker's accept paths — plain TCP, TLS, WebSocket, WebSocket over TLS, and cluster — disabled Nagle's algorithm on the socket returned by `accept()`, so broker-to-subscriber delivery ran with Nagle enabled while the client side already set the option. Interacting with the peer's delayed-ACK timer, this added roughly 5 ms to median delivery latency and pinned the tail at the Linux 40 ms delayed-ACK boundary; QUIC was unaffected because it does not run over TCP. MQTT delivery is a stream of small, latency-sensitive writes, which is exactly the case Nagle harms, so the broker now disables it on each accepted socket before wrapping it in a transport. Reported in issue #128.
 
 ## [mqtt5-protocol 0.14.3] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.38.3] - 2026-08-04
+
+### Fixed
+
+- **The broker now sets `TCP_NODELAY` on every accepted TCP connection.** None of the broker's accept paths — plain TCP, TLS, WebSocket, WebSocket over TLS, and cluster — disabled Nagle's algorithm on the socket returned by `accept()`, so broker-to-subscriber delivery ran with Nagle enabled while the client side already set the option. Interacting with the peer's delayed-ACK timer, this added roughly 5 ms to median delivery latency and pinned the tail at the Linux 40 ms delayed-ACK boundary; QUIC was unaffected because it does not run over TCP. MQTT delivery is a stream of small, latency-sensitive writes, which is exactly the case Nagle harms, so the broker now disables it on each accepted socket before wrapping it in a transport. Reported in issue #128.
+
 ## [mqtt5 0.38.2] - 2026-08-04
 
 ### Fixed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.38.2"
+version = "0.38.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.38.3"
+version = "0.38.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -17,7 +17,7 @@ use crate::broker::websocket_server::{accept_websocket_connection, WebSocketServ
 use crate::error::{MqttError, Result};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, watch};
 use tokio_rustls::TlsAcceptor;
 use tracing::{debug, error, info, warn};
@@ -32,6 +32,12 @@ use crate::telemetry;
 use opentelemetry::metrics::MeterProvider;
 #[cfg(feature = "transport-quic")]
 use quinn::Endpoint;
+
+fn disable_nagle(stream: &TcpStream, addr: std::net::SocketAddr) {
+    if let Err(e) = stream.set_nodelay(true) {
+        warn!(addr = %addr, "failed to set TCP_NODELAY on accepted socket: {e}");
+    }
+}
 
 #[derive(Clone)]
 struct AcceptLoopState {
@@ -986,6 +992,8 @@ impl MqttBroker {
                                         continue;
                                     }
 
+                                    disable_nagle(&tcp_stream, addr);
+
                                     match accept_websocket_connection(tcp_stream, &ws_cfg, addr).await {
                                         Ok(ws_stream) => {
                                             let transport = BrokerTransport::websocket(ws_stream);
@@ -1063,6 +1071,8 @@ impl MqttBroker {
                                         warn!("WebSocket TLS connection rejected from {}: resource limits exceeded", addr);
                                         continue;
                                     }
+
+                                    disable_nagle(&tcp_stream, addr);
 
                                     let acc_clone = acceptor.clone();
                                     let cfg_clone = ws_cfg.clone();
@@ -1151,6 +1161,8 @@ impl MqttBroker {
                                         warn!("TLS connection rejected from {}: resource limits exceeded", addr);
                                         continue;
                                     }
+
+                                    disable_nagle(&tcp_stream, addr);
 
                                     match accept_tls_connection(&acceptor, tcp_stream, addr).await {
                                         Ok(tls_stream) => {
@@ -1307,6 +1319,8 @@ impl MqttBroker {
                                         warn!("Cluster connection rejected from {}: resource limits exceeded", addr);
                                         continue;
                                     }
+
+                                    disable_nagle(&tcp_stream, addr);
 
                                     if let Some(ref tls_acceptor) = acceptor {
                                         let acc_clone = Arc::clone(tls_acceptor);
@@ -1489,6 +1503,8 @@ impl MqttBroker {
                                         warn!("Connection rejected from {}: resource limits exceeded", addr);
                                         continue;
                                     }
+
+                                    disable_nagle(&stream, addr);
 
                                     let transport = BrokerTransport::tcp(stream);
 
@@ -1900,6 +1916,28 @@ mod tests {
         // Use random port to avoid conflicts
         let broker = MqttBroker::bind("127.0.0.1:0").await;
         assert!(broker.is_ok());
+    }
+
+    #[tokio::test]
+    async fn disable_nagle_sets_tcp_nodelay_on_accepted_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).await.unwrap();
+        let (server, peer) = listener.accept().await.unwrap();
+
+        server.set_nodelay(false).unwrap();
+        assert!(
+            !server.nodelay().unwrap(),
+            "precondition: accepted socket starts with Nagle enabled"
+        );
+
+        disable_nagle(&server, peer);
+
+        assert!(
+            server.nodelay().unwrap(),
+            "disable_nagle must enable TCP_NODELAY on the accepted socket"
+        );
+        drop(client);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #128.

## Problem

None of the broker's accept paths disabled Nagle's algorithm on the socket returned by `accept()`, so broker-to-subscriber delivery ran with Nagle enabled while the client side already set `TCP_NODELAY`. Interacting with the peer's delayed-ACK timer, this added ~5 ms to median delivery latency and pinned the tail at the Linux 40 ms delayed-ACK boundary. QUIC was unaffected (not TCP).

`grep -rn set_nodelay crates/mqtt5/src/broker/` previously returned nothing.

## Fix

- Added a private `disable_nagle(&TcpStream, addr)` helper (sets `TCP_NODELAY`, warns on failure without dropping the connection).
- Called it in all five accept loops in `broker/server.rs` — plain TCP, TLS, WebSocket, WebSocket over TLS, and cluster — after the resource-limit guard, before the stream is wrapped in a transport. The cluster insertion point covers both its TLS and non-TLS branches.

## Decisions

- **No config flag.** Nagle-off is the unambiguously correct default for a broker (small, latency-sensitive writes), so a disable knob would be a speculative feature with no real use case. Easy to add later if needed.

## Test

`disable_nagle_sets_tcp_nodelay_on_accepted_socket` — sets `nodelay(false)` on a real accepted loopback socket, calls the helper, asserts it flipped to `true`. Hermetic; fails if the helper ever becomes a no-op.

## Verification

- Regression test passes; `clippy --all-targets --all-features -D warnings -W pedantic` clean; also builds clean with default features.
- `cargo make ci-verify` (pre-commit) passed.

Version: mqtt5 0.38.2 → 0.38.3 (patch); CHANGELOG updated.