### PR TITLE
Decouple bench throughput topics from publisher connections

### DIFF
--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -624,6 +624,9 @@ fn spawn_publishers(
     running: &Arc<std::sync::atomic::AtomicBool>,
     published: &Arc<AtomicU64>,
 ) -> Vec<tokio::task::JoinHandle<()>> {
+    if pub_clients.is_empty() {
+        return Vec::new();
+    }
     let mut handles = Vec::with_capacity(cfg.num_topics);
     for topic_idx in 0..cfg.num_topics {
         let client = pub_clients[topic_idx % pub_clients.len()].clone();
@@ -656,9 +659,10 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
     let base_id = base_client_id(&cmd, "bench");
 
     let num_topics = resolved_topics(&cmd);
+    let active_pub_conns = num_topics.min(cmd.publishers);
     eprintln!(
-        "connecting {} publisher(s) and {} subscriber(s) to {url} ({num_topics} topics across {} publisher connection(s))...",
-        cmd.publishers, cmd.subscribers, cmd.publishers
+        "connecting {} publisher(s) and {} subscriber(s) to {url} ({num_topics} topics round-robin across {active_pub_conns} publisher connection(s))...",
+        cmd.publishers, cmd.subscribers
     );
 
     let mut pub_clients = Vec::with_capacity(cmd.publishers);

--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -126,8 +126,11 @@ pub struct BenchCommand {
     )]
     pub pub_url: Option<String>,
 
-    #[arg(long, default_value = "4")]
-    pub topics: usize,
+    #[arg(
+        long,
+        help = "Number of distinct topics. Throughput mode: topics are distributed round-robin across --publishers connections (unset = one topic per publisher connection, the original behaviour); --publishers 1 --topics N puts N topics on a single connection. HOL mode: number of topics distributed across --pub-connections (unset = 4)"
+    )]
+    pub topics: Option<usize>,
 
     #[arg(
         long,
@@ -312,6 +315,7 @@ struct BenchConfig {
     filter: String,
     publishers: usize,
     subscribers: usize,
+    topics: usize,
     transport: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     quic_stream_strategy: Option<String>,
@@ -462,6 +466,13 @@ fn strategy_display(s: mqtt5::transport::StreamStrategy) -> String {
     }
 }
 
+fn resolved_topics(cmd: &BenchCommand) -> usize {
+    match cmd.mode {
+        BenchMode::HolBlocking => cmd.topics.unwrap_or(4),
+        _ => cmd.topics.unwrap_or(cmd.publishers),
+    }
+}
+
 fn bench_config(cmd: &BenchCommand, url: &str) -> BenchConfig {
     let filter = cmd.filter.clone().unwrap_or_else(|| cmd.topic.clone());
     let sample = encode_payload(cmd.payload_format, cmd.payload_size, 0);
@@ -474,6 +485,7 @@ fn bench_config(cmd: &BenchCommand, url: &str) -> BenchConfig {
         filter,
         publishers: cmd.publishers,
         subscribers: cmd.subscribers,
+        topics: resolved_topics(cmd),
         transport: transport_from_url(url),
         quic_stream_strategy: cmd.quic_stream_strategy.map(strategy_display),
         quic_datagrams: cmd.quic_datagrams,
@@ -598,26 +610,35 @@ fn percentile_stats(sorted: &[u64]) -> (f64, u64, u64, u64) {
     (avg, p50, p95, p99)
 }
 
-fn spawn_publishers(
-    pub_clients: Vec<MqttClient>,
-    topic_base: &str,
+struct PublishConfig {
+    num_topics: usize,
     format: PayloadFormat,
     payload_size: usize,
     qos: QoS,
+}
+
+fn spawn_publishers(
+    pub_clients: &[MqttClient],
+    topic_base: &str,
+    cfg: &PublishConfig,
     running: &Arc<std::sync::atomic::AtomicBool>,
     published: &Arc<AtomicU64>,
 ) -> Vec<tokio::task::JoinHandle<()>> {
-    let mut handles = Vec::with_capacity(pub_clients.len());
-    for (i, pub_client) in pub_clients.into_iter().enumerate() {
-        let topic = format!("{topic_base}/{i}");
+    let mut handles = Vec::with_capacity(cfg.num_topics);
+    for topic_idx in 0..cfg.num_topics {
+        let client = pub_clients[topic_idx % pub_clients.len()].clone();
+        let topic = format!("{topic_base}/{topic_idx}");
         let running = Arc::clone(running);
         let published = Arc::clone(published);
+        let format = cfg.format;
+        let payload_size = cfg.payload_size;
+        let qos = cfg.qos;
 
         handles.push(tokio::spawn(async move {
             let mut seq = 0u32;
             while running.load(Ordering::Relaxed) {
                 let payload = encode_payload(format, payload_size, seq);
-                if publish_message(&pub_client, &topic, &payload, qos)
+                if publish_message(&client, &topic, &payload, qos)
                     .await
                     .is_ok()
                 {
@@ -625,7 +646,6 @@ fn spawn_publishers(
                 }
                 seq = seq.wrapping_add(1);
             }
-            pub_client.disconnect().await.ok();
         }));
     }
     handles
@@ -635,9 +655,10 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
     let url = broker_url(&cmd);
     let base_id = base_client_id(&cmd, "bench");
 
+    let num_topics = resolved_topics(&cmd);
     eprintln!(
-        "connecting {} publisher(s) and {} subscriber(s) to {url}...",
-        cmd.publishers, cmd.subscribers
+        "connecting {} publisher(s) and {} subscriber(s) to {url} ({num_topics} topics across {} publisher connection(s))...",
+        cmd.publishers, cmd.subscribers, cmd.publishers
     );
 
     let mut pub_clients = Vec::with_capacity(cmd.publishers);
@@ -670,15 +691,13 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
     let published = Arc::new(AtomicU64::new(0));
 
     eprintln!("warming up for {}s...", cmd.warmup);
-    let handles = spawn_publishers(
-        pub_clients,
-        &topic,
+    let pub_cfg = PublishConfig {
+        num_topics,
         format,
-        cmd.payload_size,
-        cmd.qos,
-        &running,
-        &published,
-    );
+        payload_size: cmd.payload_size,
+        qos: cmd.qos,
+    };
+    let handles = spawn_publishers(&pub_clients, &topic, &pub_cfg, &running, &published);
 
     tokio::time::sleep(Duration::from_secs(cmd.warmup)).await;
     received.store(0, Ordering::SeqCst);
@@ -715,6 +734,9 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
 
     println!("{}", serde_json::to_string_pretty(&output)?);
 
+    for pub_client in &pub_clients {
+        pub_client.disconnect().await.ok();
+    }
     for sub_client in sub_clients {
         sub_client.disconnect().await.ok();
     }
@@ -1455,7 +1477,7 @@ async fn run_hol_blocking(cmd: BenchCommand) -> Result<()> {
     let url = broker_url(&cmd);
     let pub_url = cmd.pub_url.clone().unwrap_or_else(|| url.clone());
     let base_id = base_client_id(&cmd, "hol");
-    let num_topics = cmd.topics;
+    let num_topics = resolved_topics(&cmd);
     let payload_size = cmd.payload_size.max(12);
     let trace_dir = cmd.trace_dir.clone();
     let pub_conns = cmd.pub_connections.max(1);


### PR DESCRIPTION
## What

Decouples `--topics` from `--publishers` in the throughput bench mode. `--topics` is now `Option<usize>`; the T topics are distributed round-robin across the P publisher connections (`topic_idx % P`). Setting `--publishers 1 --topics N` puts **N topics on a single connection**.

## Why

The throughput mode previously gave publisher *i* the topic `{base}/{i}` on its *own* connection, so "16 topics" was unavoidably "16 connections carrying one topic each" — a configuration in which per-topic and control-only stream mapping are structurally identical. That made it impossible to measure the one case the mapping strategies actually differ in: many topics sharing a single transport connection.

## Details

- `--topics` unset resolves to `--publishers` in throughput mode — **one topic per publisher connection, the original behaviour, preserved exactly**. In HOL mode it still defaults to 4 (unchanged).
- Topic *t* publishes over connection `t % P`; when `T == P` this is identical to the old mapping.
- The publish parameters are bundled into a `PublishConfig` struct (mirrors the existing `HolPublishConfig`) to keep the argument count within clippy's limit. Publisher connections are now disconnected by the caller after the publish tasks join, since tasks share connections and can no longer each own one.
- `topics` is recorded in the results `config` block so every run is self-describing.

## Verification

Against a local in-memory broker, with `lsof` snapshots taken mid-measure:

| Configuration | `config.topics` | Broker-accepted TCP sockets | Delivery |
|---|---|---|---|
| `--publishers 1 --topics 8` | 8 | 2 (1 pub + 1 sub) | 0.991 |
| `--publishers 4` (unset `--topics`) | 4 | 5 (4 pub + 1 sub) | old behaviour |

The 1×8 run carries 8 topics over a single publisher socket; the default 4-publisher run keeps one topic per connection. `cargo clippy --all-targets --workspace -- -D warnings -W clippy::pedantic`, `cargo fmt --check`, and the CLI test suite all pass.

## Not included

Latency mode is left single-topic. It is a single-stream RTT probe, and multi-topic-per-connection latency is exactly what the HOL bench mode already measures per topic, so it was not duplicated here.
