### PR TITLE
Rework bench throughput metrics: offered rate, steady-state, delivered ratio

### DIFF
--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -149,6 +149,13 @@ pub struct BenchCommand {
     #[arg(long, default_value = "0")]
     pub rate: u64,
 
+    #[arg(
+        long,
+        default_value = "0.1",
+        help = "Throughput mode: fraction of per-second samples dropped from each end (ramp-up/tail) before computing steady-state throughput"
+    )]
+    pub steady_trim: f64,
+
     #[arg(long, value_enum, default_value = "raw")]
     pub payload_format: PayloadFormat,
 
@@ -322,6 +329,7 @@ struct BenchConfig {
     quic_datagrams: bool,
     quic_flow_headers: bool,
     rate: u64,
+    steady_trim: f64,
     hol_pub_connections: usize,
     hol_sub_connections: usize,
     payload_format: String,
@@ -333,8 +341,12 @@ struct ThroughputResults {
     published: u64,
     received: u64,
     elapsed_secs: f64,
+    offered_rate: f64,
     throughput_avg: f64,
+    throughput_steady: f64,
+    delivered_ratio: f64,
     samples: Vec<u64>,
+    offered_samples: Vec<u64>,
 }
 
 #[derive(Serialize)]
@@ -491,6 +503,7 @@ fn bench_config(cmd: &BenchCommand, url: &str) -> BenchConfig {
         quic_datagrams: cmd.quic_datagrams,
         quic_flow_headers: cmd.quic_flow_headers,
         rate: cmd.rate,
+        steady_trim: cmd.steady_trim,
         hol_pub_connections: cmd.pub_connections,
         hol_sub_connections: cmd.sub_connections,
         payload_format: format_name(cmd.payload_format),
@@ -709,20 +722,30 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
 
     eprintln!("measuring for {}s...", cmd.duration);
     let measure_start = Instant::now();
-    let samples =
-        sample_counter_per_second(measure_start, Duration::from_secs(cmd.duration), &received)
-            .await;
+    let (offered_samples, delivered_samples) = sample_rates_per_second(
+        measure_start,
+        Duration::from_secs(cmd.duration),
+        &published,
+        &received,
+    )
+    .await;
 
     running.store(false, Ordering::SeqCst);
     for handle in handles {
         handle.await.ok();
     }
-    tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let total_published = published.load(Ordering::Relaxed);
-    let total_received = received.load(Ordering::Relaxed);
-    let elapsed = measure_start.elapsed().as_secs_f64();
-    let throughput_avg = as_f64_lossy(total_received) / elapsed;
+    let total_published: u64 = offered_samples.iter().sum();
+    let total_received: u64 = delivered_samples.iter().sum();
+    let elapsed = usize_as_f64_lossy(delivered_samples.len());
+    let offered_rate = rate_mean(&offered_samples);
+    let throughput_avg = rate_mean(&delivered_samples);
+    let throughput_steady = steady_state_mean(&delivered_samples, cmd.steady_trim);
+    let delivered_ratio = if total_published == 0 {
+        0.0
+    } else {
+        as_f64_lossy(total_received) / as_f64_lossy(total_published)
+    };
 
     let output = BenchOutput {
         mode: "throughput".to_string(),
@@ -731,8 +754,12 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
             published: total_published,
             received: total_received,
             elapsed_secs: elapsed,
+            offered_rate,
             throughput_avg,
-            samples,
+            throughput_steady,
+            delivered_ratio,
+            samples: delivered_samples,
+            offered_samples,
         }),
     };
 
@@ -745,6 +772,67 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
         sub_client.disconnect().await.ok();
     }
     Ok(())
+}
+
+async fn sample_rates_per_second(
+    start: Instant,
+    duration: Duration,
+    offered: &AtomicU64,
+    delivered: &AtomicU64,
+) -> (Vec<u64>, Vec<u64>) {
+    let end = start + duration;
+    let mut next_sample = start + Duration::from_secs(1);
+    let mut last_offered = 0u64;
+    let mut last_delivered = 0u64;
+    let mut offered_samples = Vec::new();
+    let mut delivered_samples = Vec::new();
+
+    while Instant::now() < end {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        if Instant::now() >= next_sample {
+            let cur_offered = offered.load(Ordering::Relaxed);
+            let cur_delivered = delivered.load(Ordering::Relaxed);
+            let d_offered = cur_offered - last_offered;
+            let d_delivered = cur_delivered - last_delivered;
+            offered_samples.push(d_offered);
+            delivered_samples.push(d_delivered);
+            eprintln!("  offered {d_offered} msg/s | delivered {d_delivered} msg/s");
+            last_offered = cur_offered;
+            last_delivered = cur_delivered;
+            next_sample += Duration::from_secs(1);
+        }
+    }
+    (offered_samples, delivered_samples)
+}
+
+fn rate_mean(samples: &[u64]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    as_f64_lossy(samples.iter().sum::<u64>()) / usize_as_f64_lossy(samples.len())
+}
+
+fn steady_state_mean(samples: &[u64], trim_frac: f64) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let n = usize_as_f64_lossy(samples.len());
+    let drop = (n * trim_frac.clamp(0.0, 0.49)).floor();
+    let hi = n - drop;
+    let kept: Vec<u64> = samples
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| {
+            let idx = usize_as_f64_lossy(*i);
+            idx >= drop && idx < hi
+        })
+        .map(|(_, &v)| v)
+        .collect();
+    if kept.is_empty() {
+        rate_mean(samples)
+    } else {
+        rate_mean(&kept)
+    }
 }
 
 async fn sample_counter_per_second(

--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -729,22 +729,23 @@ async fn run_throughput(cmd: BenchCommand) -> Result<()> {
         &received,
     )
     .await;
+    let elapsed = measure_start.elapsed().as_secs_f64();
 
     running.store(false, Ordering::SeqCst);
     for handle in handles {
         handle.await.ok();
     }
 
-    let total_published: u64 = offered_samples.iter().sum();
-    let total_received: u64 = delivered_samples.iter().sum();
-    let elapsed = usize_as_f64_lossy(delivered_samples.len());
+    let total_published = published.load(Ordering::Relaxed);
+    let total_received = drain_until_stable(&received).await;
     let offered_rate = rate_mean(&offered_samples);
     let throughput_avg = rate_mean(&delivered_samples);
     let throughput_steady = steady_state_mean(&delivered_samples, cmd.steady_trim);
-    let delivered_ratio = if total_published == 0 {
+    let expected = as_f64_lossy(total_published) * usize_as_f64_lossy(cmd.subscribers);
+    let delivered_ratio = if expected == 0.0 {
         0.0
     } else {
-        as_f64_lossy(total_received) / as_f64_lossy(total_published)
+        as_f64_lossy(total_received) / expected
     };
 
     let output = BenchOutput {
@@ -803,6 +804,19 @@ async fn sample_rates_per_second(
         }
     }
     (offered_samples, delivered_samples)
+}
+
+async fn drain_until_stable(counter: &AtomicU64) -> u64 {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut last = counter.load(Ordering::Relaxed);
+    loop {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let current = counter.load(Ordering::Relaxed);
+        if current == last || Instant::now() >= deadline {
+            return current;
+        }
+        last = current;
+    }
 }
 
 fn rate_mean(samples: &[u64]) -> f64 {


### PR DESCRIPTION
## What

Reworks the throughput bench mode's reported metrics. The measure loop samples the offered (published) and delivered (received) counters once per second for the rate series, while the totals used for the delivered fraction come from authoritative counter reads taken after a bounded drain.

## Why

The old `throughput_avg` divided `total_received` by `measure_start.elapsed()`, but both the elapsed value and the counter reads happened *after* the publisher tasks were joined and a 100 ms tail sleep — so the denominator absorbed teardown time carrying little traffic, deflating the figure in an arm-dependent way (~10%). The mode also reported no offered load and no delivered ratio, so a run where a subscriber could not keep up looked like low throughput rather than a drop.

## Details

New `ThroughputResults` fields:

| Field | Source | Meaning |
|---|---|---|
| `offered_rate` | mean of per-second offered samples | offered (published) msg/s in-window |
| `throughput_avg` | mean of per-second delivered samples | delivered msg/s in-window — the corrected headline (denominator is the sampled window, teardown excluded) |
| `throughput_steady` | trimmed mean of delivered samples | ramp-up and shutdown-tail seconds dropped |
| `delivered_ratio` | `received / (published × subscribers)` | delivered fraction, normalized for subscriber fan-out |

- `offered_samples` is added alongside the existing delivered `samples` series.
- `published` and `received` are authoritative counter reads: `published` after the publisher tasks join, `received` after `drain_until_stable` — a bounded wait (polls until delivered stops growing, 2 s cap) that lets in-flight messages arrive so the ratio reflects loss, not pipeline depth. Genuinely dropped messages never arrive, so real loss still shows.
- `delivered_ratio` divides by `published × subscribers` because every subscriber receives every message; without that a run with N subscribers would report a ratio around N.
- `elapsed_secs` is the wall-clock measurement window (`measure_start.elapsed()`), captured before teardown.
- Steady-state trim is the `--steady-trim` flag (default `0.1`, clamped `≤0.49`, recorded in `config.steady_trim`) — a **temporal** head/tail trim, not a value trim.

## Verification

Against a local in-memory broker:

- `--subscribers 3`, QoS 1, lossless: `received = 3 × published`, `delivered_ratio = 1.000` (fan-out normalized).
- `--subscribers 1`, QoS 1, lossless: `delivered_ratio = 1.000` (the drain lets delivered catch up to offered — no false loss).
- `--publishers 4 --subscribers 1`, QoS 0: `delivered_ratio ≈ 0.63`, a genuine receiver overrun the drain does not mask.
- `throughput_steady` engages once there are ≥10 samples (a 15 s run drops 1 s from each end and differs from `throughput_avg`; an 8 s run trims nothing and equals it).

`cargo clippy --all-targets --workspace -- -D warnings -W clippy::pedantic`, `cargo fmt --check`, and the CLI test suite all pass. The steady-state trim computes its bounds by f64 index comparison rather than a float→int cast, so no `#[allow]` is needed.
