### PR TITLE
Phase-1 experiment hygiene: CPU metric, broker restart per run, empty-cell plotting

### DIFF
--- a/publications/comnet/experiments/analysis/figures/fig08_connection_latency.py
+++ b/publications/comnet/experiments/analysis/figures/fig08_connection_latency.py
@@ -80,9 +80,9 @@ def main(results_dir: Path, output_dir: Path):
                 p50_cis.append(p50_ci)
                 p95_tops.append(max(0, p95_mean - p50_mean))
             else:
-                p50_means.append(0)
-                p50_cis.append(0)
-                p95_tops.append(0)
+                p50_means.append(np.nan)
+                p50_cis.append(np.nan)
+                p95_tops.append(np.nan)
 
         offset = (tidx - (num_transports - 1) / 2) * bar_width
         positions = group_positions + offset

--- a/publications/comnet/experiments/analysis/figures/fig08_connection_latency.py
+++ b/publications/comnet/experiments/analysis/figures/fig08_connection_latency.py
@@ -70,18 +70,15 @@ def main(results_dir: Path, output_dir: Path):
 
     for tidx, transport in enumerate(CONN_TRANSPORT_ORDER):
         p50_means = []
-        p50_cis = []
         p95_tops = []
         for delay in DELAYS_MS:
             if delay in data[transport]:
-                p50_mean, p50_ci = compute_ci(data[transport][delay]["p50"])
+                p50_mean, _ = compute_ci(data[transport][delay]["p50"])
                 p95_mean, _ = compute_ci(data[transport][delay]["p95"])
                 p50_means.append(p50_mean)
-                p50_cis.append(p50_ci)
                 p95_tops.append(max(0, p95_mean - p50_mean))
             else:
                 p50_means.append(np.nan)
-                p50_cis.append(np.nan)
                 p95_tops.append(np.nan)
 
         offset = (tidx - (num_transports - 1) / 2) * bar_width

--- a/publications/comnet/experiments/monitor/resource_monitor.sh
+++ b/publications/comnet/experiments/monitor/resource_monitor.sh
@@ -7,16 +7,31 @@ INTERVAL="${2:-1}"
 IFACE=$(ip route show default 2>/dev/null | awk '{print $5; exit}')
 : "${IFACE:=eth0}"
 
+CLK_TCK=$(getconf CLK_TCK 2>/dev/null || echo 100)
+
 read_net_counters() {
     awk -v iface="${IFACE}:" '$1 == iface {print $2, $3, $10, $11}' /proc/net/dev
 }
 
+read_cpu_jiffies() {
+    awk '{ s=$0; sub(/^.*\) /, "", s); split(s, f, " "); print f[12] + f[13] }' \
+        "/proc/${PID}/stat" 2>/dev/null || echo 0
+}
+
 echo "timestamp,rss_kb,cpu_percent,threads,net_rx_bytes,net_tx_bytes,net_rx_packets,net_tx_packets"
+
+prev_jiffies=$(read_cpu_jiffies)
+prev_time=$(date +%s.%N)
 
 while kill -0 "$PID" 2>/dev/null; do
     ts=$(date +%s)
+    now=$(date +%s.%N)
+    cur_jiffies=$(read_cpu_jiffies)
+    cpu=$(awk -v cj="$cur_jiffies" -v pj="$prev_jiffies" -v t1="$prev_time" -v t2="$now" -v hz="$CLK_TCK" \
+        'BEGIN { dt = t2 - t1; if (dt <= 0) { print "0.0" } else { printf "%.1f", 100 * ((cj - pj) / hz) / dt } }')
+    prev_jiffies=$cur_jiffies
+    prev_time=$now
     rss=$(awk '/^VmRSS:/ {print $2}' "/proc/${PID}/status" 2>/dev/null || echo 0)
-    cpu=$(ps -p "$PID" -o %cpu= 2>/dev/null | tr -d ' ' || echo 0)
     threads=$(awk '/^Threads:/ {print $2}' "/proc/${PID}/status" 2>/dev/null || echo 0)
     net=$(read_net_counters)
     rx_bytes=$(echo "$net" | awk '{print $1}')

--- a/publications/comnet/experiments/monitor/resource_monitor.sh
+++ b/publications/comnet/experiments/monitor/resource_monitor.sh
@@ -24,11 +24,13 @@ prev_jiffies=$(read_cpu_jiffies)
 prev_time=$(date +%s.%N)
 
 while kill -0 "$PID" 2>/dev/null; do
-    ts=$(date +%s)
+    sleep "$INTERVAL"
+    kill -0 "$PID" 2>/dev/null || break
     now=$(date +%s.%N)
+    ts="${now%.*}"
     cur_jiffies=$(read_cpu_jiffies)
     cpu=$(awk -v cj="$cur_jiffies" -v pj="$prev_jiffies" -v t1="$prev_time" -v t2="$now" -v hz="$CLK_TCK" \
-        'BEGIN { dt = t2 - t1; if (dt <= 0) { print "0.0" } else { printf "%.1f", 100 * ((cj - pj) / hz) / dt } }')
+        'BEGIN { dt = t2 - t1; if (dt <= 0 || cj < pj) { print "0.0" } else { printf "%.1f", 100 * ((cj - pj) / hz) / dt } }')
     prev_jiffies=$cur_jiffies
     prev_time=$now
     rss=$(awk '/^VmRSS:/ {print $2}' "/proc/${PID}/status" 2>/dev/null || echo 0)
@@ -40,5 +42,4 @@ while kill -0 "$PID" 2>/dev/null; do
     tx_packets=$(echo "$net" | awk '{print $4}')
     : "${rx_bytes:=0}" "${rx_packets:=0}" "${tx_bytes:=0}" "${tx_packets:=0}"
     echo "${ts},${rss},${cpu},${threads},${rx_bytes},${tx_bytes},${rx_packets},${tx_packets}"
-    sleep "$INTERVAL"
 done

--- a/publications/comnet/experiments/run/common.sh
+++ b/publications/comnet/experiments/run/common.sh
@@ -21,9 +21,11 @@ ssh_broker() { ssh -i "$SSH_KEY_PATH" $SSH_OPTS "${SSH_USER}@${BROKER_SSH_IP}" "
 ssh_client() { ssh -i "$SSH_KEY_PATH" $SSH_OPTS "${SSH_USER}@${CLIENT_IP}" "$@"; }
 
 BROKER_PID=""
+BROKER_FLAGS=""
 
 start_broker() {
     local extra_flags="${1:-}"
+    BROKER_FLAGS="$extra_flags"
     echo "starting broker on ${BROKER_IP}..."
     BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
         ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!")
@@ -36,6 +38,11 @@ stop_broker() {
     ssh_broker "pkill -f 'mqttv5 broker'" 2>/dev/null || true
     BROKER_PID=""
     sleep 1
+}
+
+restart_broker() {
+    stop_broker
+    start_broker "$BROKER_FLAGS"
 }
 
 apply_netem() {
@@ -115,6 +122,7 @@ run_monitored() {
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"
+        restart_broker
         start_monitor "${output_dir}/${run_label}_broker_resources.csv"
         start_client_monitor
         run_bench "$experiment" "$run_label" "$bench_args"

--- a/publications/comnet/experiments/run/common.sh
+++ b/publications/comnet/experiments/run/common.sh
@@ -22,6 +22,7 @@ ssh_client() { ssh -i "$SSH_KEY_PATH" $SSH_OPTS "${SSH_USER}@${CLIENT_IP}" "$@";
 
 BROKER_PID=""
 BROKER_FLAGS=""
+BROKER_FRESH=0
 
 start_broker() {
     local extra_flags="${1:-}"
@@ -30,19 +31,24 @@ start_broker() {
     BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
         ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!")
     sleep 2
-    echo "broker pid: ${BROKER_PID}"
+    if ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
+        echo "broker pid: ${BROKER_PID}"
+    else
+        echo "ERROR: broker ${BROKER_PID} not running after start (see /tmp/broker.log on ${BROKER_IP})" >&2
+    fi
+    BROKER_FRESH=1
 }
 
 stop_broker() {
     echo "stopping broker..."
-    ssh_broker "pkill -f 'mqttv5 broker'" 2>/dev/null || true
+    ssh_broker "pkill -f 'mqttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f 'mqttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
     BROKER_PID=""
-    sleep 1
 }
 
 restart_broker() {
     stop_broker
     start_broker "$BROKER_FLAGS"
+    BROKER_FRESH=0
 }
 
 apply_netem() {
@@ -122,7 +128,11 @@ run_monitored() {
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"
-        restart_broker
+        if [ "$BROKER_FRESH" = "1" ]; then
+            BROKER_FRESH=0
+        else
+            restart_broker
+        fi
         start_monitor "${output_dir}/${run_label}_broker_resources.csv"
         start_client_monitor
         run_bench "$experiment" "$run_label" "$bench_args"


### PR DESCRIPTION
## What

Three independent fixes to the Computer Networks experiment harness, prerequisites for the re-runs.

## 1. CPU metric — `monitor/resource_monitor.sh`

`cpu_percent` was `ps -p "$PID" -o %cpu=`, the process's **average CPU over its entire lifetime**, not utilisation during the sample interval — so every CPU column was a near-constant lifetime average rather than a time series.

Now computed as a per-interval delta of `utime + stime` from `/proc/$PID/stat`, normalised by `CLK_TCK` and the actual wall-clock interval. Details:

- Parsing strips everything up to the last `)` so a process name containing spaces or parentheses cannot shift the field offsets.
- The `sleep` runs at the top of the loop, so the first emitted sample spans a full interval (no ~5 ms first-`dt` artifact), and a `kill -0 || break` after the sleep drops the trailing sample when the process exits mid-interval.
- The awk guard is `dt <= 0 || cj < pj`, so a failed `/proc` read on a dying process yields `0.0` rather than a negative value.
- `ts` is derived from the sub-second timestamp (`${now%.*}`) instead of a second `date` call.

The CSV schema is unchanged; values can now exceed 100% for the multi-threaded broker, which is correct.

## 2. Broker restart per run — `run/common.sh`

The start-once experiments (`03`, `04`, `05`, `06`) ran every cell against one long-lived broker that ages measurably (RSS climbing, throughput decaying monotonically within each arm), so measurements were taken against a drifting broker.

- `start_broker` records its flags in `BROKER_FLAGS`; `restart_broker` restarts with those exact flags; `run_monitored` gives every run a fresh broker (fresh in-memory storage).
- A `BROKER_FRESH` flag makes `run_monitored` **consume** the just-started broker on the first run rather than immediately killing it, so the externally-started broker isn't wasted (and the HOL per-cell double-restart is removed).
- `stop_broker` now polls `pgrep` until the broker process has actually exited (up to ~10 s) before returning, so a per-run restart cannot race the old broker's port release and hit "address already in use".
- `start_broker` warns to stderr if the new PID is not alive shortly after start, so a failed bind is visible rather than silently producing an empty results file.

## 3. Empty-cell plotting — `analysis/figures/fig08_connection_latency.py`

The QUIC 0 ms connection-latency cell in `results-v5` has no data (15 zero-byte run files). The loader already skips zero-byte inputs, but the plotting loop substituted `0` for the missing cell, which on the log y-axis renders as a misleading near-zero bar (and `log(0)` is undefined). Missing cells now use `np.nan`, so matplotlib draws a gap. The dead `p50_cis` list (built every run, never plotted) is removed.

The underlying data regenerates in the GCP re-run; this only stops the figure from misrepresenting the gap in the meantime.

## Verification

- All 16 run scripts pass `bash -n`; `resource_monitor.sh` is shellcheck-clean; `common.sh` has only pre-existing `$SSH_OPTS` word-splitting notices (intentional).
- The `/proc/stat` parse, CPU delta math, the `cj < pj` guard, and the `${now%.*}` derivation were validated in isolation (including a comm containing a space).
- `fig08` renders against `results-v5` with the failed cell shown as a gap.

## Not included

The pre-existing `SC2086` on `$SSH_OPTS` (intentional word-splitting; the correct fix is an array refactor, unrelated and untestable without a live SSH environment). The empty-file data regenerates in the re-run rather than here. Cold-start transients from the per-run restart are inherent to that design; the benches' own `--warmup` covers the client-visible measurement window.
