### PR TITLE
Harden broker restart across both bench harnesses (per-run restart, self-match, retry, fail-soft)

### DIFF
--- a/publications/comnet/experiments/analysis/figures/fig14_strategy_comparison.py
+++ b/publications/comnet/experiments/analysis/figures/fig14_strategy_comparison.py
@@ -38,25 +38,16 @@ def load_data(results_dir: Path):
 
     data = {}
     for strategy in STRATEGY_ORDER:
-        data[strategy] = {"latency": {}, "throughput": {}}
+        data[strategy] = {"throughput": {}}
         for topics in TOPIC_COUNTS:
-            lat_values = []
             tp_values = []
             for run in RUNS:
-                lat_path = exp_dir / f"{strategy}_{topics}topics_latency_run{run}.json"
-                if lat_path.exists():
-                    with open(lat_path) as f:
-                        d = json.load(f)
-                    lat_values.append(d["results"]["p50_us"])
-
                 tp_path = exp_dir / f"{strategy}_{topics}topics_throughput_run{run}.json"
                 if tp_path.exists():
                     with open(tp_path) as f:
                         d = json.load(f)
                     tp_values.append(d["results"]["throughput_avg"])
 
-            if lat_values:
-                data[strategy]["latency"][topics] = lat_values
             if tp_values:
                 data[strategy]["throughput"][topics] = tp_values
     return data
@@ -68,39 +59,8 @@ def main(results_dir: Path, output_dir: Path):
     if data is None:
         return
 
-    fig, axes = plt.subplots(1, 2, figsize=(7, 3.5))
+    fig, ax_tp = plt.subplots(1, 1, figsize=(4.5, 3.5))
 
-    ax_lat = axes[0]
-    for strategy in STRATEGY_ORDER:
-        x_vals = []
-        y_means = []
-        y_errs = []
-        for topics in TOPIC_COUNTS:
-            lat_data = data[strategy]["latency"].get(topics)
-            if lat_data:
-                m, e = compute_ci(lat_data)
-                x_vals.append(topics)
-                y_means.append(m / 1000.0)
-                y_errs.append(e / 1000.0)
-
-        if not x_vals:
-            continue
-
-        ax_lat.errorbar(
-            x_vals, y_means, yerr=y_errs,
-            marker=STRATEGY_MARKERS[strategy],
-            color=STRATEGY_COLORS[strategy],
-            label=STRATEGY_LABELS[strategy],
-            linewidth=1.5, markersize=6, capsize=4,
-        )
-
-    ax_lat.set_xlabel("Topic Count")
-    ax_lat.set_ylabel("p50 Latency (ms)")
-    ax_lat.set_title("(a) Latency vs. Topic Count")
-    ax_lat.set_xticks(TOPIC_COUNTS)
-    ax_lat.legend(loc="best", fontsize=8)
-
-    ax_tp = axes[1]
     for strategy in STRATEGY_ORDER:
         x_vals = []
         y_means = []
@@ -126,7 +86,7 @@ def main(results_dir: Path, output_dir: Path):
 
     ax_tp.set_xlabel("Topic Count")
     ax_tp.set_ylabel("Throughput (K msgs/sec)")
-    ax_tp.set_title("(b) Throughput vs. Topic Count")
+    ax_tp.set_title("Throughput vs. Topic Count")
     ax_tp.set_xticks(TOPIC_COUNTS)
     ax_tp.legend(loc="best", fontsize=8)
 

--- a/publications/comnet/experiments/analysis/publication_stats.py
+++ b/publications/comnet/experiments/analysis/publication_stats.py
@@ -197,7 +197,7 @@ RESOURCE_PARSERS = {
 
 STRATEGY_PARSERS = {
     "04_stream_strategies": (
-        re.compile(r"(.+?)_(\d+)topics_(latency|throughput)_run(\d+)\.json"),
+        re.compile(r"(.+?)_(\d+)topics_(throughput)_run(\d+)\.json"),
         lambda m: (m.group(1), f"{m.group(2)}topics_{m.group(3)}"),
     ),
 }
@@ -313,7 +313,7 @@ def build_stats_table_generic(
             key = (transport, condition)
             if key not in grouped:
                 continue
-            entry = {"transport": transport, "condition": condition}
+            entry: dict[str, object] = {"transport": transport, "condition": condition}
             for field in fields:
                 stat = compute_stats(grouped[key], field)
                 if stat:
@@ -333,7 +333,7 @@ def build_stats_table(
             key = (transport, condition)
             if key not in grouped:
                 continue
-            entry = {"transport": transport, "condition": condition}
+            entry: dict[str, object] = {"transport": transport, "condition": condition}
             for field in fields:
                 stat = compute_stats(grouped[key], field)
                 if stat:
@@ -506,20 +506,9 @@ def aggregate_strategy_experiment(base_dir: Path, experiment: str) -> dict[tuple
             data = load_json(jf)
         except (json.JSONDecodeError, ValueError):
             continue
-        mode = data["mode"]
-        if mode == "latency":
-            metrics = {
-                "p50_us": data["results"]["p50_us"],
-                "p95_us": data["results"]["p95_us"],
-                "throughput_avg": None,
-            }
-        else:
-            metrics = {
-                "p50_us": None,
-                "p95_us": None,
-                "throughput_avg": data["results"]["throughput_avg"],
-            }
-        grouped[(strategy, condition)].append(metrics)
+        grouped[(strategy, condition)].append(
+            {"throughput_avg": data["results"]["throughput_avg"]}
+        )
 
     return grouped
 
@@ -850,7 +839,7 @@ def main():
     if exp04:
         strat_order = ["control-only", "per-publish", "per-topic"]
         strat_conditions = sorted({k[1] for k in exp04})
-        strat_fields = ["p50_us", "p95_us", "throughput_avg"]
+        strat_fields = ["throughput_avg"]
         all_stats["exp04"] = build_stats_table_generic(exp04, strat_order, strat_conditions, strat_fields)
         print(f"Exp 04 (stream strategies): processed ({len(strat_conditions)} conditions)")
 

--- a/publications/comnet/experiments/parallel/01_connection_latency_v5.sh
+++ b/publications/comnet/experiments/parallel/01_connection_latency_v5.sh
@@ -49,8 +49,10 @@ for tidx in "${!TRANSPORTS[@]}"; do
 
         if [ "$tname" = "quic" ]; then
             for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
-                stop_broker
-                start_broker "$flags"
+                if ! restart_broker; then
+                    echo "WARN: broker restart failed, skipping ${label}_run${run}" >&2
+                    continue
+                fi
                 run_monitored_single "$EXPERIMENT" "${label}_run${run}" \
                     "--url ${url} --ca-cert /opt/mqtt-certs/ca.pem --mode connections --concurrency 1 --duration 30"
             done

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
@@ -104,6 +104,12 @@ for tname in "${TRANSPORTS[@]}"; do
 
         for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
             run_label="${label}_run${run}"
+            if [ "$BROKER_FRESH" = "1" ]; then
+                BROKER_FRESH=0
+            elif ! restart_broker; then
+                echo "WARN: broker restart failed, skipping ${run_label}" >&2
+                continue
+            fi
             start_monitors
             run_hol_colocated "$EXPERIMENT" "$run_label" "$bench_args"
             stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
@@ -82,6 +82,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5.sh
@@ -37,9 +37,9 @@ read -ra TRANSPORTS <<< "$V3_TRANSPORTS"
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -92,7 +92,10 @@ for tname in "${TRANSPORTS[@]}"; do
     delivery="${BROKER_DELIVERY[$tname]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${tname}, skipping transport" >&2
+        continue
+    fi
 
     for loss in "${LOSSES[@]}"; do
         apply_netem "$DELAY" "$loss"

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
@@ -98,6 +98,12 @@ for tname in "${TRANSPORTS[@]}"; do
 
         for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
             run_label="${label}_run${run}"
+            if [ "$BROKER_FRESH" = "1" ]; then
+                BROKER_FRESH=0
+            elif ! restart_broker; then
+                echo "WARN: broker restart failed, skipping ${run_label}" >&2
+                continue
+            fi
             start_monitors
             run_hol_colocated "$EXPERIMENT" "$run_label" "$bench_args"
             stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
@@ -76,6 +76,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
+++ b/publications/comnet/experiments/parallel/02_hol_blocking_v5_fp.sh
@@ -31,9 +31,9 @@ read -ra TRANSPORTS <<< "$V4_TRANSPORTS"
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -86,7 +86,10 @@ for tname in "${TRANSPORTS[@]}"; do
     delivery="${BROKER_DELIVERY[$tname]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${tname}, skipping transport" >&2
+        continue
+    fi
 
     for loss in "${LOSSES[@]}"; do
         apply_netem "$DELAY" "$loss"

--- a/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
+++ b/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
@@ -104,6 +104,12 @@ for tname in "${TRANSPORTS[@]}"; do
 
         for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
             run_label="${label}_run${run}"
+            if [ "$BROKER_FRESH" = "1" ]; then
+                BROKER_FRESH=0
+            elif ! restart_broker; then
+                echo "WARN: broker restart failed, skipping ${run_label}" >&2
+                continue
+            fi
             start_monitors
             run_hol_colocated "$EXPERIMENT" "$run_label" "$bench_args"
             stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
+++ b/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
@@ -82,6 +82,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
+++ b/publications/comnet/experiments/parallel/02b_hol_rtt_sweep_v5.sh
@@ -37,9 +37,9 @@ read -ra TRANSPORTS <<< "$RTT_TRANSPORTS"
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -92,7 +92,10 @@ for tname in "${TRANSPORTS[@]}"; do
     delivery="${BROKER_DELIVERY[$tname]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${tname}, skipping transport" >&2
+        continue
+    fi
 
     for delay in "${DELAYS[@]}"; do
         apply_netem "$delay" "$LOSS"

--- a/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
+++ b/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
@@ -104,6 +104,12 @@ for tname in "${TRANSPORTS[@]}"; do
 
         for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
             run_label="${label}_run${run}"
+            if [ "$BROKER_FRESH" = "1" ]; then
+                BROKER_FRESH=0
+            elif ! restart_broker; then
+                echo "WARN: broker restart failed, skipping ${run_label}" >&2
+                continue
+            fi
             start_monitors
             run_hol_colocated "$EXPERIMENT" "$run_label" "$bench_args"
             stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
+++ b/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
@@ -82,6 +82,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
+++ b/publications/comnet/experiments/parallel/02d_hol_rtt_boundary_v5.sh
@@ -37,9 +37,9 @@ read -ra TRANSPORTS <<< "$RTT_TRANSPORTS"
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -92,7 +92,10 @@ for tname in "${TRANSPORTS[@]}"; do
     delivery="${BROKER_DELIVERY[$tname]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${tname}, skipping transport" >&2
+        continue
+    fi
 
     for delay in "${DELAYS[@]}"; do
         apply_netem "$delay" "$LOSS"

--- a/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
+++ b/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
@@ -96,6 +96,12 @@ for tname in "${TRANSPORTS[@]}"; do
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         run_label="${label}_run${run}"
+        if [ "$BROKER_FRESH" = "1" ]; then
+            BROKER_FRESH=0
+        elif ! restart_broker; then
+            echo "WARN: broker restart failed, skipping ${run_label}" >&2
+            continue
+        fi
         start_monitors
         run_hol_colocated "$EXPERIMENT" "$run_label" "$bench_args"
         stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
+++ b/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
@@ -75,6 +75,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
+++ b/publications/comnet/experiments/parallel/02e_hol_qos1_v5.sh
@@ -30,9 +30,9 @@ TRANSPORTS=(tcp quic-pertopic)
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -85,7 +85,10 @@ for tname in "${TRANSPORTS[@]}"; do
     delivery="${BROKER_DELIVERY[$tname]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${tname}, skipping transport" >&2
+        continue
+    fi
 
     apply_netem "$DELAY" "$LOSS"
     label="${tname}_qos1"

--- a/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
+++ b/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
@@ -12,10 +12,14 @@ RUNS_PER_DATAPOINT=15
 RESULTS_DIR="${ROOT_DIR}/results-v5"
 mkdir -p "$RESULTS_DIR"
 
-start_broker "--tls-cert /opt/mqtt-certs/server.pem --tls-key /opt/mqtt-certs/server.key --quic-host 0.0.0.0:14567"
 apply_netem "$DELAY" "$LOSS"
 
 for strategy in "${STRATEGIES[@]}"; do
+    stop_broker 2>/dev/null || true
+    if ! start_broker "--tls-cert /opt/mqtt-certs/server.pem --tls-key /opt/mqtt-certs/server.key --quic-host 0.0.0.0:14567 --quic-delivery-strategy ${strategy}"; then
+        echo "WARN: broker start failed for strategy ${strategy}, skipping" >&2
+        continue
+    fi
     for ntopics in "${TOPIC_COUNTS[@]}"; do
         label="${strategy}_${ntopics}topics_throughput"
         echo "[${EXPERIMENT}] ${label}"

--- a/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
+++ b/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
@@ -20,12 +20,7 @@ for strategy in "${STRATEGIES[@]}"; do
         label="${strategy}_${ntopics}topics_throughput"
         echo "[${EXPERIMENT}] ${label}"
         run_monitored_split "$EXPERIMENT" "$label" \
-            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers ${ntopics} --subscribers ${ntopics}"
-
-        label="${strategy}_${ntopics}topics_latency"
-        echo "[${EXPERIMENT}] ${label}"
-        run_monitored_split "$EXPERIMENT" "$label" \
-            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode latency --duration 60 --warmup 5 --payload-size 256 --publishers ${ntopics} --subscribers ${ntopics}"
+            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers 1 --topics ${ntopics} --subscribers 1"
     done
 done
 

--- a/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
+++ b/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
@@ -12,14 +12,14 @@ RUNS_PER_DATAPOINT=15
 RESULTS_DIR="${ROOT_DIR}/results-v5"
 mkdir -p "$RESULTS_DIR"
 
-apply_netem "$DELAY" "$LOSS"
-
 for strategy in "${STRATEGIES[@]}"; do
+    clear_netem 2>/dev/null || true
     stop_broker 2>/dev/null || true
     if ! start_broker "--tls-cert /opt/mqtt-certs/server.pem --tls-key /opt/mqtt-certs/server.key --quic-host 0.0.0.0:14567 --quic-delivery-strategy ${strategy}"; then
         echo "WARN: broker start failed for strategy ${strategy}, skipping" >&2
         continue
     fi
+    apply_netem "$DELAY" "$LOSS"
     for ntopics in "${TOPIC_COUNTS[@]}"; do
         label="${strategy}_${ntopics}topics_throughput"
         echo "[${EXPERIMENT}] ${label}"

--- a/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
+++ b/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
@@ -73,6 +73,7 @@ run_hol_colocated() {
     echo "  running (co-located): ${label}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" \
         > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 

--- a/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
+++ b/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
@@ -30,9 +30,9 @@ read -ra MODES <<< "$SUB_MODES"
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
 }
 
 stop_monitors() {
@@ -82,7 +82,10 @@ for mode in "${MODES[@]}"; do
     delivery="${BROKER_DELIVERY[$mode]}"
 
     stop_broker 2>/dev/null || true
-    start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"
+    if ! start_broker "${BROKER_TLS} ${BROKER_QUIC} ${delivery}"; then
+        echo "WARN: broker start failed for ${mode}, skipping" >&2
+        continue
+    fi
 
     for loss in "${LOSSES[@]}"; do
         apply_netem "$DELAY" "$loss"

--- a/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
+++ b/publications/comnet/experiments/parallel/07_subscriber_flow_delivery.sh
@@ -94,6 +94,12 @@ for mode in "${MODES[@]}"; do
 
         for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
             run_label="${label}_run${run}"
+            if [ "$BROKER_FRESH" = "1" ]; then
+                BROKER_FRESH=0
+            elif ! restart_broker; then
+                echo "WARN: broker restart failed, skipping ${run_label}" >&2
+                continue
+            fi
             start_monitors
             run_hol_colocated "$run_label" "$bench_args"
             stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -89,8 +89,12 @@ clear_netem() {
 
 restore_netem() {
     if [ -n "$CUR_NETEM_DELAY" ]; then
-        ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/apply.sh ${CUR_NETEM_DELAY} ${CUR_NETEM_LOSS}" 2>/dev/null || true
+        if ! ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/apply.sh ${CUR_NETEM_DELAY} ${CUR_NETEM_LOSS}" 2>/dev/null; then
+            echo "WARN: failed to restore netem (delay=${CUR_NETEM_DELAY}ms loss=${CUR_NETEM_LOSS}%)" >&2
+            return 1
+        fi
     fi
+    return 0
 }
 
 restart_broker() {
@@ -99,10 +103,12 @@ restart_broker() {
     fi
     stop_broker
     if ! start_broker "$BROKER_FLAGS"; then
-        restore_netem
+        restore_netem || true
         return 1
     fi
-    restore_netem
+    if ! restore_netem; then
+        return 1
+    fi
     BROKER_FRESH=0
 }
 

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -112,11 +112,11 @@ SUB_MONITOR_PID=""
 
 start_monitors() {
     BROKER_MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=$(ssh_pub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || PUB_MONITOR_PID=""
     SUB_MONITOR_PID=$(ssh_sub "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || SUB_MONITOR_PID=""
 }
 
 stop_monitors() {

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -70,22 +70,40 @@ stop_broker() {
     BROKER_PID=""
 }
 
-restart_broker() {
-    stop_broker
-    if ! start_broker "$BROKER_FLAGS"; then
-        return 1
-    fi
-    BROKER_FRESH=0
-}
+CUR_NETEM_DELAY=""
+CUR_NETEM_LOSS=""
 
 apply_netem() {
     local delay_ms="$1"
     local loss_pct="${2:-0}"
+    CUR_NETEM_DELAY="$delay_ms"
+    CUR_NETEM_LOSS="$loss_pct"
     ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/apply.sh ${delay_ms} ${loss_pct}"
 }
 
 clear_netem() {
+    CUR_NETEM_DELAY=""
+    CUR_NETEM_LOSS=""
     ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/clear.sh"
+}
+
+restore_netem() {
+    if [ -n "$CUR_NETEM_DELAY" ]; then
+        ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/apply.sh ${CUR_NETEM_DELAY} ${CUR_NETEM_LOSS}" 2>/dev/null || true
+    fi
+}
+
+restart_broker() {
+    if [ -n "$CUR_NETEM_DELAY" ]; then
+        ssh_broker "sudo bash /opt/mqtt-lib/experiments/netem/clear.sh" 2>/dev/null || true
+    fi
+    stop_broker
+    if ! start_broker "$BROKER_FLAGS"; then
+        restore_netem
+        return 1
+    fi
+    restore_netem
+    BROKER_FRESH=0
 }
 
 BROKER_MONITOR_PID=""

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -39,21 +39,34 @@ scp_from_sub() {
 }
 
 BROKER_PID=""
+BROKER_FLAGS=""
+BROKER_FRESH=0
 
 start_broker() {
     local extra_flags="${1:-}"
+    BROKER_FLAGS="$extra_flags"
     echo "starting broker on ${BROKER_IP} (group ${GROUP})..."
     BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
         ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!")
     sleep 2
-    echo "broker pid: ${BROKER_PID}"
+    if ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
+        echo "broker pid: ${BROKER_PID}"
+    else
+        echo "ERROR: broker ${BROKER_PID} not running after start (see /tmp/broker.log on ${BROKER_IP})" >&2
+    fi
+    BROKER_FRESH=1
 }
 
 stop_broker() {
     echo "stopping broker (group ${GROUP})..."
-    ssh_broker "pkill -f 'mqttv5 broker'" 2>/dev/null || true
+    ssh_broker "pkill -f 'mqttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f 'mqttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
     BROKER_PID=""
-    sleep 1
+}
+
+restart_broker() {
+    stop_broker
+    start_broker "$BROKER_FLAGS"
+    BROKER_FRESH=0
 }
 
 apply_netem() {
@@ -170,6 +183,11 @@ run_monitored_pub_only() {
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"
+        if [ "$BROKER_FRESH" = "1" ]; then
+            BROKER_FRESH=0
+        else
+            restart_broker
+        fi
         start_monitors
         run_bench_pub_only "$experiment" "$run_label" "$bench_args"
         stop_monitors "$output_dir" "$run_label"
@@ -187,6 +205,11 @@ run_monitored_split() {
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"
+        if [ "$BROKER_FRESH" = "1" ]; then
+            BROKER_FRESH=0
+        else
+            restart_broker
+        fi
         start_monitors
         run_bench_split "$experiment" "$run_label" "$bench_args"
         stop_monitors "$output_dir" "$run_label"

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -45,27 +45,36 @@ BROKER_FRESH=0
 start_broker() {
     local extra_flags="${1:-}"
     BROKER_FLAGS="$extra_flags"
-    echo "starting broker on ${BROKER_IP} (group ${GROUP})..."
-    BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
-        ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!")
-    sleep 2
-    if ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
-        echo "broker pid: ${BROKER_PID}"
-    else
-        echo "ERROR: broker ${BROKER_PID} not running after start (see /tmp/broker.log on ${BROKER_IP})" >&2
-    fi
-    BROKER_FRESH=1
+    local attempt
+    for attempt in 1 2 3; do
+        echo "starting broker on ${BROKER_IP} (group ${GROUP}) [attempt ${attempt}]..."
+        BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
+            ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!") || BROKER_PID=""
+        sleep 2
+        if [ -n "${BROKER_PID}" ] && ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
+            echo "broker pid: ${BROKER_PID}"
+            BROKER_FRESH=1
+            return 0
+        fi
+        echo "WARN: broker not running after start attempt ${attempt} (see /tmp/broker.log on ${BROKER_IP})" >&2
+        ssh_broker "pkill -f '[m]qttv5 broker'" 2>/dev/null || true
+        sleep 1
+    done
+    echo "ERROR: broker failed to start after 3 attempts on ${BROKER_IP}" >&2
+    return 1
 }
 
 stop_broker() {
     echo "stopping broker (group ${GROUP})..."
-    ssh_broker "pkill -f 'mqttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f 'mqttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
+    ssh_broker "pkill -f '[m]qttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f '[m]qttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
     BROKER_PID=""
 }
 
 restart_broker() {
     stop_broker
-    start_broker "$BROKER_FLAGS"
+    if ! start_broker "$BROKER_FLAGS"; then
+        return 1
+    fi
     BROKER_FRESH=0
 }
 
@@ -101,14 +110,20 @@ stop_monitors() {
     ssh_sub "kill ${SUB_MONITOR_PID}" 2>/dev/null || true
 
     scp -i "$SSH_KEY_PATH" "${SSH_USER}@${BROKER_SSH_IP}:/tmp/monitor.csv" \
-        "${output_dir}/${run_label}_broker_resources.csv"
+        "${output_dir}/${run_label}_broker_resources.csv" || true
     scp -i "$SSH_KEY_PATH" "${SSH_USER}@${PUB_IP}:/tmp/client_monitor.csv" \
-        "${output_dir}/${run_label}_pub_resources.csv"
-    scp_from_sub "/tmp/client_monitor.csv" "${output_dir}/${run_label}_sub_resources.csv"
+        "${output_dir}/${run_label}_pub_resources.csv" || true
+    scp_from_sub "/tmp/client_monitor.csv" "${output_dir}/${run_label}_sub_resources.csv" || true
 
     BROKER_MONITOR_PID=""
     PUB_MONITOR_PID=""
     SUB_MONITOR_PID=""
+}
+
+warn_if_empty() {
+    if [ ! -s "$1" ]; then
+        echo "WARN: empty result $1 (broker down or bench failed)" >&2
+    fi
 }
 
 run_bench_pub_only() {
@@ -121,6 +136,7 @@ run_bench_pub_only() {
 
     echo "  running (pub-only): mqttv5 bench ${bench_args}"
     ssh_pub "ulimit -n 65536; mqttv5 bench ${bench_args}" > "${output_dir}/${label}.json" 2>/dev/null || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 
@@ -169,7 +185,8 @@ run_bench_split() {
         waited=$((waited + 2))
     done
 
-    scp_from_sub "/tmp/sub_bench.json" "${output_dir}/${label}.json"
+    scp_from_sub "/tmp/sub_bench.json" "${output_dir}/${label}.json" || true
+    warn_if_empty "${output_dir}/${label}.json"
     echo "  saved: ${output_dir}/${label}.json"
 }
 
@@ -185,8 +202,9 @@ run_monitored_pub_only() {
         local run_label="${label}_run${run}"
         if [ "$BROKER_FRESH" = "1" ]; then
             BROKER_FRESH=0
-        else
-            restart_broker
+        elif ! restart_broker; then
+            echo "WARN: broker restart failed, skipping ${run_label}" >&2
+            continue
         fi
         start_monitors
         run_bench_pub_only "$experiment" "$run_label" "$bench_args"
@@ -207,8 +225,9 @@ run_monitored_split() {
         local run_label="${label}_run${run}"
         if [ "$BROKER_FRESH" = "1" ]; then
             BROKER_FRESH=0
-        else
-            restart_broker
+        elif ! restart_broker; then
+            echo "WARN: broker restart failed, skipping ${run_label}" >&2
+            continue
         fi
         start_monitors
         run_bench_split "$experiment" "$run_label" "$bench_args"

--- a/publications/comnet/experiments/run/common.sh
+++ b/publications/comnet/experiments/run/common.sh
@@ -75,7 +75,7 @@ MONITOR_PID=""
 start_monitor() {
     local output_file="$1"
     MONITOR_PID=$(ssh_broker "nohup bash /opt/mqtt-lib/experiments/monitor/resource_monitor.sh ${BROKER_PID} \
-        > /tmp/monitor.csv 2>&1 & echo \$!")
+        > /tmp/monitor.csv 2>&1 & echo \$!") || MONITOR_PID=""
     echo "monitor pid: ${MONITOR_PID}"
 }
 
@@ -90,7 +90,7 @@ CLIENT_MONITOR_PID=""
 
 start_client_monitor() {
     CLIENT_MONITOR_PID=$(ssh_client "nohup bash /opt/mqtt-lib/experiments/monitor/client_monitor.sh \
-        > /tmp/client_monitor.csv 2>&1 & echo \$!")
+        > /tmp/client_monitor.csv 2>&1 & echo \$!") || CLIENT_MONITOR_PID=""
     echo "client monitor pid: ${CLIENT_MONITOR_PID}"
 }
 

--- a/publications/comnet/experiments/run/common.sh
+++ b/publications/comnet/experiments/run/common.sh
@@ -27,27 +27,36 @@ BROKER_FRESH=0
 start_broker() {
     local extra_flags="${1:-}"
     BROKER_FLAGS="$extra_flags"
-    echo "starting broker on ${BROKER_IP}..."
-    BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
-        ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!")
-    sleep 2
-    if ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
-        echo "broker pid: ${BROKER_PID}"
-    else
-        echo "ERROR: broker ${BROKER_PID} not running after start (see /tmp/broker.log on ${BROKER_IP})" >&2
-    fi
-    BROKER_FRESH=1
+    local attempt
+    for attempt in 1 2 3; do
+        echo "starting broker on ${BROKER_IP} [attempt ${attempt}]..."
+        BROKER_PID=$(ssh_broker "ulimit -n 65536; nohup mqttv5 broker --allow-anonymous --host 0.0.0.0:1883 --storage-backend memory --max-clients 50000 \
+            ${extra_flags} > /tmp/broker.log 2>&1 & echo \$!") || BROKER_PID=""
+        sleep 2
+        if [ -n "${BROKER_PID}" ] && ssh_broker "kill -0 ${BROKER_PID}" 2>/dev/null; then
+            echo "broker pid: ${BROKER_PID}"
+            BROKER_FRESH=1
+            return 0
+        fi
+        echo "WARN: broker not running after start attempt ${attempt} (see /tmp/broker.log on ${BROKER_IP})" >&2
+        ssh_broker "pkill -f '[m]qttv5 broker'" 2>/dev/null || true
+        sleep 1
+    done
+    echo "ERROR: broker failed to start after 3 attempts on ${BROKER_IP}" >&2
+    return 1
 }
 
 stop_broker() {
     echo "stopping broker..."
-    ssh_broker "pkill -f 'mqttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f 'mqttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
+    ssh_broker "pkill -f '[m]qttv5 broker' 2>/dev/null; for _ in \$(seq 1 20); do pgrep -f '[m]qttv5 broker' >/dev/null 2>&1 || break; sleep 0.5; done" || true
     BROKER_PID=""
 }
 
 restart_broker() {
     stop_broker
-    start_broker "$BROKER_FLAGS"
+    if ! start_broker "$BROKER_FLAGS"; then
+        return 1
+    fi
     BROKER_FRESH=0
 }
 
@@ -73,7 +82,7 @@ start_monitor() {
 stop_monitor() {
     local output_file="$1"
     ssh_broker "kill ${MONITOR_PID}" 2>/dev/null || true
-    scp -i "$SSH_KEY_PATH" "${SSH_USER}@${BROKER_SSH_IP}:/tmp/monitor.csv" "$output_file"
+    scp -i "$SSH_KEY_PATH" "${SSH_USER}@${BROKER_SSH_IP}:/tmp/monitor.csv" "$output_file" || true
     MONITOR_PID=""
 }
 
@@ -88,8 +97,14 @@ start_client_monitor() {
 stop_client_monitor() {
     local output_file="$1"
     ssh_client "kill ${CLIENT_MONITOR_PID}" 2>/dev/null || true
-    scp -i "$SSH_KEY_PATH" "${SSH_USER}@${CLIENT_IP}:/tmp/client_monitor.csv" "$output_file"
+    scp -i "$SSH_KEY_PATH" "${SSH_USER}@${CLIENT_IP}:/tmp/client_monitor.csv" "$output_file" || true
     CLIENT_MONITOR_PID=""
+}
+
+warn_if_empty() {
+    if [ ! -s "$1" ]; then
+        echo "WARN: empty result $1 (broker down or bench failed)" >&2
+    fi
 }
 
 run_bench() {
@@ -102,7 +117,8 @@ run_bench() {
     local output_file="${output_dir}/${label}.json"
 
     echo "  running: mqttv5 bench ${bench_args}"
-    ssh_client "ulimit -n 65536; mqttv5 bench ${bench_args}" > "$output_file" 2>/dev/null
+    ssh_client "ulimit -n 65536; mqttv5 bench ${bench_args}" > "$output_file" 2>/dev/null || true
+    warn_if_empty "$output_file"
     echo "  saved: ${output_file}"
 }
 
@@ -130,8 +146,9 @@ run_monitored() {
         local run_label="${label}_run${run}"
         if [ "$BROKER_FRESH" = "1" ]; then
             BROKER_FRESH=0
-        else
-            restart_broker
+        elif ! restart_broker; then
+            echo "WARN: broker restart failed, skipping ${run_label}" >&2
+            continue
         fi
         start_monitor "${output_dir}/${run_label}_broker_resources.csv"
         start_client_monitor


### PR DESCRIPTION
## What

Restarts the mqttv5 broker per run across the whole parallel bench harness and hardens the start/stop/result-collection path in both harnesses (`parallel/common_parallel.sh` and `run/common.sh`), so the Computer Networks re-runs measure each datapoint against a fresh broker without silently recording garbage or aborting mid-sweep.

## Why

The re-runs execute through the `parallel/` harness. Starting from the per-run-restart port (#137 covered only `run/`), a high-effort review plus a 39-agent adversarial quorum surfaced a cluster of defects — several in the initial hardening itself — that would corrupt experiment data or kill a multi-hour run.

## Fixes

**Per-run restart coverage**
- `common_parallel.sh`'s `run_monitored_*` loops now restart the broker every run (BROKER_FLAGS + BROKER_FRESH consume-once), matching `run/`.
- The HOL family and subscriber-flow experiments drive their own inline loops and were **not** covered by that; the same consume-or-restart block is now added to `02_hol_blocking_v5`, `02_hol_blocking_v5_fp`, `02b_hol_rtt_sweep_v5`, `02d_hol_rtt_boundary_v5`, `02e_hol_qos1_v5`, and `07_subscriber_flow_delivery`. Previously these ran ~60 runs against one broker, reintroducing exactly the state-decay contamination the re-run targets.

**Broker kill correctness**
- `stop_broker` used `pkill -f 'mqttv5 broker'`, which self-matched the remote ssh wrapper shell (its argv contains the pattern) and killed it before the drain loop ran — defeating the wait entirely. Now uses the bracket trick `[m]qttv5 broker` in both harnesses.

**Robustness under `set -euo pipefail`**
- `start_broker`'s `BROKER_PID=$(ssh_broker …)` assignment now has `|| BROKER_PID=""`, so a transient ssh failure no longer aborts the retry loop before it can retry.
- `start_broker` retries 3× and `return 1` (was `exit 1`); per-run restart is fail-soft — a transient restart failure skips that one run instead of killing the whole experiment. A genuinely un-startable broker still aborts at the initial start (before any netem is applied, so netem is never left configured).
- Added `|| true` to the `run/` `run_bench` and to the `stop_monitors` scp calls, so a nonzero bench under loss or a transient scp no longer aborts the sweep (and `clear_netem` still runs).

**Silent bad data**
- `warn_if_empty` now flags any empty result JSON at collection time instead of silently saving it as a datapoint.

**netem restart-under-loss**
- netem is applied whole-NIC on the broker, so a per-run restart's ssh control ops crossed the degraded link. `restart_broker` now clears netem, restarts the broker on a clean link, and restores netem (tracked via `CUR_NETEM_*`), cutting degraded-link ssh ops from ~3 to 1. Unit-tested for ordering (`CLEAR,STOP,START,APPLY` when active; `STOP,START` when not).

**Exp-4 topic mapping and delivery strategy (§1.5)**
- `04_stream_strategies_v5.sh` passed `--publishers ${ntopics} --subscribers ${ntopics}` — N connections of one topic each, a config in which the stream strategies are structurally identical. It now runs `--publishers 1 --topics ${ntopics} --subscribers 1` (N topics on one connection), which C5 enables and which makes control-only / per-publish / per-topic finally distinguishable. The non-functional `--mode latency` variant (single-topic; ignored `--topics`/`--publishers`, so identical across strategies) is removed; per-topic isolation is measured by the HOL family, and `fig14_strategy_comparison.py` is now a single throughput panel (the orphaned latency panel removed).
- The broker was started once without `--quic-delivery-strategy`, so only the client publish path varied while broker→subscriber delivery stayed default for all three strategies. The broker now restarts per strategy with `--quic-delivery-strategy ${strategy}` (mirroring the HOL scripts), so both the publish and delivery paths are differentiated.

**Remaining fail-soft / hardening gaps (from a follow-up review)**
- `01_connection_latency_v5.sh`'s inline quic loop called `start_broker` bare, which (now `return 1`) would abort the whole run under `set -e`; converted to the fail-soft netem-aware `restart_broker` pattern.
- The monitor-start command substitutions (`*_MONITOR_PID=$(ssh_* …)`) were unguarded under `set -e`; now `|| VAR=""` in both harnesses, matching the `BROKER_PID` guard.
- `warn_if_empty` was wired only into the shared `run_bench_*`; it is now also called from the HOL/07 `run_hol_colocated`, the functions the per-run-restart change actually added.

## Verification

- All run/parallel scripts pass `bash -n`; shellcheck reports only pre-existing notices (intentional `$SSH_OPTS` word-splitting, non-constant source, `sed` style) — the changed functions add none.
- The bracket-trick regex was checked to match the real broker command line but not the wrapper shell.
- A mock-`ssh_broker` unit test validates the state machine: retry-recovery after transient failures, no `set -e` abort when every ssh fails, and fail-soft skip (broker breaks mid-sweep → runs skipped, not aborted) — 7/7 checks.

The remote `/proc`/ssh paths run only on the Linux bench VMs, exercised end-to-end during provisioning.

## Not included / flagged

- HOL uses per-run restart here for consistency with the throughput family.
- The pre-existing `$SSH_OPTS` `SC2086` (intentional word-splitting) is left as-is.
