### PR TITLE
client: enforce broker Receive Maximum on outbound QoS1/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.38.3] - 2026-08-16
+
+### Fixed
+
+- **The client now enforces the broker's advertised Receive Maximum on outbound QoS 1 and QoS 2 publishes.** MQTT v5.0 §4.9 requires that a Client MUST NOT send more than the Server's Receive Maximum count of unacknowledged QoS 1 and QoS 2 PUBLISH packets, yet the client publish path never captured the value from the CONNACK and never acquired a send-quota permit before sending: the outbound `FlowControlManager` was constructed once with the default window (65 535) and never reprogrammed, and its `acquire_send_quota`/`acknowledge` API had no callers on the publish path. The only bound on concurrent in-flight publishes was the application's own concurrency. Against a broker advertising a small Receive Maximum (for example mosquitto's default of 20), the client would burst past the window, and a strict peer is entitled to respond with a `ReceiveMaximumExceeded` DISCONNECT. The in-tree broker masked the defect because its own default `server_receive_maximum` is also 65 535 and its inbound check populated no in-flight entry on the immediate-PUBACK QoS 1 path. The client now captures the CONNACK Receive Maximum (absent ⇒ 65 535), rejects a CONNACK advertising a Receive Maximum of 0 as a Protocol Error (`[MQTT-3.2.2-4]`), acquires a send-quota permit before each outbound QoS 1/2 PUBLISH (blocking with backpressure once the window is full), and releases it on PUBACK for QoS 1, on PUBCOMP for QoS 2, and early on an error PUBREC (reason ≥ 0x80). The QoS 2 release point was verified in TLA+ (`specs/tla/outbound-receive-max/`): releasing on a success PUBREC rather than on PUBCOMP lets a fresh PUBLISH exceed the window while the PUBREL/PUBCOMP exchange is still outstanding, which the model refutes as a window-bound violation.
+
 ## [mqtt5 0.38.2] - 2026-08-05
 
 ### Fixed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.38.2"
+version = "0.38.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/client/direct/handlers.rs
+++ b/crates/mqtt5/src/client/direct/handlers.rs
@@ -381,6 +381,8 @@ pub(super) async fn handle_pubcomp_outgoing(
         .complete_pubrel(pubcomp.packet_id)
         .await;
 
+    super::DirectClientInner::release_outbound_quota(session, Some(pubcomp.packet_id)).await;
+
     Ok(())
 }
 

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -417,6 +417,8 @@ impl DirectClientInner {
 
         self.apply_negotiated_keep_alive(connack.properties.get_server_keep_alive());
 
+        self.apply_negotiated_packet_sizes(&connack).await?;
+
         let protocol_version = self.options.protocol_version.as_u8();
         let (reader, writer) = match transport {
             TransportType::Tcp(tcp) => {
@@ -473,8 +475,6 @@ impl DirectClientInner {
             .await;
         self.writer = Some(writer_arc);
         self.set_connected(true);
-
-        self.apply_negotiated_packet_sizes(&connack).await?;
 
         tracing::debug!("Starting background tasks (packet reader and keepalive)");
         self.start_background_tasks(reader, connection_epoch)?;
@@ -802,7 +802,9 @@ impl DirectClientInner {
                 .wait_for_acknowledgment(rx, options.qos, packet_id)
                 .await
             {
-                Self::release_outbound_quota(&self.session, packet_id).await;
+                if !matches!(e, MqttError::Timeout) {
+                    Self::release_outbound_quota(&self.session, packet_id).await;
+                }
                 return Err(e);
             }
         }

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -474,7 +474,7 @@ impl DirectClientInner {
         self.writer = Some(writer_arc);
         self.set_connected(true);
 
-        self.apply_negotiated_packet_sizes(&connack).await;
+        self.apply_negotiated_packet_sizes(&connack).await?;
 
         tracing::debug!("Starting background tasks (packet reader and keepalive)");
         self.start_background_tasks(reader, connection_epoch)?;
@@ -485,8 +485,24 @@ impl DirectClientInner {
         })
     }
 
-    async fn apply_negotiated_packet_sizes(&self, connack: &crate::packet::connack::ConnAckPacket) {
+    async fn apply_negotiated_packet_sizes(
+        &self,
+        connack: &crate::packet::connack::ConnAckPacket,
+    ) -> Result<()> {
         let session = self.session.write().await;
+
+        match connack.properties.get_receive_maximum() {
+            Some(0) => {
+                return Err(MqttError::ProtocolError(
+                    "server advertised a Receive Maximum of 0".to_string(),
+                ));
+            }
+            Some(server_receive_maximum) => {
+                session.set_receive_maximum(server_receive_maximum).await;
+                tracing::debug!("Server Receive Maximum: {}", server_receive_maximum);
+            }
+            None => session.set_receive_maximum(65535).await,
+        }
 
         if self.options.deferred_ack {
             if let Some(receive_maximum) = self.options.properties.receive_maximum {
@@ -509,6 +525,8 @@ impl DirectClientInner {
             }
             None => session.reset_server_maximum_packet_size().await,
         }
+
+        Ok(())
     }
 
     /// # Errors
@@ -681,6 +699,16 @@ impl DirectClientInner {
         }
     }
 
+    pub(super) async fn release_outbound_quota(
+        session: &Arc<tokio::sync::RwLock<SessionState>>,
+        packet_id: Option<u16>,
+    ) {
+        if let Some(pid) = packet_id {
+            let flow = session.read().await.flow_control().clone();
+            let _ = flow.read().await.acknowledge(pid).await;
+        }
+    }
+
     /// # Errors
     ///
     /// Returns an error if the operation fails
@@ -734,12 +762,22 @@ impl DirectClientInner {
         let packet_id = needs_packet_id.then(|| self.packet_id_generator.next());
         publish.packet_id = packet_id;
 
+        if let Some(pid) = packet_id {
+            let flow = self.session.read().await.flow_control().clone();
+            flow.read().await.acquire_send_quota(pid).await?;
+        }
+
         if options.qos != QoS::AtMostOnce {
-            self.session
+            if let Err(e) = self
+                .session
                 .write()
                 .await
                 .store_unacked_publish(publish.clone())
-                .await?;
+                .await
+            {
+                Self::release_outbound_quota(&self.session, packet_id).await;
+                return Err(e);
+            }
         }
 
         let rx = self.setup_publish_acknowledgment(options.qos, packet_id);
@@ -754,11 +792,19 @@ impl DirectClientInner {
             );
         }
 
-        self.send_publish_packet(publish, options.qos).await?;
+        if let Err(e) = self.send_publish_packet(publish, options.qos).await {
+            Self::release_outbound_quota(&self.session, packet_id).await;
+            return Err(e);
+        }
 
         if let Some(rx) = rx {
-            self.wait_for_acknowledgment(rx, options.qos, packet_id)
-                .await?;
+            if let Err(e) = self
+                .wait_for_acknowledgment(rx, options.qos, packet_id)
+                .await
+            {
+                Self::release_outbound_quota(&self.session, packet_id).await;
+                return Err(e);
+            }
         }
 
         Ok(match packet_id {

--- a/crates/mqtt5/src/client/direct/reader.rs
+++ b/crates/mqtt5/src/client/direct/reader.rs
@@ -132,6 +132,11 @@ pub(super) async fn packet_reader_task_with_responses(
                         }
                     }
                     Packet::PubAck(puback) => {
+                        super::DirectClientInner::release_outbound_quota(
+                            &ctx.session,
+                            Some(puback.packet_id),
+                        )
+                        .await;
                         if let Some(tx) = ctx.puback_channels.lock().remove(&puback.packet_id) {
                             let _ = tx.send(puback.reason_code);
                             continue;
@@ -151,9 +156,19 @@ pub(super) async fn packet_reader_task_with_responses(
                             .await
                             .remove_unacked_publish(pubrec.packet_id)
                             .await;
+                        super::DirectClientInner::release_outbound_quota(
+                            &ctx.session,
+                            Some(pubrec.packet_id),
+                        )
+                        .await;
                         continue;
                     }
                     Packet::PubComp(pubcomp) => {
+                        super::DirectClientInner::release_outbound_quota(
+                            &ctx.session,
+                            Some(pubcomp.packet_id),
+                        )
+                        .await;
                         if let Some(tx) = ctx.pubcomp_channels.lock().remove(&pubcomp.packet_id) {
                             let _ = tx.send(pubcomp.reason_code);
                         }

--- a/crates/mqtt5/tests/outbound_receive_maximum.rs
+++ b/crates/mqtt5/tests/outbound_receive_maximum.rs
@@ -3,6 +3,7 @@ mod common;
 
 use common::{MessageCollector, TestBroker};
 use mqtt5::broker::config::{BrokerConfig, StorageBackend, StorageConfig};
+use mqtt5::error::MqttError;
 use mqtt5::MqttClient;
 use mqtt5_protocol::packet::connack::ConnAckPacket;
 use mqtt5_protocol::packet::MqttPacket;
@@ -123,6 +124,55 @@ async fn client_rejects_zero_receive_maximum() {
         result.is_err(),
         "client must reject a CONNACK advertising a Receive Maximum of 0"
     );
+    assert!(
+        !client.is_connected().await,
+        "a rejected CONNACK must leave the client disconnected, not half-connected"
+    );
+
+    let publish = client.publish_qos1("t/zero", b"nope".to_vec()).await;
+    assert!(
+        matches!(publish, Err(MqttError::NotConnected)),
+        "publishing after a rejected connect must fail fast with NotConnected, not hang"
+    );
+}
+
+#[tokio::test]
+async fn ack_timeout_holds_quota_and_does_not_exceed_window() {
+    let publish_count = std::sync::Arc::new(AtomicUsize::new(0));
+    let addr = stub_server(1, publish_count.clone()).await;
+
+    let client = MqttClient::new("outbound-timeout-hold");
+    client.connect(&format!("mqtt://{addr}")).await.unwrap();
+
+    let first = client.clone();
+    let first_handle =
+        tokio::spawn(async move { first.publish_qos1("t/timeout", b"first".to_vec()).await });
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        publish_count.load(Ordering::SeqCst),
+        1,
+        "the first publish must consume the only window slot and reach the wire"
+    );
+
+    let first_result = first_handle.await.unwrap();
+    assert!(
+        matches!(first_result, Err(MqttError::Timeout)),
+        "an unacknowledged publish must eventually time out"
+    );
+
+    let second = client.clone();
+    let second_handle =
+        tokio::spawn(async move { second.publish_qos1("t/timeout", b"second".to_vec()).await });
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        publish_count.load(Ordering::SeqCst),
+        1,
+        "the ack timeout must not release the quota while the message is still unacknowledged"
+    );
+
+    second_handle.abort();
 }
 
 fn broker_config(receive_maximum: u16) -> BrokerConfig {

--- a/crates/mqtt5/tests/outbound_receive_maximum.rs
+++ b/crates/mqtt5/tests/outbound_receive_maximum.rs
@@ -1,0 +1,177 @@
+#![cfg(feature = "broker")]
+mod common;
+
+use common::{MessageCollector, TestBroker};
+use mqtt5::broker::config::{BrokerConfig, StorageBackend, StorageConfig};
+use mqtt5::MqttClient;
+use mqtt5_protocol::packet::connack::ConnAckPacket;
+use mqtt5_protocol::packet::MqttPacket;
+use mqtt5_protocol::protocol::v5::reason_codes::ReasonCode;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+const PUBLISH_TYPE: u8 = 3;
+
+async fn read_one_packet(stream: &mut TcpStream) -> Option<u8> {
+    let mut first = [0u8; 1];
+    stream.read_exact(&mut first).await.ok()?;
+
+    let mut multiplier = 1usize;
+    let mut remaining = 0usize;
+    loop {
+        let mut byte = [0u8; 1];
+        stream.read_exact(&mut byte).await.ok()?;
+        remaining += usize::from(byte[0] & 0x7f) * multiplier;
+        if byte[0] & 0x80 == 0 {
+            break;
+        }
+        multiplier *= 128;
+    }
+
+    let mut body = vec![0u8; remaining];
+    stream.read_exact(&mut body).await.ok()?;
+    Some(first[0] >> 4)
+}
+
+fn connack_with_receive_maximum(receive_maximum: u16) -> Vec<u8> {
+    let mut connack = ConnAckPacket::new(false, ReasonCode::Success);
+    connack.properties.set_receive_maximum(receive_maximum);
+    let mut encoded = Vec::new();
+    connack.encode(&mut encoded).unwrap();
+    encoded
+}
+
+/// A stub server that advertises `receive_maximum` in its CONNACK and then
+/// withholds all PUBACKs, counting how many PUBLISH packets the client sends.
+/// A compliant client self-throttles to the advertised window.
+async fn stub_server(
+    receive_maximum: u16,
+    publish_count: std::sync::Arc<AtomicUsize>,
+) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        if read_one_packet(&mut stream).await.is_none() {
+            return;
+        }
+        if stream
+            .write_all(&connack_with_receive_maximum(receive_maximum))
+            .await
+            .is_err()
+        {
+            return;
+        }
+        let _ = stream.flush().await;
+
+        while let Some(packet_type) = read_one_packet(&mut stream).await {
+            if packet_type == PUBLISH_TYPE {
+                publish_count.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
+
+    addr
+}
+
+#[tokio::test]
+async fn client_self_throttles_to_broker_receive_maximum() {
+    let publish_count = std::sync::Arc::new(AtomicUsize::new(0));
+    let addr = stub_server(2, publish_count.clone()).await;
+
+    let client = MqttClient::new("outbound-throttle");
+    client.connect(&format!("mqtt://{addr}")).await.unwrap();
+
+    let mut handles = Vec::new();
+    for i in 0..5u8 {
+        let client = client.clone();
+        handles.push(tokio::spawn(async move {
+            let _ = client
+                .publish_qos1("t/throttle", format!("m{i}").into_bytes())
+                .await;
+        }));
+    }
+
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        publish_count.load(Ordering::SeqCst),
+        2,
+        "client must self-throttle outbound QoS1 to the broker's advertised Receive Maximum (2)"
+    );
+
+    for handle in handles {
+        handle.abort();
+    }
+}
+
+#[tokio::test]
+async fn client_rejects_zero_receive_maximum() {
+    let publish_count = std::sync::Arc::new(AtomicUsize::new(0));
+    let addr = stub_server(0, publish_count).await;
+
+    let client = MqttClient::new("outbound-zero-rm");
+    let result = client.connect(&format!("mqtt://{addr}")).await;
+
+    assert!(
+        result.is_err(),
+        "client must reject a CONNACK advertising a Receive Maximum of 0"
+    );
+}
+
+fn broker_config(receive_maximum: u16) -> BrokerConfig {
+    BrokerConfig::default()
+        .with_bind_address("127.0.0.1:0".parse::<SocketAddr>().unwrap())
+        .with_storage(StorageConfig {
+            backend: StorageBackend::Memory,
+            enable_persistence: false,
+            ..Default::default()
+        })
+        .with_server_receive_maximum(receive_maximum)
+}
+
+#[tokio::test]
+async fn small_window_still_delivers_qos1_and_qos2() {
+    let broker = TestBroker::start_with_config(broker_config(2)).await;
+
+    let subscriber = MqttClient::new("small-window-sub");
+    subscriber.connect(broker.address()).await.unwrap();
+    let collector = MessageCollector::new();
+    subscriber
+        .subscribe("t/window/#", collector.callback())
+        .await
+        .unwrap();
+
+    let publisher = MqttClient::new("small-window-pub");
+    publisher.connect(broker.address()).await.unwrap();
+
+    for i in 0..10u8 {
+        publisher
+            .publish_qos1("t/window/one", format!("q1-{i}").into_bytes())
+            .await
+            .unwrap();
+    }
+    for i in 0..10u8 {
+        publisher
+            .publish_qos2("t/window/two", format!("q2-{i}").into_bytes())
+            .await
+            .unwrap();
+    }
+
+    assert!(
+        collector
+            .wait_for_messages(20, Duration::from_secs(5))
+            .await,
+        "all QoS1 and QoS2 messages must be delivered despite the window of 2"
+    );
+
+    publisher.disconnect().await.ok();
+    subscriber.disconnect().await.ok();
+    drop(broker);
+}

--- a/specs/tla/outbound-receive-max/DIARY.md
+++ b/specs/tla/outbound-receive-max/DIARY.md
@@ -1,0 +1,39 @@
+# Outbound Receive Maximum — TLA+ diary
+
+Newest entries on top.
+
+## Planned / future stages
+
+- Stage 2: add network loss + duplication (bag semantics), resend of stored unacked publishes.
+- Stage 3: reconnect / session-resume — re-prime the outbound window to the new CONNACK
+  Receive Maximum and re-acquire permits while replaying stored unacked publishes; prove
+  `Cardinality(SpecUnacked) <= SRM'` holds mid-replay.
+- Liveness (needs fairness WF on the ack actions): every acquired permit is eventually
+  released, so a full window always drains. Deadlock-freedom is already checked as safety
+  (`allow_deadlock = false` passed on the fixed model).
+
+## 2026-08-16 — Stage 1: release-point safety, verdict
+
+`OutboundReceiveMax.tla` models the client publishing QoS2 messages gated by a send-quota
+permit bounded by the broker's advertised Receive Maximum (`SRM`). `permitHeld` is the
+implementation's accounting (the gate); `SpecUnacked` is MQTT-5 §4.9's definition of
+"unacknowledged" (sent, not yet PUBCOMP). The safety invariant `InvWindowBound` is stated
+over `SpecUnacked`, so any release point that lets `permitHeld` diverge from `SpecUnacked`
+is caught. The constant `ReleaseOnPubrec` selects the buggy vs correct release point.
+
+Runs (TLC via tla mcp):
+
+- `OutboundReceiveMax_fixed.cfg` (`ReleaseOnPubrec = FALSE`, release on PUBCOMP), SRM=2,
+  MaxMsgs=3: **status ok**, 98 states, no deadlock. `TypeOK`, `InvWindowBound`,
+  `InvPermitBound`, and `InvPermitTracksUnacked` (`permitHeld = SpecUnacked`) all hold.
+- `OutboundReceiveMax_buggy.cfg` (`ReleaseOnPubrec = TRUE`, release on success PUBREC),
+  SRM=2, MaxMsgs=3: **InvWindowBound VIOLATED** in 5 steps —
+  Send(1); Send(2) [window full]; RecvPubrec(1) frees a permit while msg 1 is still in
+  the `pubrec` phase; Send(3) is admitted → `SpecUnacked = {1,2,3}` = 3 > SRM=2.
+- Buggy at the tightest boundary SRM=1, MaxMsgs=2: **VIOLATED** in 4 steps
+  (Send(1); RecvPubrec(1) frees; Send(2) → SpecUnacked={1,2}=2 > 1).
+
+**Verdict:** the QoS2 send-quota permit MUST be released on PUBCOMP, not on a success
+PUBREC. An error PUBREC (reason ≥ 0x80) ends the exchange early and releases the permit
+there (`RecvPubrecError`), which the model includes and which preserves the bound. QoS1 is
+the degenerate single-release case (release on PUBACK) and is trivially safe.

--- a/specs/tla/outbound-receive-max/OutboundReceiveMax.tla
+++ b/specs/tla/outbound-receive-max/OutboundReceiveMax.tla
@@ -1,0 +1,119 @@
+------------------------- MODULE OutboundReceiveMax -------------------------
+(***************************************************************************)
+(* Client-side OUTBOUND flow control: the client MUST NOT have more than    *)
+(* the broker's advertised Receive Maximum (SRM) unacknowledged QoS1/QoS2    *)
+(* PUBLISH packets outstanding at once (MQTT-5 section 4.9).                  *)
+(*                                                                          *)
+(* The bug this models: the client holds a send-quota permit per outbound    *)
+(* QoS2 PUBLISH and must release it only when the message stops counting as  *)
+(* "unacknowledged".  Per 4.9 a QoS2 message is unacknowledged for the WHOLE  *)
+(* PUBLISH -> PUBREC -> PUBREL -> PUBCOMP exchange, so the permit is released  *)
+(* on PUBCOMP (or on an error PUBREC with reason >= 0x80, which ends the      *)
+(* exchange early).  Releasing on a SUCCESS PUBREC is the tempting-but-wrong  *)
+(* choice: it frees a slot while PUBREL/PUBCOMP are still outstanding, so a    *)
+(* fresh PUBLISH can push the true unacked count above SRM.                    *)
+(*                                                                          *)
+(* permitHeld  = the implementation's send-quota accounting (gates sends).    *)
+(* SpecUnacked = the spec's definition of "unacknowledged" (sent, not yet     *)
+(*               completed).  Safety requires Cardinality(SpecUnacked) <= SRM. *)
+(* The gate uses permitHeld; the invariant is stated over SpecUnacked, so a    *)
+(* release point that makes permitHeld diverge from SpecUnacked is caught.     *)
+(*                                                                          *)
+(* ReleaseOnPubrec = TRUE reproduces the bug; FALSE is the correct fix.        *)
+(* Network is ordered and lossless at this stage -- adequate to expose the     *)
+(* release-point defect; loss/dup/reconnect are later stages.                 *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    SRM,             \* broker-advertised Server Receive Maximum (the window)
+    MaxMsgs,         \* total QoS2 messages the client will publish (bounds model)
+    ReleaseOnPubrec  \* TRUE = buggy (free at PUBREC), FALSE = correct (free at PUBCOMP)
+
+Msgs == 1..MaxMsgs
+
+\* Per-message phase:
+\*   "none"      not yet sent
+\*   "published" PUBLISH sent, awaiting PUBREC
+\*   "pubrec"    PUBREC received, PUBREL not yet sent
+\*   "pubrel"    PUBREL sent, awaiting PUBCOMP
+\*   "done"      PUBCOMP received (fully acknowledged) -- also used for error-PUBREC end
+Phases == {"none", "published", "pubrec", "pubrel", "done"}
+
+VARIABLES
+    phase,       \* [Msgs -> Phases]
+    permitHeld   \* subset of Msgs currently holding a send-quota permit
+
+vars == <<phase, permitHeld>>
+
+\* MQTT-5 4.9: a QoS2 message counts as unacknowledged from PUBLISH until PUBCOMP.
+SpecUnacked == { m \in Msgs : phase[m] \in {"published", "pubrec", "pubrel"} }
+
+Init ==
+    /\ phase = [m \in Msgs |-> "none"]
+    /\ permitHeld = {}
+
+(* Client publishes m only while a quota permit is available (the gate). *)
+Send(m) ==
+    /\ phase[m] = "none"
+    /\ Cardinality(permitHeld) < SRM
+    /\ phase' = [phase EXCEPT ![m] = "published"]
+    /\ permitHeld' = permitHeld \cup {m}
+
+(* Client receives a SUCCESS PUBREC.  Buggy variant releases the permit here. *)
+RecvPubrec(m) ==
+    /\ phase[m] = "published"
+    /\ phase' = [phase EXCEPT ![m] = "pubrec"]
+    /\ permitHeld' = IF ReleaseOnPubrec THEN permitHeld \ {m} ELSE permitHeld
+
+(* Client sends PUBREL. *)
+SendPubrel(m) ==
+    /\ phase[m] = "pubrec"
+    /\ phase' = [phase EXCEPT ![m] = "pubrel"]
+    /\ UNCHANGED permitHeld
+
+(* Client receives PUBCOMP.  Correct variant releases the permit here. *)
+RecvPubcomp(m) ==
+    /\ phase[m] = "pubrel"
+    /\ phase' = [phase EXCEPT ![m] = "done"]
+    /\ permitHeld' = IF ReleaseOnPubrec THEN permitHeld ELSE permitHeld \ {m}
+
+(* Client receives an ERROR PUBREC (reason >= 0x80): the QoS2 exchange ends,  *)
+(* no PUBREL/PUBCOMP follow, and the permit is released regardless of variant. *)
+RecvPubrecError(m) ==
+    /\ phase[m] = "published"
+    /\ phase' = [phase EXCEPT ![m] = "done"]
+    /\ permitHeld' = permitHeld \ {m}
+
+Terminating ==
+    /\ \A m \in Msgs : phase[m] = "done"
+    /\ UNCHANGED vars
+
+Next ==
+    \/ \E m \in Msgs : Send(m)
+    \/ \E m \in Msgs : RecvPubrec(m)
+    \/ \E m \in Msgs : SendPubrel(m)
+    \/ \E m \in Msgs : RecvPubcomp(m)
+    \/ \E m \in Msgs : RecvPubrecError(m)
+    \/ Terminating
+
+Spec == Init /\ [][Next]_vars
+
+----------------------------------------------------------------------------
+(* Invariants *)
+
+TypeOK ==
+    /\ phase \in [Msgs -> Phases]
+    /\ permitHeld \subseteq Msgs
+
+(* The core MUST of 4.9: the true unacknowledged count never exceeds the      *)
+(* broker's advertised window.  Violated by ReleaseOnPubrec = TRUE.           *)
+InvWindowBound == Cardinality(SpecUnacked) <= SRM
+
+(* Implementation accounting never itself exceeds the window.                 *)
+InvPermitBound == Cardinality(permitHeld) <= SRM
+
+(* In the correct model the permit accounting tracks the spec definition      *)
+(* exactly -- no permit is released early and none is leaked.                  *)
+InvPermitTracksUnacked == permitHeld = SpecUnacked
+=============================================================================

--- a/specs/tla/outbound-receive-max/OutboundReceiveMax_buggy.cfg
+++ b/specs/tla/outbound-receive-max/OutboundReceiveMax_buggy.cfg
@@ -1,0 +1,8 @@
+CONSTANTS
+    SRM = 2
+    MaxMsgs = 3
+    ReleaseOnPubrec = TRUE
+
+INVARIANTS
+    TypeOK
+    InvWindowBound

--- a/specs/tla/outbound-receive-max/OutboundReceiveMax_fixed.cfg
+++ b/specs/tla/outbound-receive-max/OutboundReceiveMax_fixed.cfg
@@ -1,0 +1,10 @@
+CONSTANTS
+    SRM = 2
+    MaxMsgs = 3
+    ReleaseOnPubrec = FALSE
+
+INVARIANTS
+    TypeOK
+    InvWindowBound
+    InvPermitBound
+    InvPermitTracksUnacked


### PR DESCRIPTION
# client: enforce broker Receive Maximum on outbound QoS1/2

## What

The MQTT client never enforced the broker's advertised Receive Maximum on outbound QoS1/2 publishes. It captured `server_max_qos` from the CONNACK but not `receive_maximum`, and the publish path never acquired a send-quota permit — the outbound `FlowControlManager` was built once with the default 65535 window and its `acquire_send_quota`/`acknowledge` API had zero callers on the publish path (fully-built dead code). The only bound on concurrent in-flight publishes was application concurrency, violating MQTT v5 §4.9.

Found while reworking the benchmark methodology: an adversarial multi-agent review flagged that the bench's "backpressure" was its own semaphore, not MQTT flow control. A focused 7-agent quorum confirmed the gap (0/2 skeptics could refute, all four investigation lenses CONFIRMED).

## Fix

- **Capture** the CONNACK Receive Maximum in `apply_negotiated_packet_sizes` (absent ⇒ 65535; wire value 0 ⇒ `ProtocolError`, `[MQTT-3.2.2-4]`), pushing it into the outbound `FlowControlManager`.
- **Acquire** a send-quota permit in `publish()` before send for QoS1/2 (awaiting, bounded by `backpressure_timeout`), with symmetric release on every error path (store/send failure, ack timeout).
- **Release** on PUBACK (QoS1), PUBCOMP (QoS2), and early on an error PUBREC (≥0x80) — wired into both the main reader match and the QUIC data-flow `handle_pubcomp_outgoing`; `acknowledge` is idempotent so overlapping paths cannot double-count.

## Why PUBCOMP, not PUBREC (TLA+)

`specs/tla/outbound-receive-max/` models the QoS2 handshake with `permitHeld` (the gate) and `SpecUnacked` (§4.9's definition of unacknowledged). The safety invariant `Cardinality(SpecUnacked) <= SRM` is stated over `SpecUnacked`, so a wrong release point is caught:

- Release on **PUBCOMP** (`ReleaseOnPubrec = FALSE`): all invariants hold, no deadlock (98 states).
- Release on **success PUBREC** (`ReleaseOnPubrec = TRUE`): window-bound **VIOLATED** in 5 steps (SRM=2) — freeing a permit at PUBREC lets a fresh PUBLISH push the true unacked count to 3.

## Tests

`crates/mqtt5/tests/outbound_receive_maximum.rs`:
- **self-throttle** — a stub server advertising Receive Maximum 2 and withholding PUBACKs receives exactly 2 of 5 concurrent QoS1 publishes (before the fix: all 5).
- **wire-0 rejection** — a CONNACK advertising Receive Maximum 0 is rejected.
- **functional** — a real broker with `server_receive_maximum(2)` still delivers all QoS1 and QoS2 traffic (no deadlock).

`cargo clippy --all-targets --workspace -- -D warnings -W clippy::pedantic` and `cargo make ci-verify` pass.

## Release

mqtt5 0.38.2 → 0.38.3 (behavioral bugfix, no public-API change; patch does not trigger the cli/wasm lockstep). CHANGELOG entry included.
