### PR TITLE
watch linked auth files for hot-reload

### DIFF
--- a/crates/mqtt5/src/broker/hot_reload.rs
+++ b/crates/mqtt5/src/broker/hot_reload.rs
@@ -7,6 +7,7 @@ use crate::broker::config::BrokerConfig;
 use crate::error::{MqttError, Result};
 use crate::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
@@ -66,6 +67,8 @@ pub struct HotReloadManager {
     watcher_handle: Option<tokio::task::JoinHandle<()>>,
     /// Last known file modification time
     last_modified: Arc<RwLock<Option<crate::time::SystemTime>>>,
+    /// Last known modification times of linked auth files (ACL, password, SCRAM)
+    linked_mtimes: Arc<RwLock<HashMap<PathBuf, crate::time::SystemTime>>>,
     /// Configuration hash for change detection
     config_hash: Arc<RwLock<u64>>,
 }
@@ -86,6 +89,7 @@ impl HotReloadManager {
             change_sender,
             watcher_handle: None,
             last_modified: Arc::new(RwLock::new(None)),
+            linked_mtimes: Arc::new(RwLock::new(HashMap::new())),
             config_hash: Arc::new(RwLock::new(initial_hash)),
         };
 
@@ -121,6 +125,7 @@ impl HotReloadManager {
     fn start_file_watcher(&self) -> tokio::task::JoinHandle<()> {
         let config_path = self.config_path.clone();
         let last_modified = self.last_modified.clone();
+        let linked_mtimes = self.linked_mtimes.clone();
         let config_hash = self.config_hash.clone();
         let current_config = self.current_config.clone();
         let change_sender = self.change_sender.clone();
@@ -184,10 +189,70 @@ impl HotReloadManager {
                         warn!("Error checking configuration file: {e}");
                     }
                 }
+
+                if let Some(changed) =
+                    Self::check_linked_files_changed(&current_config, &linked_mtimes).await
+                {
+                    info!("Linked auth file changed, reloading: {:?}", changed);
+                    let hash = *config_hash.read().await;
+                    let event = ConfigChangeEvent {
+                        timestamp: unix_timestamp_secs(),
+                        change_type: ConfigChangeType::AuthConfig,
+                        config_path: changed,
+                        previous_hash: hash,
+                        new_hash: hash,
+                    };
+                    if let Err(e) = change_sender.send(event) {
+                        warn!("Failed to send auth file change notification: {e}");
+                    }
+                }
             }
         });
 
         handle
+    }
+
+    fn linked_auth_files(config: &BrokerConfig) -> [Option<PathBuf>; 3] {
+        [
+            config.auth_config.acl_file.clone(),
+            config.auth_config.password_file.clone(),
+            config.auth_config.scram_file.clone(),
+        ]
+    }
+
+    async fn check_linked_files_changed(
+        current_config: &Arc<RwLock<BrokerConfig>>,
+        linked_mtimes: &Arc<RwLock<HashMap<PathBuf, crate::time::SystemTime>>>,
+    ) -> Option<PathBuf> {
+        let paths = {
+            let config = current_config.read().await;
+            Self::linked_auth_files(&config)
+        };
+
+        let mut mtimes = linked_mtimes.write().await;
+        let mut changed = None;
+
+        for path in paths.into_iter().flatten() {
+            let Ok(metadata) = fs::metadata(&path).await else {
+                continue;
+            };
+            let Ok(modified) = metadata.modified() else {
+                continue;
+            };
+
+            match mtimes.get(&path) {
+                Some(&last) if modified > last => {
+                    mtimes.insert(path.clone(), modified);
+                    changed = Some(path);
+                }
+                Some(_) => {}
+                None => {
+                    mtimes.insert(path, modified);
+                }
+            }
+        }
+
+        changed
     }
 
     /// Checks if the configuration file has been modified
@@ -577,5 +642,62 @@ mod tests {
             event.change_type,
             ConfigChangeType::ResourceLimits
         ));
+    }
+
+    #[tokio::test]
+    async fn test_linked_auth_file_first_sight_is_not_a_change() {
+        let acl = NamedTempFile::new().unwrap();
+        tokio::fs::write(acl.path(), "topic readwrite #\n")
+            .await
+            .unwrap();
+
+        let mut config = BrokerConfig::default();
+        config.auth_config.acl_file = Some(acl.path().to_path_buf());
+        let current = Arc::new(RwLock::new(config));
+        let mtimes = Arc::new(RwLock::new(HashMap::new()));
+
+        assert!(
+            HotReloadManager::check_linked_files_changed(&current, &mtimes)
+                .await
+                .is_none()
+        );
+        assert!(mtimes.read().await.contains_key(acl.path()));
+    }
+
+    #[tokio::test]
+    async fn test_linked_auth_file_change_detected() {
+        let acl = NamedTempFile::new().unwrap();
+        tokio::fs::write(acl.path(), "topic readwrite #\n")
+            .await
+            .unwrap();
+
+        let mut config = BrokerConfig::default();
+        config.auth_config.acl_file = Some(acl.path().to_path_buf());
+        let current = Arc::new(RwLock::new(config));
+        let mtimes = Arc::new(RwLock::new(HashMap::new()));
+        mtimes
+            .write()
+            .await
+            .insert(acl.path().to_path_buf(), UNIX_EPOCH);
+
+        let changed = HotReloadManager::check_linked_files_changed(&current, &mtimes).await;
+        assert_eq!(changed.as_deref(), Some(acl.path()));
+
+        let changed_again = HotReloadManager::check_linked_files_changed(&current, &mtimes).await;
+        assert!(changed_again.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_linked_auth_file_absent_is_ignored() {
+        let mut config = BrokerConfig::default();
+        config.auth_config.acl_file = Some(PathBuf::from("/nonexistent/acl.txt"));
+        let current = Arc::new(RwLock::new(config));
+        let mtimes = Arc::new(RwLock::new(HashMap::new()));
+
+        assert!(
+            HotReloadManager::check_linked_files_changed(&current, &mtimes)
+                .await
+                .is_none()
+        );
     }
 }

--- a/crates/mqtt5/src/broker/hot_reload.rs
+++ b/crates/mqtt5/src/broker/hot_reload.rs
@@ -67,8 +67,8 @@ pub struct HotReloadManager {
     watcher_handle: Option<tokio::task::JoinHandle<()>>,
     /// Last known file modification time
     last_modified: Arc<RwLock<Option<crate::time::SystemTime>>>,
-    /// Last known modification times of linked auth files (ACL, password, SCRAM)
-    linked_mtimes: Arc<RwLock<HashMap<PathBuf, crate::time::SystemTime>>>,
+    /// Last known content hashes of linked auth files (ACL, password, SCRAM)
+    linked_hashes: Arc<RwLock<HashMap<PathBuf, u64>>>,
     /// Configuration hash for change detection
     config_hash: Arc<RwLock<u64>>,
 }
@@ -89,7 +89,7 @@ impl HotReloadManager {
             change_sender,
             watcher_handle: None,
             last_modified: Arc::new(RwLock::new(None)),
-            linked_mtimes: Arc::new(RwLock::new(HashMap::new())),
+            linked_hashes: Arc::new(RwLock::new(HashMap::new())),
             config_hash: Arc::new(RwLock::new(initial_hash)),
         };
 
@@ -110,6 +110,16 @@ impl HotReloadManager {
             }
         }
 
+        let linked_paths = Self::linked_auth_files(&*self.current_config.read().await);
+        {
+            let mut hashes = self.linked_hashes.write().await;
+            for path in linked_paths.into_iter().flatten() {
+                if let Some(hash) = Self::hash_file(&path).await {
+                    hashes.insert(path, hash);
+                }
+            }
+        }
+
         // Start file system monitoring
         let watcher = self.start_file_watcher();
         self.watcher_handle = Some(watcher);
@@ -125,7 +135,7 @@ impl HotReloadManager {
     fn start_file_watcher(&self) -> tokio::task::JoinHandle<()> {
         let config_path = self.config_path.clone();
         let last_modified = self.last_modified.clone();
-        let linked_mtimes = self.linked_mtimes.clone();
+        let linked_hashes = self.linked_hashes.clone();
         let config_hash = self.config_hash.clone();
         let current_config = self.current_config.clone();
         let change_sender = self.change_sender.clone();
@@ -190,15 +200,12 @@ impl HotReloadManager {
                     }
                 }
 
-                if let Some(changed) =
-                    Self::check_linked_files_changed(&current_config, &linked_mtimes).await
-                {
-                    info!("Linked auth file changed, reloading: {:?}", changed);
+                if Self::check_linked_files_changed(&current_config, &linked_hashes).await {
                     let hash = *config_hash.read().await;
                     let event = ConfigChangeEvent {
                         timestamp: unix_timestamp_secs(),
                         change_type: ConfigChangeType::AuthConfig,
-                        config_path: changed,
+                        config_path: config_path.clone(),
                         previous_hash: hash,
                         new_hash: hash,
                     };
@@ -220,34 +227,40 @@ impl HotReloadManager {
         ]
     }
 
+    async fn hash_file(path: &Path) -> Option<u64> {
+        use std::hash::{Hash, Hasher};
+        let bytes = fs::read(path).await.ok()?;
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        bytes.hash(&mut hasher);
+        Some(hasher.finish())
+    }
+
     async fn check_linked_files_changed(
         current_config: &Arc<RwLock<BrokerConfig>>,
-        linked_mtimes: &Arc<RwLock<HashMap<PathBuf, crate::time::SystemTime>>>,
-    ) -> Option<PathBuf> {
+        linked_hashes: &Arc<RwLock<HashMap<PathBuf, u64>>>,
+    ) -> bool {
         let paths = {
             let config = current_config.read().await;
             Self::linked_auth_files(&config)
         };
 
-        let mut mtimes = linked_mtimes.write().await;
-        let mut changed = None;
+        let mut hashes = linked_hashes.write().await;
+        let mut changed = false;
 
         for path in paths.into_iter().flatten() {
-            let Ok(metadata) = fs::metadata(&path).await else {
-                continue;
-            };
-            let Ok(modified) = metadata.modified() else {
+            let Some(hash) = Self::hash_file(&path).await else {
                 continue;
             };
 
-            match mtimes.get(&path) {
-                Some(&last) if modified > last => {
-                    mtimes.insert(path.clone(), modified);
-                    changed = Some(path);
+            match hashes.get(&path) {
+                Some(&last) if hash != last => {
+                    info!("Linked auth file changed, reloading: {path:?}");
+                    hashes.insert(path, hash);
+                    changed = true;
                 }
                 Some(_) => {}
                 None => {
-                    mtimes.insert(path, modified);
+                    hashes.insert(path, hash);
                 }
             }
         }
@@ -654,14 +667,10 @@ mod tests {
         let mut config = BrokerConfig::default();
         config.auth_config.acl_file = Some(acl.path().to_path_buf());
         let current = Arc::new(RwLock::new(config));
-        let mtimes = Arc::new(RwLock::new(HashMap::new()));
+        let hashes = Arc::new(RwLock::new(HashMap::new()));
 
-        assert!(
-            HotReloadManager::check_linked_files_changed(&current, &mtimes)
-                .await
-                .is_none()
-        );
-        assert!(mtimes.read().await.contains_key(acl.path()));
+        assert!(!HotReloadManager::check_linked_files_changed(&current, &hashes).await);
+        assert!(hashes.read().await.contains_key(acl.path()));
     }
 
     #[tokio::test]
@@ -674,17 +683,16 @@ mod tests {
         let mut config = BrokerConfig::default();
         config.auth_config.acl_file = Some(acl.path().to_path_buf());
         let current = Arc::new(RwLock::new(config));
-        let mtimes = Arc::new(RwLock::new(HashMap::new()));
-        mtimes
-            .write()
+        let hashes = Arc::new(RwLock::new(HashMap::new()));
+
+        assert!(!HotReloadManager::check_linked_files_changed(&current, &hashes).await);
+
+        tokio::fs::write(acl.path(), "topic readwrite #\ntopic read $SYS/#\n")
             .await
-            .insert(acl.path().to_path_buf(), UNIX_EPOCH);
+            .unwrap();
 
-        let changed = HotReloadManager::check_linked_files_changed(&current, &mtimes).await;
-        assert_eq!(changed.as_deref(), Some(acl.path()));
-
-        let changed_again = HotReloadManager::check_linked_files_changed(&current, &mtimes).await;
-        assert!(changed_again.is_none());
+        assert!(HotReloadManager::check_linked_files_changed(&current, &hashes).await);
+        assert!(!HotReloadManager::check_linked_files_changed(&current, &hashes).await);
     }
 
     #[tokio::test]
@@ -692,12 +700,8 @@ mod tests {
         let mut config = BrokerConfig::default();
         config.auth_config.acl_file = Some(PathBuf::from("/nonexistent/acl.txt"));
         let current = Arc::new(RwLock::new(config));
-        let mtimes = Arc::new(RwLock::new(HashMap::new()));
+        let hashes = Arc::new(RwLock::new(HashMap::new()));
 
-        assert!(
-            HotReloadManager::check_linked_files_changed(&current, &mtimes)
-                .await
-                .is_none()
-        );
+        assert!(!HotReloadManager::check_linked_files_changed(&current, &hashes).await);
     }
 }


### PR DESCRIPTION
## Problem

Reported in [discussion #139](https://github.com/LabOverWire/mqtt-lib/discussions/139).

Broker config hot-reload watched only the main config file's mtime. Editing a *linked* auth file — the ACL file, password file, or SCRAM credential file referenced by the config — did not trigger a reload; the change was only picked up on the next config-file edit or a manual `SIGHUP`.

The reload path itself was already correct: on any reload, `create_auth_provider` re-reads the ACL/password/SCRAM files from disk. The only gap was that `HotReloadManager`'s watcher never noticed those files change.

## Fix

`HotReloadManager`'s file watcher now also checks the linked auth files derived from the current config (`auth_config.acl_file`, `auth_config.password_file`, `auth_config.scram_file`) each tick. When one's content changes, it emits a `ConfigChangeType::AuthConfig` event, which drives the same downstream reload that a config-file change or `SIGHUP` triggers — rebuilding the auth provider and re-reading the files.

Result: editing `acl.txt` (or the password/SCRAM file) now auto-reloads within the watcher's 5s interval, no `SIGHUP` needed.

Detection is **content-hash based** (not mtime): each linked file's bytes are hashed and compared, so changes are caught regardless of mtime granularity, mtime-preserving atomic renames, or restore-from-backup with an older timestamp. Baselines are **seeded in `start()`**, at the moment the auth provider is first built, so an edit during the first watcher interval is not silently absorbed.

- Fix lives in `HotReloadManager`, so both the library and the `mqttv5` CLI benefit automatically.
- Config-file handling is unchanged; the linked-file check is additive.
- First observation of each file records its hash without reporting a change, so startup never triggers a spurious reload.

## Scope / known limitation

- TLS certificate/key files are not watched — out of scope for this issue.
- Unchanged precondition: hot-reload (file-watch or `SIGHUP`) is active only when the broker is started with a `--config` file, and the linked-file path must be present in that config.
- **Detection commits the new baseline before the downstream reload runs** (the reload is decoupled in `server.rs`). If a *complete* linked file is written that `create_auth_provider` then rejects, and the file is never edited again, the broker keeps the previous auth provider. Any subsequent edit is re-detected (different content hash), so the common transient/partial-write case self-heals; only a persistently-rejected file sticks. This mirrors the existing config-file path's semantics. Tightening it to revert the baseline on reload failure needs reload-success feedback from `server.rs` and is a reasonable follow-up.

## Tests

Three deterministic unit tests added (content-based, no filesystem-timing sleeps):

- `test_linked_auth_file_first_sight_is_not_a_change`
- `test_linked_auth_file_change_detected`
- `test_linked_auth_file_absent_is_ignored`

All 7 `hot_reload` unit tests pass; `cargo clippy -p mqtt5 --lib -- -D warnings -W clippy::pedantic` and `cargo fmt --check` are clean.
