### PR TITLE
client connection events with disconnect reasons, remove on_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.39.0] - 2026-09-05
+
+### Breaking
+
+- **`ConnectionEvent`, `DisconnectReason`, and `ReasonCode` are now `#[non_exhaustive]`.** New reason codes and event variants stay additive from here on, so a `match` on any of these enums outside the crate needs a wildcard arm. `DisconnectReason::ServerClosed`, which nothing ever produced, is removed; a broker-initiated disconnect is now reported as `DisconnectReason::ServerDisconnect(ReasonCode)` carrying the broker's reason code.
+- **`MqttClient::on_error` and `MqttClient::clear_error_callbacks` are removed, along with the `ErrorCallback` type.** The registered callbacks were never invoked: the only place they could have been hooked is the reader error path, which now feeds `ConnectionEvent::Disconnected` with a reason, so wiring them would have reported the same failure twice. Use `on_connection_event` instead. Reported in issue #125.
+
+### Fixed
+
+- **The client now reports that a connection was lost, and why.** `ConnectionEvent::Disconnected` previously fired only for an application-initiated `disconnect()` and one custom-TLS connect-failure path; a dropped TCP connection, a broker `DISCONNECT`, or a keepalive timeout only flipped an internal flag, so a subscriber saw `Connected`, later another `Connected`, and never learned anything was lost in between. The packet reader now emits `Disconnected` when it terminates, with the reason derived from the cause: `ServerDisconnect(reason_code)` for a broker `DISCONNECT`, whose reason code was previously logged and discarded; `NetworkError` for a transport drop; `AuthFailure` for a failed re-authentication; `ProtocolError` otherwise. The keepalive task emits `Disconnected { KeepAliveTimeout }` on a missed `PINGRESP` and `NetworkError` when a `PINGREQ` cannot be written. Each connection emits at most one `Disconnected`: the transition is a compare-and-swap on the connection flag guarded by the connection epoch, so a client-initiated `disconnect()` reports only `ClientInitiated` and a stale task from a previous connection reports nothing. Reported in issue #123.
+- **`ConnectionEvent::Connecting` and `ConnectionEvent::ReconnectFailed` now fire.** Both were declared, documented, and matched in the examples, but the client never produced them. `Connecting` fires on the initial `connect` / `connect_with_options` (plain and TLS), `Reconnecting { attempt }` on each automatic retry, and `ReconnectFailed { error }` when the reconnection loop gives up for good, either because `max_attempts` was exhausted or because no address was recorded to reconnect to. Previously the monitor task exited silently in both cases and the client stayed offline with no signal. Reported in issue #123.
+- **A failed connect no longer emits `Disconnected` on the custom-TLS path.** `connect_with_tls_and_options` emitted `Disconnected { NetworkError }` when the initial connection failed, while the plain TCP path (correctly) emitted nothing, since the client was never connected. The two paths now agree.
+
+## [mqttv5-cli 0.28.6] - 2026-09-05
+
+### Changed
+
+- Depends on `mqtt5` 0.39, so the CLI's connection-event logging now sees `Connecting`, a reasoned `Disconnected`, and `ReconnectFailed`.
+
+## [mqtt5-wasm 1.4.5] - 2026-09-05
+
+### Changed
+
+- Depends on `mqtt5` 0.39 and `mqtt5-protocol` 0.15.
+
+## [mqtt5-protocol 0.15.0] - 2026-09-05
+
+### Breaking
+
+- **`ConnectionEvent`, `DisconnectReason`, and `ReasonCode` are `#[non_exhaustive]`; `DisconnectReason::ServerClosed` is replaced by `ServerDisconnect(ReasonCode)`.** See mqtt5 0.39.0.
+- **`MqttError::ServerDisconnect(ReasonCode)` is added.** The client's packet handlers return it for a broker-sent `DISCONNECT` instead of a `ConnectionError` built from a fixed string, so the reason code survives to the application.
+
 ## [mqtt5 0.38.5] - 2026-09-05
 
 ### Fixed

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.14.3"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-protocol/src/connection.rs
+++ b/crates/mqtt5-protocol/src/connection.rs
@@ -1,6 +1,7 @@
 use crate::error::MqttError;
 use crate::numeric::u128_to_u64_saturating;
 use crate::prelude::*;
+use crate::protocol::v5::reason_codes::ReasonCode;
 use crate::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -40,9 +41,10 @@ impl ConnectionState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum DisconnectReason {
     ClientInitiated,
-    ServerClosed,
+    ServerDisconnect(ReasonCode),
     NetworkError(String),
     ProtocolError(String),
     KeepAliveTimeout,
@@ -50,6 +52,7 @@ pub enum DisconnectReason {
 }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ConnectionEvent {
     Connecting,
     Connected {

--- a/crates/mqtt5-protocol/src/error.rs
+++ b/crates/mqtt5-protocol/src/error.rs
@@ -35,6 +35,9 @@ pub enum MqttError {
     #[cfg_attr(feature = "std", error("Connection refused: {0:?}"))]
     ConnectionRefused(ReasonCode),
 
+    #[cfg_attr(feature = "std", error("Server disconnected: {0:?}"))]
+    ServerDisconnect(ReasonCode),
+
     #[cfg_attr(feature = "std", error("Protocol error: {0}"))]
     ProtocolError(String),
 
@@ -208,6 +211,7 @@ impl fmt::Display for MqttError {
             Self::InvalidClientId(s) => write!(f, "Invalid client ID: {s}"),
             Self::ConnectionError(s) => write!(f, "Connection error: {s}"),
             Self::ConnectionRefused(r) => write!(f, "Connection refused: {r:?}"),
+            Self::ServerDisconnect(r) => write!(f, "Server disconnected: {r:?}"),
             Self::ProtocolError(s) => write!(f, "Protocol error: {s}"),
             Self::MalformedPacket(s) => write!(f, "Malformed packet: {s}"),
             Self::PacketTooLarge { size, max } => {

--- a/crates/mqtt5-protocol/src/protocol/v5/reason_codes.rs
+++ b/crates/mqtt5-protocol/src/protocol/v5/reason_codes.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ReasonCode {
     // Success codes (0x00 - 0x7F)
     Success = 0x00, // Also used for NormalDisconnection and GrantedQoS0

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.4.4"
+version = "1.4.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,8 +27,8 @@ broker = ["client", "dep:mqtt5", "mqtt5/broker", "dep:tokio"]
 codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
-mqtt5-protocol = "0.14.0"
-mqtt5 = { version = "0.38", optional = true, default-features = false, features = [
+mqtt5-protocol = "0.15.0"
+mqtt5 = { version = "0.39", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.38.5"
+version = "0.39.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -154,7 +154,7 @@ opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metric
 opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic", "metrics"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
-mqtt5-protocol = "0.14.0"
+mqtt5-protocol = "0.15.0"
 argon2 = { version = "0.5", optional = true }
 getrandom = "0.4.3"
 bebytes = { version = "3.0", features = ["bytes"] }

--- a/crates/mqtt5/examples/simple_client.rs
+++ b/crates/mqtt5/examples/simple_client.rs
@@ -89,6 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ConnectionEvent::ReconnectFailed { error } => {
                 println!("💥 Reconnection failed: {error}");
             }
+            _ => {}
         })
         .await?;
 

--- a/crates/mqtt5/src/client/builders.rs
+++ b/crates/mqtt5/src/client/builders.rs
@@ -51,11 +51,11 @@ impl MqttClient {
     pub fn with_options(options: ConnectOptions) -> Self {
         tracing::trace!(client_id = %options.client_id, "MQTT CLIENT - with_options() method called");
         let inner = DirectClientInner::new(options);
+        let connection_event_callbacks = Arc::clone(&inner.connection_event_callbacks);
 
         Self {
             inner: Arc::new(RwLock::new(inner)),
-            connection_event_callbacks: Arc::new(RwLock::new(Vec::new())),
-            error_callbacks: Arc::new(RwLock::new(Vec::new())),
+            connection_event_callbacks,
             error_recovery_config: Arc::new(RwLock::new(ErrorRecoveryConfig::default())),
             connection_mutex: Arc::new(tokio::sync::Mutex::new(())),
             tls_config: Arc::new(RwLock::new(None)),

--- a/crates/mqtt5/src/client/direct/handlers.rs
+++ b/crates/mqtt5/src/client/direct/handlers.rs
@@ -64,10 +64,9 @@ pub(super) async fn handle_incoming_packet_with_writer(
         Packet::PubRel(pubrel) => handle_pubrel(pubrel, writer, session).await,
         Packet::PubComp(pubcomp) => handle_pubcomp_outgoing(pubcomp, session).await,
         Packet::Disconnect(disconnect) => {
-            tracing::info!("Server sent DISCONNECT: {:?}", disconnect.reason_code);
-            Err(MqttError::ConnectionError(
-                "Server disconnected".to_string(),
-            ))
+            let reason_code = disconnect.reason_code;
+            tracing::info!("Server sent DISCONNECT: {reason_code:?}");
+            Err(MqttError::ServerDisconnect(reason_code))
         }
         _ => Ok(()),
     }
@@ -334,10 +333,9 @@ pub(super) async fn handle_incoming_packet_no_writer(
             Ok(())
         }
         Packet::Disconnect(disconnect) => {
-            tracing::info!("Server sent DISCONNECT: {:?}", disconnect.reason_code);
-            Err(MqttError::ConnectionError(
-                "Server disconnected".to_string(),
-            ))
+            let reason_code = disconnect.reason_code;
+            tracing::info!("Server sent DISCONNECT: {reason_code:?}");
+            Err(MqttError::ServerDisconnect(reason_code))
         }
         _ => Ok(()),
     }

--- a/crates/mqtt5/src/client/direct/keepalive.rs
+++ b/crates/mqtt5/src/client/direct/keepalive.rs
@@ -1,5 +1,7 @@
 //! Keepalive management and background tasks
 
+use crate::client::connection::{ConnectionEvent, DisconnectReason};
+use crate::client::ConnectionEventCallback;
 use crate::error::Result;
 use crate::packet::Packet;
 use crate::transport::PacketWriter;
@@ -58,13 +60,49 @@ pub(crate) fn owns_current_connection(
     current_connection_epoch.load(Ordering::SeqCst) == connection_epoch
 }
 
+#[must_use]
 pub(crate) fn mark_disconnected_if_current(
     connected: &AtomicBool,
     connection_epoch: u64,
     current_connection_epoch: &AtomicU64,
+) -> bool {
+    owns_current_connection(connection_epoch, current_connection_epoch)
+        && connected
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+}
+
+pub(crate) async fn fire_connection_event(
+    callbacks: &tokio::sync::RwLock<Vec<ConnectionEventCallback>>,
+    event: ConnectionEvent,
 ) {
-    if owns_current_connection(connection_epoch, current_connection_epoch) {
-        connected.store(false, Ordering::SeqCst);
+    let callbacks = callbacks.read().await.clone();
+    for callback in callbacks {
+        callback(event.clone());
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct ConnectionLifecycle {
+    pub(super) connected: Arc<AtomicBool>,
+    pub(super) connection_epoch: u64,
+    pub(super) current_connection_epoch: Arc<AtomicU64>,
+    pub(super) callbacks: Arc<tokio::sync::RwLock<Vec<ConnectionEventCallback>>>,
+}
+
+impl ConnectionLifecycle {
+    pub(super) fn owns_current_connection(&self) -> bool {
+        owns_current_connection(self.connection_epoch, &self.current_connection_epoch)
+    }
+
+    pub(super) async fn end(&self, reason: DisconnectReason) {
+        if mark_disconnected_if_current(
+            &self.connected,
+            self.connection_epoch,
+            &self.current_connection_epoch,
+        ) {
+            fire_connection_event(&self.callbacks, ConnectionEvent::Disconnected { reason }).await;
+        }
     }
 }
 
@@ -104,9 +142,7 @@ pub(super) async fn keepalive_task_with_writer(
     writer: Arc<tokio::sync::Mutex<UnifiedWriter>>,
     keepalive_interval: Duration,
     keepalive_state: Arc<Mutex<KeepaliveState>>,
-    connected: Arc<AtomicBool>,
-    connection_epoch: u64,
-    current_connection_epoch: Arc<AtomicU64>,
+    lifecycle: ConnectionLifecycle,
     keepalive_config: Option<mqtt5_protocol::KeepaliveConfig>,
 ) {
     let config = keepalive_config.unwrap_or_default();
@@ -120,17 +156,11 @@ pub(super) async fn keepalive_task_with_writer(
     loop {
         interval.tick().await;
 
-        {
-            let state = keepalive_state.lock();
-            if state.is_timeout(timeout_duration) {
-                tracing::error!("Keepalive timeout - no PINGRESP received");
-                mark_disconnected_if_current(
-                    &connected,
-                    connection_epoch,
-                    &current_connection_epoch,
-                );
-                break;
-            }
+        let timed_out = keepalive_state.lock().is_timeout(timeout_duration);
+        if timed_out {
+            tracing::error!("Keepalive timeout - no PINGRESP received");
+            lifecycle.end(DisconnectReason::KeepAliveTimeout).await;
+            break;
         }
 
         let should_send_ping = {
@@ -155,20 +185,18 @@ pub(super) async fn keepalive_task_with_writer(
             Ok(Ok(())) => {}
             Ok(Err(e)) => {
                 tracing::error!("Error sending PINGREQ: {e}");
-                mark_disconnected_if_current(
-                    &connected,
-                    connection_epoch,
-                    &current_connection_epoch,
-                );
+                lifecycle
+                    .end(DisconnectReason::NetworkError(e.to_string()))
+                    .await;
                 break;
             }
             Err(_) => {
                 tracing::error!("PINGREQ send timed out");
-                mark_disconnected_if_current(
-                    &connected,
-                    connection_epoch,
-                    &current_connection_epoch,
-                );
+                lifecycle
+                    .end(DisconnectReason::NetworkError(
+                        "PINGREQ send timed out".to_string(),
+                    ))
+                    .await;
                 break;
             }
         }
@@ -214,7 +242,7 @@ mod tests {
         let connected = AtomicBool::new(true);
         let current_epoch = AtomicU64::new(2);
 
-        mark_disconnected_if_current(&connected, 1, &current_epoch);
+        assert!(!mark_disconnected_if_current(&connected, 1, &current_epoch));
 
         assert!(connected.load(Ordering::SeqCst));
     }
@@ -224,7 +252,8 @@ mod tests {
         let connected = AtomicBool::new(true);
         let current_epoch = AtomicU64::new(2);
 
-        mark_disconnected_if_current(&connected, 2, &current_epoch);
+        assert!(mark_disconnected_if_current(&connected, 2, &current_epoch));
+        assert!(!mark_disconnected_if_current(&connected, 2, &current_epoch));
 
         assert!(!connected.load(Ordering::SeqCst));
     }

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -91,6 +91,8 @@ pub struct DirectClientInner {
     pub quic_stream_manager: Option<Arc<QuicStreamManager>>,
     pub session: Arc<tokio::sync::RwLock<SessionState>>,
     pub connected: Arc<AtomicBool>,
+    pub connection_event_callbacks:
+        Arc<tokio::sync::RwLock<Vec<crate::client::ConnectionEventCallback>>>,
     pub connection_epoch: ConnectionEpoch,
     pub callback_manager: Arc<CallbackManager>,
     /// Registry of `subscribe_with_ack` callbacks (single-owner, token-bearing).
@@ -156,6 +158,7 @@ impl DirectClientInner {
             quic_stream_manager: None,
             session,
             connected: Arc::new(AtomicBool::new(false)),
+            connection_event_callbacks: Arc::new(tokio::sync::RwLock::new(Vec::new())),
             connection_epoch: Arc::new(AtomicU64::new(0)),
             callback_manager: Arc::new(CallbackManager::new()),
             ack_callbacks,
@@ -245,6 +248,7 @@ impl DirectClientInner {
             reason = %String::from_utf8_lossy(reason),
             "resetting connection runtime"
         );
+        self.set_connected(false);
         self.stop_background_tasks().await;
         self.keepalive_state.lock().reset();
 
@@ -255,7 +259,6 @@ impl DirectClientInner {
 
         self.writer = None;
         self.ack_dispatcher.clear_writer().await;
-        self.set_connected(false);
 
         #[cfg(feature = "transport-quic")]
         if let Some(conn) = self.quic_connection.take() {
@@ -1317,7 +1320,12 @@ impl DirectClientInner {
         let puback_channels = self.pending_pubacks.clone();
         let pubcomp_channels = self.pending_pubcomps.clone();
         let writer_for_keepalive = self.writer.as_ref().ok_or(MqttError::NotConnected)?.clone();
-        let connected = self.connected.clone();
+        let lifecycle = keepalive::ConnectionLifecycle {
+            connected: self.connected.clone(),
+            connection_epoch,
+            current_connection_epoch: self.connection_epoch.clone(),
+            callbacks: Arc::clone(&self.connection_event_callbacks),
+        };
 
         let writer_for_reader = writer_for_keepalive.clone();
         let keepalive_state = self.keepalive_state.clone();
@@ -1330,9 +1338,7 @@ impl DirectClientInner {
             puback_channels,
             pubcomp_channels,
             writer: writer_for_reader,
-            connected,
-            connection_epoch,
-            current_connection_epoch: self.connection_epoch.clone(),
+            lifecycle: lifecycle.clone(),
             #[cfg(feature = "transport-quic")]
             protocol_version: self.options.protocol_version.as_u8(),
             auth_handler: self.auth_handler.clone(),
@@ -1356,18 +1362,14 @@ impl DirectClientInner {
             tracing::debug!("💓 KEEPALIVE - Disabled (interval is zero)");
         } else {
             let keepalive_writer = writer_for_keepalive;
-            let keepalive_connected = self.connected.clone();
             let keepalive_config = self.options.keepalive_config;
-            let current_connection_epoch = self.connection_epoch.clone();
             self.keepalive_handle = Some(tokio::spawn(async move {
                 tracing::debug!("💓 KEEPALIVE - Task starting");
                 keepalive_task_with_writer(
                     keepalive_writer,
                     keepalive_interval,
                     keepalive_state,
-                    keepalive_connected,
-                    connection_epoch,
-                    current_connection_epoch,
+                    lifecycle,
                     keepalive_config,
                 )
                 .await;

--- a/crates/mqtt5/src/client/direct/reader.rs
+++ b/crates/mqtt5/src/client/direct/reader.rs
@@ -2,6 +2,7 @@
 
 use crate::callback::CallbackManager;
 use crate::client::auth_handler::{AuthHandler, AuthResponse};
+use crate::client::connection::DisconnectReason;
 use crate::codec::CodecRegistry;
 use crate::error::{MqttError, Result};
 use crate::packet::auth::AuthPacket;
@@ -13,12 +14,11 @@ use crate::session::SessionState;
 use crate::transport::PacketWriter;
 use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
 use super::handlers::handle_incoming_packet_with_writer;
-use super::keepalive::{mark_disconnected_if_current, owns_current_connection, KeepaliveState};
+use super::keepalive::{ConnectionLifecycle, KeepaliveState};
 use super::unified::{UnifiedReader, UnifiedWriter};
 
 #[cfg(feature = "transport-quic")]
@@ -43,9 +43,7 @@ pub(super) struct PacketReaderContext {
     pub(super) puback_channels: Arc<Mutex<HashMap<u16, oneshot::Sender<ReasonCode>>>>,
     pub(super) pubcomp_channels: Arc<Mutex<HashMap<u16, oneshot::Sender<ReasonCode>>>>,
     pub(super) writer: Arc<tokio::sync::Mutex<UnifiedWriter>>,
-    pub(super) connected: Arc<AtomicBool>,
-    pub(super) connection_epoch: u64,
-    pub(super) current_connection_epoch: Arc<AtomicU64>,
+    pub(super) lifecycle: ConnectionLifecycle,
     #[cfg(feature = "transport-quic")]
     pub(super) protocol_version: u8,
     pub(super) auth_handler: Option<Arc<dyn AuthHandler>>,
@@ -84,20 +82,8 @@ impl PacketReaderContext {
 }
 
 impl PacketReaderContext {
-    fn owns_current_connection(&self) -> bool {
-        owns_current_connection(self.connection_epoch, &self.current_connection_epoch)
-    }
-
-    fn mark_disconnected_if_current(&self) {
-        mark_disconnected_if_current(
-            &self.connected,
-            self.connection_epoch,
-            &self.current_connection_epoch,
-        );
-    }
-
     fn clear_pending_if_current(&self) {
-        if !self.owns_current_connection() {
+        if !self.lifecycle.owns_current_connection() {
             return;
         }
         self.puback_channels.lock().drain();
@@ -107,12 +93,27 @@ impl PacketReaderContext {
     }
 }
 
+fn disconnect_reason_for(error: &MqttError) -> DisconnectReason {
+    match error {
+        MqttError::ServerDisconnect(reason_code) => {
+            DisconnectReason::ServerDisconnect(*reason_code)
+        }
+        MqttError::AuthenticationFailed | MqttError::NotAuthorized => DisconnectReason::AuthFailure,
+        MqttError::KeepAliveTimeout => DisconnectReason::KeepAliveTimeout,
+        MqttError::Io(_)
+        | MqttError::ConnectionError(_)
+        | MqttError::ConnectionClosedByPeer
+        | MqttError::ClientClosed => DisconnectReason::NetworkError(error.to_string()),
+        _ => DisconnectReason::ProtocolError(error.to_string()),
+    }
+}
+
 pub(super) async fn packet_reader_task_with_responses(
     mut reader: UnifiedReader,
     ctx: PacketReaderContext,
 ) {
     tracing::debug!("Packet reader task started and ready to process incoming packets");
-    loop {
+    let disconnect_reason = loop {
         let packet = reader.read_packet().await;
 
         match packet {
@@ -176,8 +177,7 @@ pub(super) async fn packet_reader_task_with_responses(
                     Packet::Auth(ref auth) => {
                         if let Err(e) = handle_auth_packet(auth.clone(), &ctx).await {
                             tracing::error!("Error handling AUTH packet: {e}");
-                            ctx.mark_disconnected_if_current();
-                            break;
+                            break disconnect_reason_for(&e);
                         }
                         continue;
                     }
@@ -190,19 +190,17 @@ pub(super) async fn packet_reader_task_with_responses(
                     handle_incoming_packet_with_writer(packet, &ctx.writer, None, &handlers).await
                 {
                     tracing::error!("Error handling packet: {e}");
-                    ctx.mark_disconnected_if_current();
-                    break;
+                    break disconnect_reason_for(&e);
                 }
             }
             Err(e) => {
                 tracing::error!("Error reading packet: {e}");
-                ctx.mark_disconnected_if_current();
-                break;
+                break DisconnectReason::NetworkError(e.to_string());
             }
         }
-    }
+    };
 
-    ctx.mark_disconnected_if_current();
+    ctx.lifecycle.end(disconnect_reason).await;
     ctx.clear_pending_if_current();
 }
 
@@ -277,7 +275,9 @@ pub(super) async fn quic_stream_acceptor_task(
                     Err(e) => {
                         let reason = crate::transport::quic_error::parse_connection_error(&e);
                         tracing::error!("QUIC uni stream accept ended: {reason}");
-                        ctx.mark_disconnected_if_current();
+                        ctx.lifecycle
+                            .end(DisconnectReason::NetworkError(reason.to_string()))
+                            .await;
                         break;
                     }
                 }
@@ -294,7 +294,9 @@ pub(super) async fn quic_stream_acceptor_task(
                     Err(e) => {
                         let reason = crate::transport::quic_error::parse_connection_error(&e);
                         tracing::error!("QUIC bi stream accept ended: {reason}");
-                        ctx.mark_disconnected_if_current();
+                        ctx.lifecycle
+                            .end(DisconnectReason::NetworkError(reason.to_string()))
+                            .await;
                         break;
                     }
                 }
@@ -546,6 +548,11 @@ async fn quic_stream_reader_task(
                         .await
                 {
                     tracing::error!(flow_id = ?flow_id, "Error handling packet from server stream: {e}");
+                    if let MqttError::ServerDisconnect(reason_code) = e {
+                        ctx.lifecycle
+                            .end(DisconnectReason::ServerDisconnect(reason_code))
+                            .await;
+                    }
                     break;
                 }
             }
@@ -595,6 +602,11 @@ async fn quic_uni_stream_reader_task(mut recv: quinn::RecvStream, ctx: PacketRea
                 .await
                 {
                     tracing::error!(flow_id = ?flow_id, "Error handling packet from uni stream: {e}");
+                    if let MqttError::ServerDisconnect(reason_code) = e {
+                        ctx.lifecycle
+                            .end(DisconnectReason::ServerDisconnect(reason_code))
+                            .await;
+                    }
                     break;
                 }
             }
@@ -608,11 +620,39 @@ async fn quic_uni_stream_reader_task(mut recv: quinn::RecvStream, ctx: PacketRea
 
 #[cfg(test)]
 mod tests {
-    use super::owns_current_connection;
+    use super::super::keepalive::owns_current_connection;
+    use super::disconnect_reason_for;
+    use crate::client::connection::DisconnectReason;
+    use crate::error::MqttError;
+    use crate::protocol::v5::reason_codes::ReasonCode;
     use std::sync::atomic::AtomicU64;
 
     #[test]
     fn stale_epoch_does_not_own_current_connection() {
         assert!(!owns_current_connection(1, &AtomicU64::new(2)));
+    }
+
+    #[test]
+    fn disconnect_reason_carries_server_reason_code() {
+        assert_eq!(
+            disconnect_reason_for(&MqttError::ServerDisconnect(ReasonCode::SessionTakenOver)),
+            DisconnectReason::ServerDisconnect(ReasonCode::SessionTakenOver)
+        );
+        assert_eq!(
+            disconnect_reason_for(&MqttError::AuthenticationFailed),
+            DisconnectReason::AuthFailure
+        );
+        assert_eq!(
+            disconnect_reason_for(&MqttError::KeepAliveTimeout),
+            DisconnectReason::KeepAliveTimeout
+        );
+        assert!(matches!(
+            disconnect_reason_for(&MqttError::ConnectionClosedByPeer),
+            DisconnectReason::NetworkError(_)
+        ));
+        assert!(matches!(
+            disconnect_reason_for(&MqttError::MalformedPacket("bad".to_string())),
+            DisconnectReason::ProtocolError(_)
+        ));
     }
 }

--- a/crates/mqtt5/src/client/error_recovery.rs
+++ b/crates/mqtt5/src/client/error_recovery.rs
@@ -96,8 +96,6 @@ impl RetryState {
     }
 }
 
-pub type ErrorCallback = Box<dyn Fn(&MqttError) + Send + Sync>;
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mqtt5/src/client/inner.rs
+++ b/crates/mqtt5/src/client/inner.rs
@@ -18,7 +18,7 @@ use crate::transport::QuicTransport;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::transport::{TcpTransport, TlsTransport, TransportType};
 
-use super::connection::{ConnectionEvent, DisconnectReason};
+use super::connection::ConnectionEvent;
 use super::direct::{AutomaticReconnectLifecycle, StoredSubscription};
 use super::state::ClientTransportType;
 use super::MqttClient;
@@ -613,6 +613,8 @@ impl MqttClient {
             inner.automatic_reconnect_lifecycle = AutomaticReconnectLifecycle::Armed;
         }
 
+        self.trigger_connection_event(ConnectionEvent::Connecting)
+            .await;
         let result = self.connect_internal(address).await;
 
         if let Err(ref error) = result {
@@ -674,19 +676,12 @@ impl MqttClient {
             inner.automatic_reconnect_lifecycle = AutomaticReconnectLifecycle::Armed;
         }
 
+        self.trigger_connection_event(ConnectionEvent::Connecting)
+            .await;
         let result = self.connect_internal_with_tls(tls_config).await;
 
-        if let Err(ref error) = result {
-            if options.reconnect_config.enabled {
-                self.trigger_connection_event(ConnectionEvent::Disconnected {
-                    reason: DisconnectReason::NetworkError(error.to_string()),
-                })
-                .await;
-
-                tracing::warn!(
-                    "Automatic reconnection with custom TLS config is not yet supported"
-                );
-            }
+        if result.is_err() && options.reconnect_config.enabled {
+            tracing::warn!("Automatic reconnection with custom TLS config is not yet supported");
         }
 
         result

--- a/crates/mqtt5/src/client/mod.rs
+++ b/crates/mqtt5/src/client/mod.rs
@@ -37,7 +37,7 @@ pub use auth_handlers::{JwtAuthHandler, PlainAuthHandler, ScramSha256AuthHandler
 
 pub use self::connection::{ConnectionEvent, DisconnectReason, ReconnectConfig};
 pub use self::error_recovery::{
-    is_recoverable, retry_delay, ErrorCallback, ErrorRecoveryConfig, RecoverableError, RetryState,
+    is_recoverable, retry_delay, ErrorRecoveryConfig, RecoverableError, RetryState,
 };
 pub use self::mock::{MockCall, MockMqttClient};
 pub use self::r#trait::MqttClientTrait;
@@ -111,7 +111,6 @@ use self::direct::DirectClientInner;
 pub struct MqttClient {
     pub(crate) inner: Arc<RwLock<DirectClientInner>>,
     pub(crate) connection_event_callbacks: Arc<RwLock<Vec<ConnectionEventCallback>>>,
-    pub(crate) error_callbacks: Arc<RwLock<Vec<error_recovery::ErrorCallback>>>,
     pub(crate) error_recovery_config: Arc<RwLock<error_recovery::ErrorRecoveryConfig>>,
     pub(crate) connection_mutex: Arc<tokio::sync::Mutex<()>>,
     pub(crate) tls_config: Arc<RwLock<Option<TlsConfig>>>,
@@ -184,6 +183,7 @@ impl MqttClient {
     ///         ConnectionEvent::ReconnectFailed { error } => {
     ///             println!("Reconnection failed: {error}");
     ///         }
+    ///         _ => {}
     ///     }
     /// }).await?;
     /// # Ok(())
@@ -199,20 +199,6 @@ impl MqttClient {
     {
         let mut callbacks = self.connection_event_callbacks.write().await;
         callbacks.push(Arc::new(callback));
-        Ok(())
-    }
-
-    /// Sets an error callback
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the operation fails
-    pub async fn on_error<F>(&self, callback: F) -> Result<()>
-    where
-        F: Fn(&MqttError) + Send + Sync + 'static,
-    {
-        let mut callbacks = self.error_callbacks.write().await;
-        callbacks.push(Box::new(callback));
         Ok(())
     }
 
@@ -819,11 +805,6 @@ impl MqttClient {
     /// Set error recovery configuration
     pub async fn set_error_recovery_config(&self, config: error_recovery::ErrorRecoveryConfig) {
         *self.error_recovery_config.write().await = config;
-    }
-
-    /// Clear all error callbacks
-    pub async fn clear_error_callbacks(&self) {
-        self.error_callbacks.write().await.clear();
     }
 
     /// Clear all connection event callbacks

--- a/crates/mqtt5/src/client/state.rs
+++ b/crates/mqtt5/src/client/state.rs
@@ -171,10 +171,20 @@ impl MqttClient {
 
                     if let Err(e) = self.attempt_reconnection(&address, &reconnect_config).await {
                         tracing::error!("Reconnection failed: {e}");
+                        self.trigger_connection_event(ConnectionEvent::ReconnectFailed {
+                            error: e,
+                        })
+                        .await;
                         break;
                     }
                 } else {
                     tracing::info!("No last address available for reconnection");
+                    self.trigger_connection_event(ConnectionEvent::ReconnectFailed {
+                        error: MqttError::ConnectionError(
+                            "no address recorded for reconnection".to_string(),
+                        ),
+                    })
+                    .await;
                     break;
                 }
             }

--- a/crates/mqtt5/src/lib.rs
+++ b/crates/mqtt5/src/lib.rs
@@ -73,6 +73,7 @@
 //!             ConnectionEvent::ReconnectFailed { error } => {
 //!                 println!("Reconnection failed: {error}");
 //!             }
+//!             _ => {}
 //!         }
 //!     }).await?;
 //!     

--- a/crates/mqtt5/tests/connection_lifecycle_events.rs
+++ b/crates/mqtt5/tests/connection_lifecycle_events.rs
@@ -1,0 +1,216 @@
+#![cfg(feature = "broker")]
+#![allow(clippy::large_futures)]
+
+mod common;
+
+use common::{test_client_id, TestBroker};
+use mqtt5::time::Duration;
+use mqtt5::types::ReasonCode;
+use mqtt5::{ConnectOptions, ConnectionEvent, DisconnectReason, MqttClient};
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+type Events = Arc<Mutex<Vec<ConnectionEvent>>>;
+
+const CONNACK_V5_SUCCESS: [u8; 5] = [0x20, 0x03, 0x00, 0x00, 0x00];
+
+enum AfterConnack {
+    Disconnect(u8),
+    Close,
+}
+
+async fn fake_broker(after_connack: AfterConnack) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let address = listener.local_addr().expect("local addr").to_string();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.expect("accept");
+        let mut connect = [0u8; 1024];
+        let _ = socket.read(&mut connect).await;
+        socket
+            .write_all(&CONNACK_V5_SUCCESS)
+            .await
+            .expect("write CONNACK");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        if let AfterConnack::Disconnect(reason_code) = after_connack {
+            socket
+                .write_all(&[0xE0, 0x02, reason_code, 0x00])
+                .await
+                .expect("write DISCONNECT");
+        }
+        drop(socket);
+    });
+    address
+}
+
+async fn record_events(client: &MqttClient) -> Events {
+    let events: Events = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&events);
+    client
+        .on_connection_event(move |event| sink.lock().unwrap().push(event))
+        .await
+        .expect("register connection event callback");
+    events
+}
+
+fn disconnect_reasons(events: &Events) -> Vec<DisconnectReason> {
+    events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|event| match event {
+            ConnectionEvent::Disconnected { reason } => Some(reason.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn has_event(events: &Events, predicate: impl Fn(&ConnectionEvent) -> bool) -> bool {
+    events.lock().unwrap().iter().any(predicate)
+}
+
+async fn wait_until(timeout: Duration, condition: impl Fn() -> bool) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if condition() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    condition()
+}
+
+fn no_reconnect(name: &str) -> ConnectOptions {
+    ConnectOptions::new(test_client_id(name)).with_automatic_reconnect(false)
+}
+
+#[tokio::test]
+async fn connecting_fires_before_connected() {
+    let broker = TestBroker::start().await;
+    let client = MqttClient::new(test_client_id("connecting"));
+    let events = record_events(&client).await;
+
+    client.connect(broker.address()).await.expect("connect");
+    assert!(
+        wait_until(Duration::from_secs(2), || has_event(&events, |e| matches!(
+            e,
+            ConnectionEvent::Connected { .. }
+        )))
+        .await,
+        "Connected never fired"
+    );
+
+    let first_two: Vec<bool> = events
+        .lock()
+        .unwrap()
+        .iter()
+        .take(2)
+        .map(|e| matches!(e, ConnectionEvent::Connecting))
+        .collect();
+    assert_eq!(
+        first_two,
+        vec![true, false],
+        "Connecting must precede Connected"
+    );
+
+    client.disconnect().await.expect("disconnect");
+}
+
+#[tokio::test]
+async fn server_disconnect_carries_reason_code() {
+    let address = fake_broker(AfterConnack::Disconnect(0x8E)).await;
+    let client = MqttClient::new(test_client_id("takeover"));
+    let events = record_events(&client).await;
+    client
+        .connect_with_options(&address, no_reconnect("takeover"))
+        .await
+        .expect("connect");
+
+    assert!(
+        wait_until(Duration::from_secs(3), || !disconnect_reasons(&events)
+            .is_empty())
+        .await,
+        "client never observed the broker DISCONNECT"
+    );
+    assert_eq!(
+        disconnect_reasons(&events),
+        vec![DisconnectReason::ServerDisconnect(
+            ReasonCode::SessionTakenOver
+        )]
+    );
+    assert!(!client.is_connected().await);
+}
+
+#[tokio::test]
+async fn lost_connection_fires_network_error() {
+    let address = fake_broker(AfterConnack::Close).await;
+    let client = MqttClient::new(test_client_id("lost"));
+    let events = record_events(&client).await;
+    client
+        .connect_with_options(&address, no_reconnect("lost"))
+        .await
+        .expect("connect");
+
+    assert!(
+        wait_until(Duration::from_secs(3), || !disconnect_reasons(&events)
+            .is_empty())
+        .await,
+        "client never observed the connection drop"
+    );
+    let reasons = disconnect_reasons(&events);
+    assert_eq!(
+        reasons.len(),
+        1,
+        "exactly one disconnect expected: {reasons:?}"
+    );
+    assert!(
+        matches!(reasons[0], DisconnectReason::NetworkError(_)),
+        "unexpected reason: {:?}",
+        reasons[0]
+    );
+    assert!(!client.is_connected().await);
+}
+
+#[tokio::test]
+async fn client_disconnect_fires_only_client_initiated() {
+    let broker = TestBroker::start().await;
+    let client = MqttClient::new(test_client_id("clean"));
+    let events = record_events(&client).await;
+
+    client.connect(broker.address()).await.expect("connect");
+    client.disconnect().await.expect("disconnect");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        disconnect_reasons(&events),
+        vec![DisconnectReason::ClientInitiated]
+    );
+}
+
+#[tokio::test]
+async fn reconnect_failed_fires_after_max_attempts() {
+    let _broker = TestBroker::start().await;
+    let client = MqttClient::new(test_client_id("give-up"));
+    let events = record_events(&client).await;
+
+    let opts = ConnectOptions::new(test_client_id("give-up"))
+        .with_automatic_reconnect(true)
+        .with_reconnect_delay(Duration::from_millis(50), Duration::from_millis(200))
+        .with_max_reconnect_attempts(2);
+    let result = client.connect_with_options("localhost:9999", opts).await;
+    assert!(result.is_err());
+
+    assert!(
+        wait_until(Duration::from_secs(10), || has_event(
+            &events,
+            |e| matches!(e, ConnectionEvent::ReconnectFailed { .. })
+        ))
+        .await,
+        "ReconnectFailed never fired after exhausting max attempts"
+    );
+    assert!(has_event(&events, |e| matches!(
+        e,
+        ConnectionEvent::Reconnecting { .. }
+    )));
+    assert!(!client.is_connected().await);
+}

--- a/crates/mqtt5/tests/error_recovery.rs
+++ b/crates/mqtt5/tests/error_recovery.rs
@@ -2,37 +2,6 @@ use mqtt5::client::{is_recoverable, retry_delay, ErrorRecoveryConfig, Recoverabl
 use mqtt5::time::Duration;
 use mqtt5::types::ReasonCode;
 use mqtt5::{MqttClient, MqttError};
-use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
-
-#[tokio::test]
-async fn test_error_callback_registration() {
-    let client = MqttClient::new("test-client");
-
-    let error_count = Arc::new(AtomicU32::new(0));
-    let error_count_clone = Arc::clone(&error_count);
-
-    // Register error callback
-    client
-        .on_error(move |error| {
-            println!("Error occurred: {error}");
-            error_count_clone.fetch_add(1, Ordering::Relaxed);
-        })
-        .await
-        .unwrap();
-
-    // Trigger an error by trying to publish while disconnected with auto_retry disabled
-    let mut config = client.error_recovery_config().await;
-    config.auto_retry = false;
-    client.set_error_recovery_config(config).await;
-
-    // This should fail and trigger the error callback
-    let result = client.publish("test/topic", "message").await;
-    assert!(result.is_err());
-
-    // Note: In a real implementation, the error callback would be triggered
-    // by the internal error handling mechanism
-}
 
 #[tokio::test]
 async fn test_error_recovery_config() {
@@ -178,35 +147,6 @@ async fn test_retry_delay_calculation() {
         retry_delay(RecoverableError::FlowControlLimited, 20, &config),
         Duration::from_secs(10)
     );
-}
-
-#[tokio::test]
-async fn test_multiple_error_callbacks() {
-    let client = MqttClient::new("test-client");
-
-    let callback1_count = Arc::new(AtomicU32::new(0));
-    let callback2_count = Arc::new(AtomicU32::new(0));
-
-    let count1 = Arc::clone(&callback1_count);
-    client
-        .on_error(move |_error| {
-            count1.fetch_add(1, Ordering::Relaxed);
-        })
-        .await
-        .unwrap();
-
-    let count2 = Arc::clone(&callback2_count);
-    client
-        .on_error(move |_error| {
-            count2.fetch_add(1, Ordering::Relaxed);
-        })
-        .await
-        .unwrap();
-
-    // Clear callbacks
-    client.clear_error_callbacks().await;
-
-    // New callbacks should not be triggered after clearing
 }
 
 #[tokio::test]

--- a/crates/mqtt5/tests/integration_reconnection.rs
+++ b/crates/mqtt5/tests/integration_reconnection.rs
@@ -77,7 +77,7 @@ async fn test_automatic_reconnection() {
             ConnectionEvent::Reconnecting { attempt } => {
                 println!("Reconnecting event, attempt {attempt}");
             }
-            ConnectionEvent::ReconnectFailed { .. } => {}
+            _ => {}
         })
         .await
         .expect("Failed to register connection event handler");
@@ -175,7 +175,7 @@ async fn test_client_initiated_disconnect_stops_automatic_reconnection() {
             ConnectionEvent::Reconnecting { .. } => {
                 reconnecting_clone.fetch_add(1, Ordering::SeqCst);
             }
-            ConnectionEvent::Connecting | ConnectionEvent::ReconnectFailed { .. } => {}
+            _ => {}
         })
         .await
         .expect("Failed to register connection event handler");

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.5"
+version = "0.28.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.38" }
+mqtt5 = { path = "../mqtt5", version = "0.39" }
 anyhow = "1.0.103"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mqttv5-cli/src/commands/pub_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/pub_cmd.rs
@@ -733,6 +733,7 @@ async fn keep_alive_loop(client: &MqttClient, auto_reconnect: bool) -> Result<()
                 ConnectionEvent::ReconnectFailed { error } => {
                     warn!("⚠ Reconnection failed: {error}");
                 }
+                _ => {}
             })
             .await?;
     }


### PR DESCRIPTION
Implements the 0.39.0 client-observability rework designed in #123 and #125. Closes #123, closes #125.

## What changes

**`ConnectionEvent::Disconnected` now fires whenever the connection is actually lost, with a reason.** Previously it fired only for an application-initiated `disconnect()` (and one custom-TLS connect-failure path). A dropped TCP connection, a broker `DISCONNECT`, or a keepalive timeout only flipped an internal flag, so a subscriber saw `Connected`, later another `Connected`, and never learned anything was lost in between (#123 §1). The packet reader now emits `Disconnected` when it terminates, with the reason derived from the cause:

- `ServerDisconnect(reason_code)` for a broker `DISCONNECT`; the reason code was previously logged and discarded (#123 §4)
- `NetworkError` for a transport drop
- `AuthFailure` for a failed re-authentication
- `ProtocolError` otherwise

The keepalive task emits `Disconnected { KeepAliveTimeout }` on a missed `PINGRESP` and `NetworkError` when a `PINGREQ` cannot be written.

**`Connecting` and `ReconnectFailed` now fire** (#123 §2, §3). Both were declared, documented, and matched in the examples, but never produced. `Connecting` fires on the initial `connect` / `connect_with_options` (plain and TLS); `Reconnecting { attempt }` on each automatic retry (unchanged); `ReconnectFailed { error }` when the reconnection loop gives up for good, either because `max_attempts` was exhausted or no address was recorded. Previously the monitor task exited silently in both cases and the client stayed offline with no signal.

**`on_error` / `clear_error_callbacks` / `ErrorCallback` are removed** (#125). The callbacks were never invoked; the only place to hook them is the reader error path that now feeds `Disconnected`, so wiring them would report the same failure twice. `on_connection_event` is the channel.

**`ConnectionEvent`, `DisconnectReason`, and `ReasonCode` are `#[non_exhaustive]`** so new reason codes stay additive. `DisconnectReason::ServerClosed` (never produced by anything) is replaced by `ServerDisconnect(ReasonCode)`. `MqttError::ServerDisconnect(ReasonCode)` is added so the reason code survives from the packet handler to the reader.

A failed *connect* no longer emits `Disconnected` on the custom-TLS path, matching the plain-TCP path (the client was never connected).

## How the reader fires events

The reader and keepalive tasks run as spawned tokio tasks holding only a `PacketReaderContext`, with no handle to `MqttClient`, which is why they could never fire events. The `connection_event_callbacks` `Arc` is now shared between `MqttClient` and `DirectClientInner` and carried into the tasks inside a small `ConnectionLifecycle` value (connected flag, connection epoch, callbacks) whose `end(reason)` does the work.

**Each connection emits at most one `Disconnected`.** `end` is a compare-and-swap on the connected flag, guarded by the connection epoch, so whichever of the reader / keepalive / QUIC-acceptor tasks observes the loss first reports it and the others report nothing; a stale task from a previous connection reports nothing; and a client-initiated `disconnect()` clears the flag before stopping the tasks, so it reports only `ClientInitiated`.

## Versions

- `mqtt5` 0.38.5 → **0.39.0** (breaking)
- `mqtt5-protocol` 0.14.3 → **0.15.0** (breaking: `#[non_exhaustive]`, new variants)
- `mqtt5-wasm` 1.4.4 → 1.4.5 and `mqttv5-cli` 0.28.5 → 0.28.6 (dependency bumps; the CLI's connection-event logging now actually sees `Connecting` / reasoned `Disconnected` / `ReconnectFailed`)

Breaking notes in the changelog. Every exhaustive `match` on the three enums in the workspace, examples, and doc examples gained a wildcard arm.

## Tests

`tests/connection_lifecycle_events.rs` (new):
- `connecting_fires_before_connected`
- `server_disconnect_carries_reason_code` — a raw-TCP fake broker replies CONNACK then writes `DISCONNECT 0x8E`; the client reports exactly `[ServerDisconnect(SessionTakenOver)]`
- `lost_connection_fires_network_error` — fake broker replies CONNACK then closes; exactly one `NetworkError`
- `client_disconnect_fires_only_client_initiated` — regression for the single-event guarantee
- `reconnect_failed_fires_after_max_attempts`

Unit tests cover the error→reason mapping and the flip-only-once compare-and-swap. The two broker-driven cases use a fake broker deliberately: the in-tree broker does not send `DISCONNECT(SessionTakenOver)` on session takeover (a separate spec gap, [MQTT-3.1.4-3], worth its own issue), and `TestBroker::stop()` only aborts the accept loop without severing existing connections.

Verified: `cargo check --workspace --all-targets`, CI clippy (`--all-targets --workspace --features opentelemetry -D warnings`), pedantic clippy on the changed crates, wasm-clippy, `mqtt5-protocol` std and no_std, doctests, and the `connection_events`, `connection_lifecycle_events`, `integration_reconnection`, `error_recovery` suites.

## Not in scope

- Automatic reconnection for custom-TLS connections is still unsupported (unchanged warning). Custom-TLS connections do now receive `Disconnected` since the reader path is shared.
- The `reconnect_attempt` counter still resets on every successful connect, so a session-takeover flap never trips `max_attempts` (#123, holovskyi's follow-up). The exposed `ServerDisconnect(SessionTakenOver)` reason is what lets an application decide not to reconnect.
