### PR TITLE
isolate callback panics from the dispatch workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.39.1] - 2026-09-06
+
+### Fixed
+
+- **A panicking subscription callback no longer stops message delivery for the whole client.** Every delivered message ran through a single lazily-spawned worker task that invoked the user callback with no panic isolation. A callback panic unwound the worker, the `OnceLock` kept handing out the dead channel's sender, and `dispatch` discarded the send error, so from then on every message routed through that manager was silently dropped while the connection stayed up and `is_connected()` kept returning `true`. It survived reconnects, since the manager is built once per client. The `subscribe_with_ack` worker had the same defect. Both workers now run each callback under `catch_unwind`, log the panic at `error` level with the topic, and keep going, so one panicking callback loses one message instead of the client. If a worker is ever gone, `CallbackManager::dispatch` now logs and returns an error rather than dropping the message silently, and the ack worker logs the drop. Connection event callbacks run under the same isolation. Reported in issue #124.
+
 ## [mqtt5 0.39.0] - 2026-09-05
 
 ### Breaking

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.39.0"
+version = "0.39.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/callback.rs
+++ b/crates/mqtt5/src/callback.rs
@@ -1,10 +1,11 @@
-use crate::error::Result;
+use crate::error::{MqttError, Result};
 use crate::packet::publish::PublishPacket;
 #[cfg(feature = "opentelemetry")]
 use crate::telemetry::propagation::UserProperty;
 use crate::validation::strip_shared_subscription_prefix;
 use parking_lot::Mutex;
 use std::collections::HashMap;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
@@ -62,7 +63,7 @@ impl CallbackManager {
             let (tx, mut rx) = mpsc::unbounded_channel::<DispatchItem>();
             tokio::spawn(async move {
                 while let Some(item) = rx.recv().await {
-                    Self::run_dispatch_item(item);
+                    Self::run_dispatch_item(&item);
                 }
             });
             tx
@@ -70,7 +71,7 @@ impl CallbackManager {
     }
 
     #[cfg(feature = "opentelemetry")]
-    fn run_dispatch_item(item: DispatchItem) {
+    fn run_dispatch_item(item: &DispatchItem) {
         use crate::telemetry::propagation;
         propagation::with_remote_context(&item.user_props, || {
             let span = tracing::info_span!(
@@ -81,16 +82,16 @@ impl CallbackManager {
                 retain = item.message.retain,
             );
             let _enter = span.enter();
-            for callback in item.callbacks {
-                callback(item.message.clone());
+            for callback in &item.callbacks {
+                invoke_callback(callback, &item.message);
             }
         });
     }
 
     #[cfg(not(feature = "opentelemetry"))]
-    fn run_dispatch_item(item: DispatchItem) {
-        for callback in item.callbacks {
-            callback(item.message.clone());
+    fn run_dispatch_item(item: &DispatchItem) {
+        for callback in &item.callbacks {
+            invoke_callback(callback, &item.message);
         }
     }
 
@@ -191,7 +192,7 @@ impl CallbackManager {
 
     /// # Errors
     ///
-    /// Currently infallible but returns Result for API stability.
+    /// Returns an error if the dispatch worker is no longer running; the message is dropped.
     pub fn dispatch(&self, message: &PublishPacket) -> Result<()> {
         let mut callbacks_to_call = Vec::new();
 
@@ -231,7 +232,15 @@ impl CallbackManager {
             user_props,
         };
 
-        let _ = self.dispatch_sender().send(item);
+        if self.dispatch_sender().send(item).is_err() {
+            tracing::error!(
+                topic = %message.topic_name,
+                "callback dispatch worker is gone; message dropped"
+            );
+            return Err(MqttError::InvalidState(
+                "callback dispatch worker is gone".to_string(),
+            ));
+        }
 
         Ok(())
     }
@@ -252,6 +261,24 @@ impl Default for CallbackManager {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn invoke_callback(callback: &PublishCallback, message: &PublishPacket) {
+    if let Err(payload) = catch_unwind(AssertUnwindSafe(|| callback(message.clone()))) {
+        tracing::error!(
+            topic = %message.topic_name,
+            "subscription callback panicked: {}",
+            panic_message(&*payload)
+        );
+    }
+}
+
+pub(crate) fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("non-string panic payload")
 }
 
 #[cfg(test)]
@@ -488,6 +515,64 @@ mod tests {
         manager.dispatch(&message3).unwrap();
         tokio::task::yield_now().await;
         assert_eq!(counter.load(Ordering::Relaxed), 2);
+    }
+
+    async fn wait_for(counter: &AtomicU32, expected: u32) -> bool {
+        for _ in 0..40 {
+            if counter.load(Ordering::SeqCst) == expected {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        counter.load(Ordering::SeqCst) == expected
+    }
+
+    #[tokio::test]
+    async fn panicking_callback_does_not_stop_later_delivery() {
+        let manager = CallbackManager::new();
+        let delivered = Arc::new(AtomicU32::new(0));
+        let counter = Arc::clone(&delivered);
+        let panicking: PublishCallback = Arc::new(|_msg| panic!("callback bug"));
+        let counting: PublishCallback = Arc::new(move |_msg| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+        manager.register("a/1", panicking).unwrap();
+        manager.register("a/2", counting).unwrap();
+
+        manager
+            .dispatch(&PublishPacket::new("a/1", b"x".to_vec(), QoS::AtMostOnce))
+            .unwrap();
+        tokio::task::yield_now().await;
+        manager
+            .dispatch(&PublishPacket::new("a/2", b"x".to_vec(), QoS::AtMostOnce))
+            .unwrap();
+
+        assert!(
+            wait_for(&delivered, 1).await,
+            "delivery stopped after a callback panic"
+        );
+    }
+
+    #[tokio::test]
+    async fn panicking_callback_does_not_skip_sibling_callbacks() {
+        let manager = CallbackManager::new();
+        let delivered = Arc::new(AtomicU32::new(0));
+        let counter = Arc::clone(&delivered);
+        let panicking: PublishCallback = Arc::new(|_msg| panic!("callback bug"));
+        let counting: PublishCallback = Arc::new(move |_msg| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+        manager.register("a/1", panicking).unwrap();
+        manager.register("a/1", counting).unwrap();
+
+        manager
+            .dispatch(&PublishPacket::new("a/1", b"x".to_vec(), QoS::AtMostOnce))
+            .unwrap();
+
+        assert!(
+            wait_for(&delivered, 1).await,
+            "sibling callback skipped after a panic"
+        );
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/client/direct/ack.rs
+++ b/crates/mqtt5/src/client/direct/ack.rs
@@ -1,4 +1,6 @@
+use crate::callback::panic_message;
 use std::collections::HashMap;
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -301,7 +303,21 @@ impl AckCallbackManager {
             let (tx, mut rx) = mpsc::unbounded_channel::<AckDispatchItem>();
             tokio::spawn(async move {
                 while let Some(item) = rx.recv().await {
-                    (item.callback)(item.message, item.token);
+                    let topic = item.message.topic_name.clone();
+                    let AckDispatchItem {
+                        callback,
+                        message,
+                        token,
+                    } = item;
+                    if let Err(payload) =
+                        catch_unwind(AssertUnwindSafe(|| callback(message, token)))
+                    {
+                        tracing::error!(
+                            topic = %topic,
+                            "ack subscription callback panicked: {}",
+                            panic_message(&*payload)
+                        );
+                    }
                 }
             });
             tx
@@ -357,11 +373,16 @@ impl AckCallbackManager {
         message: PublishPacket,
         token: AckToken,
     ) {
-        let _ = self.dispatch_sender().send(AckDispatchItem {
+        if let Err(dropped) = self.dispatch_sender().send(AckDispatchItem {
             callback,
             message,
             token,
-        });
+        }) {
+            tracing::error!(
+                topic = %dropped.0.message.topic_name,
+                "ack dispatch worker is gone; message dropped"
+            );
+        }
     }
 }
 
@@ -373,6 +394,49 @@ mod tests {
     use crate::QoS;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn panicking_ack_callback_does_not_stop_later_delivery() {
+        let mgr = AckCallbackManager::new();
+        let delivered = Arc::new(AtomicU32::new(0));
+        let counter = Arc::clone(&delivered);
+        let panicking: AckPublishCallback = Arc::new(|_p, _t| panic!("callback bug"));
+        let counting: AckPublishCallback = Arc::new(move |_p, _t| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+        mgr.register("a/1", panicking);
+        mgr.register("a/2", counting);
+
+        let dispatcher = AckDispatcher::new(Arc::new(tokio::sync::RwLock::new(SessionState::new(
+            "t".to_string(),
+            SessionConfig::default(),
+            true,
+        ))));
+
+        let first = mgr.find_one("a/1").expect("a/1 registered");
+        mgr.dispatch(
+            first,
+            PublishPacket::new("a/1", b"x".to_vec(), QoS::AtLeastOnce),
+            dispatcher.token(1, QoS::AtLeastOnce),
+        );
+        tokio::task::yield_now().await;
+        let second = mgr.find_one("a/2").expect("a/2 registered");
+        mgr.dispatch(
+            second,
+            PublishPacket::new("a/2", b"x".to_vec(), QoS::AtLeastOnce),
+            dispatcher.token(2, QoS::AtLeastOnce),
+        );
+
+        let mut delivered_ok = false;
+        for _ in 0..40 {
+            if delivered.load(Ordering::SeqCst) == 1 {
+                delivered_ok = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(delivered_ok, "ack delivery stopped after a callback panic");
+    }
 
     #[tokio::test]
     async fn duplicate_wildcard_subscription_dispatches_to_a_single_callback() {

--- a/crates/mqtt5/src/client/direct/keepalive.rs
+++ b/crates/mqtt5/src/client/direct/keepalive.rs
@@ -1,7 +1,7 @@
 //! Keepalive management and background tasks
 
 use crate::client::connection::{ConnectionEvent, DisconnectReason};
-use crate::client::ConnectionEventCallback;
+use crate::client::{fire_connection_event, ConnectionEventCallback};
 use crate::error::Result;
 use crate::packet::Packet;
 use crate::transport::PacketWriter;
@@ -70,16 +70,6 @@ pub(crate) fn mark_disconnected_if_current(
         && connected
             .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
-}
-
-pub(crate) async fn fire_connection_event(
-    callbacks: &tokio::sync::RwLock<Vec<ConnectionEventCallback>>,
-    event: ConnectionEvent,
-) {
-    let callbacks = callbacks.read().await.clone();
-    for callback in callbacks {
-        callback(event.clone());
-    }
 }
 
 #[derive(Clone)]

--- a/crates/mqtt5/src/client/mod.rs
+++ b/crates/mqtt5/src/client/mod.rs
@@ -44,6 +44,24 @@ pub use self::r#trait::MqttClientTrait;
 
 pub use builders::ConnectionEventCallback;
 
+pub(crate) async fn fire_connection_event(
+    callbacks: &tokio::sync::RwLock<Vec<ConnectionEventCallback>>,
+    event: ConnectionEvent,
+) {
+    let callbacks = callbacks.read().await.clone();
+    for callback in callbacks {
+        let outcome =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callback(event.clone())));
+        if let Err(payload) = outcome {
+            tracing::error!(
+                ?event,
+                "connection event callback panicked: {}",
+                crate::callback::panic_message(&*payload)
+            );
+        }
+    }
+}
+
 pub use self::direct::AckToken;
 use self::direct::AutomaticReconnectLifecycle;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/mqtt5/src/client/state.rs
+++ b/crates/mqtt5/src/client/state.rs
@@ -28,10 +28,7 @@ pub(crate) enum ClientTransportType {
 
 impl MqttClient {
     pub(crate) async fn trigger_connection_event(&self, event: ConnectionEvent) {
-        let callbacks = self.connection_event_callbacks.read().await.clone();
-        for callback in callbacks {
-            callback(event.clone());
-        }
+        super::fire_connection_event(&self.connection_event_callbacks, event).await;
     }
 
     pub(crate) async fn reset_reconnect_counter(&self) {


### PR DESCRIPTION
Closes #124.

## Problem

Every delivered message runs through a single lazily-spawned worker task that invokes the user's callback with no panic isolation. If a callback panics, the panic unwinds the worker and the task ends. The `OnceLock` still holds the dead channel's `Sender`, and `dispatch` discarded the send result, so from then on every message routed through that manager is dropped. The failure is total for that half of the delivery surface, permanent (it survives reconnects, since the manager is built once per client), and silent: the connection stays up, `is_connected()` keeps returning `true`, and publishes keep succeeding. The `subscribe_with_ack` worker in `ack.rs` had the same structure and the same defect.

## Fix

- Both workers run each callback under `catch_unwind(AssertUnwindSafe(..))`, log the panic at `error` with the topic and the panic message, and continue. One panicking callback loses one message, not the client. In `CallbackManager`, isolation is per callback, so a panic in one callback for a topic does not skip the other callbacks registered for the same message.
- `CallbackManager::dispatch` no longer discards the send result. If the worker is gone it logs and returns `Err(InvalidState)`; the `# Errors` doc now says so instead of "currently infallible". The ack dispatcher logs the dropped message.
- Connection event callbacks were invoked bare in two duplicated loops (`trigger_connection_event` and the keepalive/reader `fire_connection_event`). Since 0.39.0 they run inline on the reader and keepalive tasks, so a panicking `on_connection_event` callback would have killed the reader mid-teardown. Both paths now go through one `fire_connection_event` with the same isolation.

`panic_message` extracts a `&str` or `String` payload for the log and falls back to a fixed string otherwise.

## Tests

No broker needed, as suggested in the issue:

- `callback::tests::panicking_callback_does_not_stop_later_delivery`: a panicking callback on `a/1`, a counting one on `a/2`; dispatch `a/1`, then `a/2`; the counter reaches 1.
- `callback::tests::panicking_callback_does_not_skip_sibling_callbacks`: two callbacks on `a/1`, the first panics; the second still runs for the same message.
- `ack::tests::panicking_ack_callback_does_not_stop_later_delivery`: same shape for the `subscribe_with_ack` worker.

## Version

`mqtt5` 0.39.0 → 0.39.1, changelog entry added. No API change beyond `dispatch` now able to return an error, which it already declared.
