### PR TITLE
send DISCONNECT session taken over to the displaced client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.39.2] - 2026-09-07
+
+### Fixed
+
+- **The broker now sends `DISCONNECT` with reason code 0x8E (Session taken over) to the displaced client on session takeover**, as `[MQTT-3.1.4-3]` requires, before closing its connection. Previously it only closed the socket, so the superseded client saw a plain network drop and could not tell a takeover from any other loss. A client that reports disconnect reasons (mqtt5 0.39.0 and later) now receives `DisconnectReason::ServerDisconnect(SessionTakenOver)` and can decide not to reconnect into a takeover flap. The conformance test for `[MQTT-3.1.4-3]` previously accepted a bare close; it now requires the `DISCONNECT`. Reported in issue #147.
+
 ## [mqtt5 0.39.1] - 2026-09-06
 
 ### Fixed

--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,37 @@
 
 ## Diary Entries
 
+### [MQTT-3.1.4-3] takeover DISCONNECT is now required by the test, and sent by the broker (2026-09-07)
+
+**Trigger**: issue #147. The in-tree broker closed the displaced client's socket on session takeover
+without sending `DISCONNECT` 0x8E, yet `session_takeover_disconnects_existing_client` was green on
+every SUT. Found while writing the 0.39.0 client tests, where a takeover against the in-tree broker
+surfaced as `NetworkError("Client closed connection")` instead of `ServerDisconnect(SessionTakenOver)`.
+
+**Why the test passed anyway**: it read the superseded connection with
+`if let Some(reason) = expect_disconnect_packet(..)` and asserted the reason code only inside the
+`if let`. `expect_disconnect_packet` returns `None` on a bare close, so the body was skipped and the
+test fell through to the close assertion, which the broker did satisfy. The first half of a MUST was
+never checked.
+
+**Test change**: the DISCONNECT is now required (`.expect(..)`), then its reason must be 0x8E, then
+the close must follow. Against the unfixed broker it fails at the first step. Mosquitto sends 0x8E.
+
+**Broker fix (same PR)**: both `disconnect_rx` arms in `client_handler/mod.rs` (`handle_packets`
+and `handle_packets_no_keepalive`) write `DisconnectPacket { reason_code: SessionTakenOver }` via
+`write_to_client` before returning, ignoring a write error since the peer may already be gone. The
+takeover signal itself, a oneshot fired from `MessageRouter::register_client`, already existed; only
+the packet was missing. One handler serves TCP, TLS, WebSocket and QUIC, so all transports get it.
+
+**Swept for the same shape**: one other `if let Some(..) = expect_disconnect_packet(..)` exists, in
+`server_disconnect_uses_valid_reason_code` for `[MQTT-3.14.2-1]`. That one is legitimately
+conditional: the statement constrains the reason code only when a DISCONNECT is sent, and sending
+one for a second CONNECT is not required by it. Left as is.
+
+**Client side**: `connection_lifecycle_events::session_takeover_via_broker_carries_reason_code`
+now proves the whole path end to end against the in-process `TestBroker`; for 0.39.0 it had to use
+a fake broker.
+
 ### External-broker CI flake investigation — concurrency ruled out, backend switched to memory (2026-08-06)
 
 **Trigger**: `puback_error_stops_retransmission [MQTT-4.4.0-2]` failed once on the external-mqtt5 CI

--- a/crates/mqtt5-conformance/src/conformance_tests/section3_connect.rs
+++ b/crates/mqtt5-conformance/src/conformance_tests/section3_connect.rs
@@ -52,12 +52,14 @@ async fn session_takeover_disconnects_existing_client(sut: SutHandle) {
         "[MQTT-3.1.4-3] taking-over CONNECT must succeed"
     );
 
-    if let Some(reason) = existing.expect_disconnect_packet(TIMEOUT).await {
-        assert_eq!(
-            reason, 0x8E,
-            "[MQTT-3.1.4-3] a DISCONNECT sent to the superseded client must carry 0x8E (Session taken over)"
-        );
-    }
+    let reason = existing
+        .expect_disconnect_packet(TIMEOUT)
+        .await
+        .expect("[MQTT-3.1.4-3] the superseded client must receive a DISCONNECT before the connection closes");
+    assert_eq!(
+        reason, 0x8E,
+        "[MQTT-3.1.4-3] the DISCONNECT sent to the superseded client must carry 0x8E (Session taken over)"
+    );
 
     assert!(
         existing.read_packet_bytes(TIMEOUT).await.is_none(),

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.39.1"
+version = "0.39.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5/src/broker/client_handler/mod.rs
+++ b/crates/mqtt5/src/broker/client_handler/mod.rs
@@ -657,6 +657,13 @@ impl ClientHandler {
 
                 _ = &mut *disconnect_rx => {
                     info!("Session taken over by another client");
+                    let disconnect = Packet::Disconnect(DisconnectPacket {
+                        reason_code: ReasonCode::SessionTakenOver,
+                        properties: Properties::default(),
+                    });
+                    if let Err(e) = self.write_to_client(disconnect).await {
+                        debug!("Failed to send session-taken-over DISCONNECT: {e}");
+                    }
                     return Ok(true);
                 }
             }
@@ -747,6 +754,13 @@ impl ClientHandler {
 
                 _ = &mut *disconnect_rx => {
                     info!("Session taken over by another client");
+                    let disconnect = Packet::Disconnect(DisconnectPacket {
+                        reason_code: ReasonCode::SessionTakenOver,
+                        properties: Properties::default(),
+                    });
+                    if let Err(e) = self.write_to_client(disconnect).await {
+                        debug!("Failed to send session-taken-over DISCONNECT: {e}");
+                    }
                     return Ok(true);
                 }
 

--- a/crates/mqtt5/tests/connection_lifecycle_events.rs
+++ b/crates/mqtt5/tests/connection_lifecycle_events.rs
@@ -142,6 +142,47 @@ async fn server_disconnect_carries_reason_code() {
 }
 
 #[tokio::test]
+async fn session_takeover_via_broker_carries_reason_code() {
+    let broker = TestBroker::start().await;
+    let client_id = test_client_id("takeover-broker");
+
+    let first = MqttClient::new(client_id.clone());
+    let events = record_events(&first).await;
+    first
+        .connect_with_options(
+            broker.address(),
+            ConnectOptions::new(client_id.clone()).with_automatic_reconnect(false),
+        )
+        .await
+        .expect("first connect");
+
+    let second = MqttClient::new(client_id.clone());
+    second
+        .connect_with_options(
+            broker.address(),
+            ConnectOptions::new(client_id).with_automatic_reconnect(false),
+        )
+        .await
+        .expect("second connect");
+
+    assert!(
+        wait_until(Duration::from_secs(3), || !disconnect_reasons(&events)
+            .is_empty())
+        .await,
+        "first client never observed the session takeover"
+    );
+    assert_eq!(
+        disconnect_reasons(&events),
+        vec![DisconnectReason::ServerDisconnect(
+            ReasonCode::SessionTakenOver
+        )]
+    );
+    assert!(!first.is_connected().await);
+
+    second.disconnect().await.expect("disconnect second");
+}
+
+#[tokio::test]
 async fn lost_connection_fires_network_error() {
     let address = fake_broker(AfterConnack::Close).await;
     let client = MqttClient::new(test_client_id("lost"));


### PR DESCRIPTION
Closes #147.

## Problem

On session takeover the broker signals the displaced client's handler through a oneshot fired from `MessageRouter::register_client`; the handler's `disconnect_rx` arm logged "Session taken over by another client" and returned, and the connection was closed with nothing written. `[MQTT-3.1.4-3]` requires the Server to send `DISCONNECT` with reason code 0x8E (Session taken over) to the existing client before closing. The superseded client therefore saw a plain network drop and could not distinguish a takeover from any other loss; since mqtt5 0.39.0 reports disconnect reasons, this surfaced as `Disconnected { NetworkError("Client closed connection") }` where EMQX and Mosquitto produce `ServerDisconnect(SessionTakenOver)`.

## Fix

Both `disconnect_rx` arms in `client_handler/mod.rs` (`handle_packets` and `handle_packets_no_keepalive`) now write `DisconnectPacket { reason_code: SessionTakenOver }` through `write_to_client` before returning, ignoring a write error since the peer may already be gone. The close that follows is unchanged. The same handler serves TCP, TLS, WebSocket and QUIC connections, so all transports get it.

## Conformance test

`session_takeover_disconnects_existing_client` already existed for `[MQTT-3.1.4-3]` but read the superseded connection with `if let Some(reason) = expect_disconnect_packet(..)`, and `expect_disconnect_packet` returns `None` on a bare close. The reason-code assertion was therefore skipped whenever no DISCONNECT arrived, and the test fell through to the close check, which the broker did satisfy. A MUST was being verified only for its second half. The DISCONNECT is now required, then its reason code, then the close. Against the unfixed broker this fails at the first step; Mosquitto sends 0x8E and passes. Logged in `CONFORMANCE_DIARY.md`.

## Client end-to-end test

`connection_lifecycle_events::session_takeover_via_broker_carries_reason_code`: two `MqttClient`s with the same ClientID against the in-process `TestBroker`; the first reports exactly `[ServerDisconnect(SessionTakenOver)]`. This is the test I could not write for 0.39.0 without a fake broker.

## Version

`mqtt5` 0.39.1 → 0.39.2, changelog entry added.
