### PR TITLE
register the ack waiter before sending in the conformance test client

### DIFF
--- a/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
+++ b/crates/mqtt5-conformance/CONFORMANCE_DIARY.md
@@ -38,6 +38,38 @@
 
 ## Diary Entries
 
+### External-broker ack timeouts were a lost-wakeup race in the test client, not broker timing (2026-09-07)
+
+**Trigger**: issue #146. `deferred_qos2_zero_quota_still_serves_control_plane [MQTT-4.9.0-3]` failed
+twice on `main` in the external-mqtt5 job (`8791b58` 2026-08-12, `a8c791a` 2026-09-06), both times
+`Timeout("pubrec")` from the test's QoS 2 publisher. Identical code passed on neighbouring commits.
+
+**Root cause**: `TestClient::publish_with_options`, `subscribe` and `unsubscribe` all wrote the packet
+first and only then called `await_ack`, which is where the `oneshot` waiter was inserted into
+`pending_acks`. The reader task resolves an incoming ack by `remove`-ing the packet id from that map
+and drops it if nothing is registered. If the broker's reply was read in the gap between the flush
+returning and the insert, the ack was gone and the waiter expired after `ACK_TIMEOUT`. The window is
+microseconds of synchronous code, so it needs the test thread to be preempted at that instant; a
+loaded two-core runner with a separate broker process does that occasionally, which is why only the
+external-broker job ever failed and why re-runs pass.
+
+**This corrects the 2026-08-06 entry below.** That investigation saw `Timeout("puback")` on the same
+job, correctly ruled out concurrency and CPU starvation, could not reproduce it, and concluded it was
+"the rare timing transient the 30s `ACK_TIMEOUT` already exists to absorb". A 30-second timeout
+expiring is not a slow broker. It is an ack that was consumed with no one waiting. Same race, QoS 1
+flavour. The memory-backend change made there was still sound; it just did not touch this.
+
+**Fix**: one `send_and_await_ack(packet, id, op)` helper registers the waiter, then writes, then
+waits, removing the waiter if the write fails. All five sites use it (PUBACK, PUBREC, PUBCOMP after
+PUBREL, SUBACK, UNSUBACK), so the ordering can no longer be gotten wrong per call site.
+
+**Tests**: `ack_map_tests` (not fixture-gated) pin the map semantics: an ack completed after
+registration is delivered; one completed before registration is lost. The race itself is not
+reproducible on demand; the proof is structural, plus CI history from here.
+
+**Lesson**: a send-then-register pattern around a oneshot map is a lost-wakeup bug, however small the
+window. Register first, always.
+
 ### [MQTT-3.1.4-3] takeover DISCONNECT is now required by the test, and sent by the broker (2026-09-07)
 
 **Trigger**: issue #147. The in-tree broker closed the displaced client's socket on session takeover

--- a/crates/mqtt5-conformance/src/test_client/raw.rs
+++ b/crates/mqtt5-conformance/src/test_client/raw.rs
@@ -192,22 +192,22 @@ impl RawTestClient {
         Ok(())
     }
 
-    async fn await_ack(
+    async fn send_and_await_ack<P: MqttPacket>(
         &self,
+        packet: &P,
         packet_id: u16,
         op: &'static str,
     ) -> Result<AckOutcome, TestClientError> {
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut acks = self.shared.pending_acks.lock().unwrap();
-            acks.insert(packet_id, tx);
+        let ack = register_ack(&self.shared.pending_acks, packet_id);
+        if let Err(e) = self.write_packet(packet).await {
+            self.shared.pending_acks.lock().unwrap().remove(&packet_id);
+            return Err(e);
         }
-        match tokio::time::timeout(ACK_TIMEOUT, rx).await {
+        match tokio::time::timeout(ACK_TIMEOUT, ack).await {
             Ok(Ok(outcome)) => Ok(outcome),
             Ok(Err(_)) => Err(TestClientError::Disconnected),
             Err(_) => {
-                let mut acks = self.shared.pending_acks.lock().unwrap();
-                acks.remove(&packet_id);
+                self.shared.pending_acks.lock().unwrap().remove(&packet_id);
                 Err(TestClientError::Timeout(op))
             }
         }
@@ -272,11 +272,12 @@ impl RawTestClient {
             publish.properties.set_subscription_identifier(sub_id);
         }
 
-        self.write_packet(&publish).await?;
-
         match qos {
-            QoS::AtMostOnce => Ok(()),
-            QoS::AtLeastOnce => match self.await_ack(packet_id, "puback").await? {
+            QoS::AtMostOnce => self.write_packet(&publish).await,
+            QoS::AtLeastOnce => match self
+                .send_and_await_ack(&publish, packet_id, "puback")
+                .await?
+            {
                 AckOutcome::PubAck(rc) => {
                     if rc.is_success() {
                         Ok(())
@@ -291,7 +292,10 @@ impl RawTestClient {
                 ))),
             },
             QoS::ExactlyOnce => {
-                match self.await_ack(packet_id, "pubrec").await? {
+                match self
+                    .send_and_await_ack(&publish, packet_id, "pubrec")
+                    .await?
+                {
                     AckOutcome::PubRec(rc) if rc.is_success() => {}
                     AckOutcome::PubRec(rc) => {
                         return Err(TestClientError::Unexpected(format!(
@@ -305,8 +309,10 @@ impl RawTestClient {
                     }
                 }
                 let pubrel = PubRelPacket::new(packet_id);
-                self.write_packet(&pubrel).await?;
-                match self.await_ack(packet_id, "pubcomp").await? {
+                match self
+                    .send_and_await_ack(&pubrel, packet_id, "pubcomp")
+                    .await?
+                {
                     AckOutcome::PubComp(rc) if rc.is_success() => Ok(()),
                     AckOutcome::PubComp(rc) => Err(TestClientError::Unexpected(format!(
                         "PUBCOMP reason code {rc:?}"
@@ -355,9 +361,9 @@ impl RawTestClient {
             subscribe = subscribe.with_subscription_identifier(sub_id);
         }
 
-        self.write_packet(&subscribe).await?;
-
-        let outcome = self.await_ack(packet_id, "suback").await?;
+        let outcome = self
+            .send_and_await_ack(&subscribe, packet_id, "suback")
+            .await?;
         let granted_qos = match outcome {
             AckOutcome::SubAck(codes) => {
                 let first = codes.first().copied().ok_or_else(|| {
@@ -393,9 +399,11 @@ impl RawTestClient {
 
         let packet_id = self.allocate_packet_id();
         let unsubscribe = UnsubscribePacket::new(packet_id).add_filter(filter.to_string());
-        self.write_packet(&unsubscribe).await?;
 
-        match self.await_ack(packet_id, "unsuback").await? {
+        match self
+            .send_and_await_ack(&unsubscribe, packet_id, "unsuback")
+            .await?
+        {
             AckOutcome::UnsubAck(codes) => {
                 if codes
                     .iter()
@@ -645,6 +653,12 @@ async fn send_raw<P: MqttPacket>(shared: &SharedState, packet: &P) -> Result<(),
     Ok(())
 }
 
+fn register_ack(acks: &AckMap, packet_id: u16) -> oneshot::Receiver<AckOutcome> {
+    let (tx, rx) = oneshot::channel();
+    acks.lock().unwrap().insert(packet_id, tx);
+    rx
+}
+
 fn complete_ack(acks: &AckMap, packet_id: u16, outcome: AckOutcome) {
     if let Some(tx) = acks.lock().unwrap().remove(&packet_id) {
         let _ = tx.send(outcome);
@@ -654,6 +668,38 @@ fn complete_ack(acks: &AckMap, packet_id: u16, outcome: AckOutcome) {
 fn drop_pending_acks(acks: &AckMap) {
     let mut guard = acks.lock().unwrap();
     guard.clear();
+}
+
+#[cfg(test)]
+mod ack_map_tests {
+    use super::{complete_ack, register_ack, AckMap, AckOutcome};
+    use mqtt5_protocol::types::ReasonCode;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn ack_completed_after_registration_is_delivered() {
+        let acks: AckMap = Arc::new(Mutex::new(HashMap::new()));
+        let rx = register_ack(&acks, 7);
+        complete_ack(&acks, 7, AckOutcome::PubRec(ReasonCode::Success));
+        assert!(matches!(
+            rx.await,
+            Ok(AckOutcome::PubRec(ReasonCode::Success))
+        ));
+    }
+
+    #[tokio::test]
+    async fn ack_completed_before_registration_is_lost() {
+        let acks: AckMap = Arc::new(Mutex::new(HashMap::new()));
+        complete_ack(&acks, 7, AckOutcome::PubRec(ReasonCode::Success));
+        let rx = register_ack(&acks, 7);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), rx)
+                .await
+                .is_err(),
+            "an ack that arrives before the waiter is registered is dropped; register before sending"
+        );
+    }
 }
 
 #[cfg(all(test, feature = "inprocess-fixture"))]

--- a/crates/mqtt5/src/transport/quic_stream_manager.rs
+++ b/crates/mqtt5/src/transport/quic_stream_manager.rs
@@ -12,9 +12,9 @@ use tokio::sync::Mutex;
 use tracing::{debug, instrument, trace, warn};
 
 struct StreamInfo {
-    stream: SendStream,
+    stream: Mutex<SendStream>,
     flow_id: FlowId,
-    last_used: Instant,
+    last_used: std::sync::Mutex<Instant>,
 }
 
 struct FlowStreamInfo {
@@ -28,7 +28,7 @@ const DEFAULT_FLOW_EXPIRE_INTERVAL: u64 = 300;
 pub struct QuicStreamManager {
     connection: Arc<Connection>,
     strategy: StreamStrategy,
-    topic_streams: Arc<Mutex<HashMap<String, StreamInfo>>>,
+    topic_streams: Arc<Mutex<HashMap<String, Arc<StreamInfo>>>>,
     flow_streams: Arc<Mutex<HashMap<FlowId, FlowStreamInfo>>>,
     max_cached_streams: usize,
     stream_idle_timeout: Duration,
@@ -190,37 +190,40 @@ impl QuicStreamManager {
     }
 
     // [MQoQ§5.3] Per-topic stream caching
-    async fn get_or_create_topic_stream(&self, topic: &str) -> Result<(SendStream, FlowId)> {
+    async fn get_or_create_topic_stream(&self, topic: &str) -> Result<Arc<StreamInfo>> {
         let mut streams = self.topic_streams.lock().await;
         let now = Instant::now();
 
         let idle_topics: Vec<String> = streams
             .iter()
-            .filter(|(_, info)| now.duration_since(info.last_used) > self.stream_idle_timeout)
+            .filter(|(_, info)| {
+                now.duration_since(info.last_used.lock().map_or(now, |used| *used))
+                    > self.stream_idle_timeout
+            })
             .map(|(topic, _)| topic.clone())
             .collect();
 
         for idle_topic in &idle_topics {
-            if let Some(mut info) = streams.remove(idle_topic) {
-                let _ = info.stream.finish();
+            if let Some(info) = streams.remove(idle_topic) {
+                let _ = info.stream.lock().await.finish();
                 debug!(topic = %idle_topic, flow_id = ?info.flow_id, "Closed idle stream");
             }
         }
 
-        if let Some(info) = streams.remove(topic) {
+        if let Some(info) = streams.get(topic) {
             trace!(topic = %topic, flow_id = ?info.flow_id, "Reusing existing stream for topic");
-            return Ok((info.stream, info.flow_id));
+            return Ok(Arc::clone(info));
         }
 
         if streams.len() >= self.max_cached_streams {
             let oldest = streams
                 .iter()
-                .min_by_key(|(_, info)| info.last_used)
+                .min_by_key(|(_, info)| info.last_used.lock().map_or(now, |used| *used))
                 .map(|(k, _)| k.clone());
 
             if let Some(oldest_topic) = oldest {
-                if let Some(mut info) = streams.remove(&oldest_topic) {
-                    let _ = info.stream.finish();
+                if let Some(info) = streams.remove(&oldest_topic) {
+                    let _ = info.stream.lock().await.finish();
                     debug!(
                         topic = %oldest_topic,
                         flow_id = ?info.flow_id,
@@ -229,8 +232,6 @@ impl QuicStreamManager {
                 }
             }
         }
-        drop(streams);
-
         debug!(topic = %topic, "Opening new stream for topic");
         let mut send = self.connection.open_uni().await.map_err(|e| {
             MqttError::ConnectionError(format!("Failed to open QUIC stream for topic: {e}"))
@@ -257,7 +258,13 @@ impl QuicStreamManager {
             FlowId::client(0)
         };
 
-        Ok((send, flow_id))
+        let info = Arc::new(StreamInfo {
+            stream: Mutex::new(send),
+            flow_id,
+            last_used: std::sync::Mutex::new(Instant::now()),
+        });
+        streams.insert(topic.to_string(), Arc::clone(&info));
+        Ok(info)
     }
 
     /// Sends a packet on a topic-specific stream.
@@ -265,26 +272,23 @@ impl QuicStreamManager {
     /// # Errors
     /// Returns an error if the stream operation or packet encoding fails.
     pub async fn send_on_topic_stream(&self, topic: String, packet: Packet) -> Result<()> {
-        let (mut stream, flow_id) = self.get_or_create_topic_stream(&topic).await?;
+        let info = self.get_or_create_topic_stream(&topic).await?;
 
         let mut buf = BytesMut::with_capacity(1024);
         encode_packet_to_buffer(&packet, &mut buf)?;
 
-        stream
+        info.stream
+            .lock()
+            .await
             .write_all(&buf)
             .await
             .map_err(|e| MqttError::ConnectionError(format!("QUIC write error: {e}")))?;
 
-        debug!(topic = %topic, flow_id = ?flow_id, "Sent packet on topic-specific stream");
+        if let Ok(mut last_used) = info.last_used.lock() {
+            *last_used = Instant::now();
+        }
 
-        self.topic_streams.lock().await.insert(
-            topic,
-            StreamInfo {
-                stream,
-                flow_id,
-                last_used: Instant::now(),
-            },
-        );
+        debug!(topic = %topic, flow_id = ?info.flow_id, "Sent packet on topic-specific stream");
 
         Ok(())
     }
@@ -433,8 +437,8 @@ impl QuicStreamManager {
 
     pub async fn close_all_streams(&self) {
         let mut streams = self.topic_streams.lock().await;
-        for (topic, mut info) in streams.drain() {
-            let _ = info.stream.finish();
+        for (topic, info) in streams.drain() {
+            let _ = info.stream.lock().await.finish();
             trace!(topic = %topic, flow_id = ?info.flow_id, "Closed topic stream");
         }
         drop(streams);

--- a/crates/mqtt5/tests/cli_functionality.rs
+++ b/crates/mqtt5/tests/cli_functionality.rs
@@ -208,7 +208,7 @@ async fn test_cli_message_throughput() {
     println!("   Throughput: {msgs_per_sec:.1} messages/second");
 }
 
-/// Bench throughput mode emits a valid flat schema and, at QoS1, the open-loop
+/// Bench throughput mode emits a valid flat schema and, at `QoS1`, the open-loop
 /// generator plus real flow control delivers ~everything offered (no coordinated-omission
 /// collapse and no overshoot) — the property the saturation rework must preserve.
 #[tokio::test]

--- a/crates/mqttv5-cli/src/commands/bench_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/bench_cmd.rs
@@ -711,9 +711,16 @@ async fn connect_counting_subscribers(
         let sub_client = connect_client(format!("{base_id}-sub-{i}"), url, cmd).await?;
         let received_clone = Arc::clone(received);
         sub_client
-            .subscribe(filter, move |_msg| {
-                received_clone.fetch_add(1, Ordering::Relaxed);
-            })
+            .subscribe_with_options(
+                filter,
+                mqtt5::SubscribeOptions {
+                    qos: cmd.qos,
+                    ..Default::default()
+                },
+                move |_msg| {
+                    received_clone.fetch_add(1, Ordering::Relaxed);
+                },
+            )
             .await
             .context("failed to subscribe")?;
         sub_clients.push(sub_client);
@@ -1029,14 +1036,21 @@ async fn run_latency(cmd: BenchCommand) -> Result<()> {
     let format = cmd.payload_format;
 
     sub_client
-        .subscribe(&filter, move |msg| {
-            let sent_nanos = decode_timestamp(format, &msg.payload);
-            if sent_nanos > 0 {
-                let now_nanos = nanos_as_u64();
-                let latency_us = (now_nanos.saturating_sub(sent_nanos)) / 1000;
-                latencies_clone.lock().unwrap().push(latency_us);
-            }
-        })
+        .subscribe_with_options(
+            &filter,
+            mqtt5::SubscribeOptions {
+                qos: cmd.qos,
+                ..Default::default()
+            },
+            move |msg| {
+                let sent_nanos = decode_timestamp(format, &msg.payload);
+                if sent_nanos > 0 {
+                    let now_nanos = nanos_as_u64();
+                    let latency_us = (now_nanos.saturating_sub(sent_nanos)) / 1000;
+                    latencies_clone.lock().unwrap().push(latency_us);
+                }
+            },
+        )
         .await
         .context("failed to subscribe")?;
 


### PR DESCRIPTION
Closes #146.

## Root cause

The conformance test client registered its ack waiter *after* sending the packet. `publish_with_options`, `subscribe` and `unsubscribe` all did `write_packet(..)` and only then called `await_ack`, which is where the `oneshot` sender was inserted into `pending_acks`. The reader task resolves incoming PUBACK/PUBREC/PUBCOMP/SUBACK/UNSUBACK by looking the packet id up in that map and, finding no waiter, drops the ack (`complete_ack` is `remove(..).map(send)`). So whenever the broker's reply was read before the waiter existed, the waiter waited for an ack that had already come and expired after `ACK_TIMEOUT`. That is why the failure is `Timeout("pubrec")` after 30 s rather than a slow response, and why it only shows up against an out-of-process broker: over a real socket the reader task can win that race whenever the test's thread is preempted between the flush returning and the insert, which a loaded two-core runner does occasionally.

`deferred_qos2_zero_quota_still_serves_control_plane` was just the test most likely to be hit, since its publisher does two back-to-back QoS 2 publishes. The 2026-08-06 diary entry investigated `puback_error_stops_retransmission` failing with `Timeout("puback")` on the same job, ruled out concurrency and CPU starvation, could not reproduce it, and left it as "the rare timing transient the 30s ACK_TIMEOUT already exists to absorb". A 30 s timeout expiring is not a slow broker; it is a lost wakeup. Same race.

## Fix

A single `send_and_await_ack(packet, packet_id, op)` helper registers the waiter, then writes the packet, then waits; if the write fails it removes the waiter. All five sites use it: QoS 1 PUBACK, QoS 2 PUBREC and then PUBCOMP (the waiter for PUBCOMP is registered before PUBREL is written), SUBACK, UNSUBACK. There is no longer a call site that can order these wrongly.

## Tests

Two map-level tests, not gated on the in-process fixture:

- `ack_completed_after_registration_is_delivered`
- `ack_completed_before_registration_is_lost` — documents the hazard the old order exposed.

The race itself is not reproducible on demand (the window is a few microseconds and needs an OS preemption at that instant), so the proof is structural plus the CI history going forward. The full in-process conformance suite passes with the change. Logged in `CONFORMANCE_DIARY.md`, correcting the earlier entry.

No published crate changes; test infrastructure only.
