### PR TITLE
Document the per-topic QUIC stream-race fix (mqtt5 0.39.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.39.3] - 2026-09-08
+
+### Fixed
+
+- **Concurrent publishes to the same topic no longer race to open duplicate per-topic QUIC streams.** Under the per-topic delivery strategy the broker caches one server-initiated QUIC stream per topic in `topic_streams`. To send, `send_on_topic_stream` **removed** the stream's `StreamInfo` (owning the `SendStream`) from the map, wrote to it, then re-inserted it. Two publishes to the same topic that overlapped in that window found the entry absent and each opened a fresh stream, so a hot topic accumulated redundant streams, evicted other topics' cached streams under `max_cached_streams`, and reported an inflated per-topic stream count. The cache now holds each stream as an `Arc<StreamInfo>` whose `SendStream` sits behind its own `Mutex` (and `last_used` behind a `std::sync::Mutex`); `get_or_create_topic_stream` keeps the entry in the map and returns a shared handle, and a send locks only that stream's mutex. Concurrent sends to one topic now share the single cached stream, serialized by its mutex, instead of racing to create duplicates. Landed in #152, which lacked a changelog note for this broker change.
+
 ## [mqtt5 0.39.2] - 2026-09-07
 
 ### Fixed

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.39.2"
+version = "0.39.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Follow-up documentation for #152.

`#152` (squash `7eef0c6`) landed a real broker behavior change in `crates/mqtt5/src/transport/quic_stream_manager.rs` — per-topic QUIC streams are now shared via `Arc<StreamInfo>` with a per-stream `Mutex<SendStream>` instead of being removed-and-reinserted from the topic map on every send — but that PR's squash message described only the conformance-test-client change ("register the ack waiter…") and added no CHANGELOG entry for the broker fix.

This PR adds the missing note and bumps `mqtt5` to 0.39.3.

**What the fix does (from the actual diff):** under the per-topic delivery strategy the broker caches one server-initiated QUIC stream per topic. `send_on_topic_stream` used to remove the stream's `StreamInfo` from `topic_streams`, write to it, then re-insert it; two publishes to the same topic overlapping in that window each found the entry absent and opened a fresh stream, accumulating redundant streams, evicting other topics' cached streams under `max_cached_streams`, and inflating the per-topic stream count. The cache now holds each stream as `Arc<StreamInfo>` behind its own mutex, so concurrent sends to one topic share the single cached stream.

**Release note:** patch bump (0.39.2 → 0.39.3); the `mqttv5-cli` / `mqtt5-wasm` `"0.39"` requirements already admit it, so no lockstep change. No code change here — only `CHANGELOG.md` and the version field. Pushing a `v0.39.3` tag would publish it per `release.yml`.
