### PR TITLE
Fix QoS1 backlog overload with a bounded, drained per-client delivery queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [mqtt5 0.40.0] - 2026-09-08
+
+### Breaking
+
+- **`MessageRouter::register_client` now takes a `DeliveryLanes` (two per-client lane senders) and a `QueueHandle` instead of a single delivery-channel sender, and new public types back the per-client delivery queue** (`ClientQueue`, `QueueHandle`, `QueueLimits`, `QueueRegistry`, `DeliveryLanes`, `Registration`, `Release`, and related). Code that drives the router directly — a custom broker front-end, as `mqtt5-wasm` does — must build the two lanes and obtain the client's queue handle; in-process broker use through `MqttBroker` is unaffected.
+
+### Fixed
+
+- **A saturating QoS 1 flood to a slow but still-connected subscriber no longer stalls delivery or grows broker memory without bound.** When a subscriber's bounded delivery channel filled, QoS >= 1 messages were diverted into the offline queue — the structure meant for *disconnected* clients — which was unbounded and never drained while the client stayed connected, so delivery to that subscriber stalled and broker RSS grew from ~9 MB to ~15 GB in a single run. The offline and live paths are now one ordered, bounded, back-pressured path: a per-client `ClientQueue` (bounded, drop-oldest) drained in bounded batches; two delivery lanes with a real Receive-Maximum window; the PUBACK/PUBREC withheld until the message is placed; and session takeover, clean-start discard, and bridge ingress reworked to keep it correct under the new model. The in-browser `mqtt5-wasm` broker moves to the same path. Reported in issue #148; two narrow residual edge cases are tracked as #150 and #151.
+
+## [mqttv5-cli 0.28.7] - 2026-09-08
+
+### Changed
+
+- Depends on `mqtt5` 0.40.
+
+## [mqtt5-wasm 1.4.6] - 2026-09-08
+
+### Changed
+
+- Depends on `mqtt5` 0.40 and `mqtt5-protocol` 0.15.1. The wasm broker's delivery path moves to the same bounded per-client delivery queue as the native broker (see mqtt5 0.40.0).
+
+## [mqtt5-protocol 0.15.1] - 2026-09-08
+
+### Added
+
+- **`Properties::subscription_identifiers()` and `Properties::remove_subscription_identifiers()`** — read every Subscription Identifier on a packet, or strip them all. Used by the broker's bridge ingress to deliver each overlapping topic mapping exactly once.
+
 ## [mqtt5 0.39.3] - 2026-09-08
 
 ### Fixed

--- a/crates/mqtt5-protocol/Cargo.toml
+++ b/crates/mqtt5-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-protocol"
-version = "0.15.0"
+version = "0.15.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
+++ b/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
@@ -1,5 +1,5 @@
 use super::{Properties, PropertyId, PropertyValue};
-use crate::prelude::String;
+use crate::prelude::{String, Vec};
 use bytes::Bytes;
 
 impl Properties {

--- a/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
+++ b/crates/mqtt5-protocol/src/protocol/v5/properties/accessors.rs
@@ -128,6 +128,27 @@ impl Properties {
             .push(PropertyValue::VariableByteInteger(id));
     }
 
+    /// Every Subscription Identifier carried by the packet, in wire order.
+    #[must_use]
+    pub fn subscription_identifiers(&self) -> Vec<u32> {
+        self.properties
+            .get(&PropertyId::SubscriptionIdentifier)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|value| match value {
+                        PropertyValue::VariableByteInteger(id) => Some(*id),
+                        _ => None,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn remove_subscription_identifiers(&mut self) {
+        self.properties.remove(&PropertyId::SubscriptionIdentifier);
+    }
+
     #[must_use]
     pub fn get_subscription_identifier(&self) -> Option<u32> {
         self.properties

--- a/crates/mqtt5-wasm/Cargo.toml
+++ b/crates/mqtt5-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5-wasm"
-version = "1.4.5"
+version = "1.4.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -27,8 +27,8 @@ broker = ["client", "dep:mqtt5", "mqtt5/broker", "dep:tokio"]
 codec = ["client", "dep:miniz_oxide"]
 
 [dependencies]
-mqtt5-protocol = "0.15.0"
-mqtt5 = { version = "0.39", optional = true, default-features = false, features = [
+mqtt5-protocol = "0.15.1"
+mqtt5 = { version = "0.40", optional = true, default-features = false, features = [
     "tokio",
 ] }
 

--- a/crates/mqtt5-wasm/src/client_handler/connect.rs
+++ b/crates/mqtt5-wasm/src/client_handler/connect.rs
@@ -138,8 +138,8 @@ impl WasmClientHandler {
         self.fire_client_connect(&connect.client_id, connect.clean_start);
 
         if session_present {
-            self.deliver_queued_messages(&connect.client_id, writer)
-                .await?;
+            // Offline-queued messages are drained by the publish forwarder from the shared
+            // per-client queue; delivering them here too would double-deliver.
             self.resend_inflight_messages(writer).await?;
             self.advance_packet_id_past_inflight();
         }
@@ -297,8 +297,8 @@ impl WasmClientHandler {
                     );
 
                     if session_present {
-                        self.deliver_queued_messages(&pending.connect.client_id, writer)
-                            .await?;
+                        // Offline-queued messages are drained by the publish forwarder; see
+                        // handle_session above.
                         self.resend_inflight_messages(writer).await?;
                         self.advance_packet_id_past_inflight();
                     }

--- a/crates/mqtt5-wasm/src/client_handler/mod.rs
+++ b/crates/mqtt5-wasm/src/client_handler/mod.rs
@@ -61,6 +61,7 @@ pub struct WasmClientHandler {
     qos0_rx: tokio::sync::mpsc::Receiver<RoutableMessage>,
     qos0_tx: tokio::sync::mpsc::Sender<RoutableMessage>,
     queue: Option<QueueHandle>,
+    generation: u64,
     pub(super) inflight_publishes: HashMap<u16, PublishPacket>,
     pub(super) outbound_inflight: Rc<RefCell<HashMap<u16, PublishPacket>>>,
     pub(super) next_packet_id: Rc<Cell<u16>>,
@@ -183,6 +184,7 @@ impl WasmClientHandler {
             qos0_rx,
             qos0_tx,
             queue: None,
+            generation: 0,
             inflight_publishes: HashMap::new(),
             outbound_inflight: Rc::new(RefCell::new(HashMap::new())),
             next_packet_id: Rc::new(Cell::new(1)),
@@ -217,7 +219,8 @@ impl WasmClientHandler {
 
         let queue = self.router.queue_handle(&client_id);
         self.queue = Some(queue.clone());
-        self.router
+        let registration = self
+            .router
             .register_client(
                 client_id.clone(),
                 DeliveryLanes {
@@ -228,6 +231,7 @@ impl WasmClientHandler {
                 disconnect_tx,
             )
             .await;
+        self.generation = registration.generation;
 
         self.stats.client_connected();
 
@@ -237,7 +241,7 @@ impl WasmClientHandler {
             self.publish_will_message(&client_id).await;
         }
 
-        self.router.unregister_client(&client_id).await;
+        self.release_router_entry(&client_id).await;
         self.stats.client_disconnected();
 
         result
@@ -266,7 +270,8 @@ impl WasmClientHandler {
 
         let queue = self.router.queue_handle(&client_id);
         self.queue = Some(queue.clone());
-        self.router
+        let registration = self
+            .router
             .register_client(
                 client_id.clone(),
                 DeliveryLanes {
@@ -277,6 +282,7 @@ impl WasmClientHandler {
                 disconnect_tx,
             )
             .await;
+        self.generation = registration.generation;
 
         self.stats.client_connected();
 
@@ -291,10 +297,24 @@ impl WasmClientHandler {
 
         self.fire_client_disconnect(&client_id, reason, unexpected);
 
-        self.router.unregister_client(&client_id).await;
+        self.release_router_entry(&client_id).await;
         self.stats.client_disconnected();
 
         result
+    }
+
+    /// Releases this connection's router entry, but only if it still owns it. A newer
+    /// connection with the same client id takes over the entry (a higher generation); an
+    /// unconditional unregister here would evict that live successor and strip its
+    /// subscriptions.
+    async fn release_router_entry(&self, client_id: &str) {
+        let preserve_session = self
+            .session
+            .as_ref()
+            .is_some_and(|session| session.expiry_interval != Some(0));
+        self.router
+            .release_client(client_id, self.generation, preserve_session)
+            .await;
     }
 
     fn spawn_disconnect_watcher(
@@ -399,7 +419,8 @@ impl WasmClientHandler {
                         }
                     } => {
                         if let Some(queue) = &queue {
-                            for message in queue.take(64).await {
+                            let mut pending = queue.take(64).await.into_iter();
+                            while let Some(message) = pending.next() {
                                 if !Self::forward_one(
                                     message.to_publish_packet(),
                                     &writer_for_forward,
@@ -411,6 +432,13 @@ impl WasmClientHandler {
                                 )
                                 .await
                                 {
+                                    // A write error must not drop the drained batch: put the
+                                    // failed message and the untried remainder back at the
+                                    // front so they survive for redelivery.
+                                    let mut rest = vec![message];
+                                    rest.extend(pending);
+                                    queue.requeue_front(rest);
+                                    queue.finish_drain();
                                     break 'outer;
                                 }
                             }

--- a/crates/mqtt5-wasm/src/client_handler/mod.rs
+++ b/crates/mqtt5-wasm/src/client_handler/mod.rs
@@ -227,11 +227,12 @@ impl WasmClientHandler {
                     qos1_tx: self.qos1_tx.clone(),
                     qos0_tx: self.qos0_tx.clone(),
                 },
-                queue,
+                queue.clone(),
                 disconnect_tx,
             )
             .await;
         self.generation = registration.generation;
+        queue.notify();
 
         self.stats.client_connected();
 
@@ -278,11 +279,12 @@ impl WasmClientHandler {
                     qos1_tx: self.qos1_tx.clone(),
                     qos0_tx: self.qos0_tx.clone(),
                 },
-                queue,
+                queue.clone(),
                 disconnect_tx,
             )
             .await;
         self.generation = registration.generation;
+        queue.notify();
 
         self.stats.client_connected();
 

--- a/crates/mqtt5-wasm/src/client_handler/mod.rs
+++ b/crates/mqtt5-wasm/src/client_handler/mod.rs
@@ -13,8 +13,8 @@ use mqtt5::broker::auth::AuthProvider;
 use mqtt5::broker::config::BrokerConfig;
 use mqtt5::broker::resource_monitor::ResourceMonitor;
 use mqtt5::broker::router::MessageRouter;
-use mqtt5::broker::router::RoutableMessage;
-use mqtt5::broker::storage::{ClientSession, DynamicStorage};
+use mqtt5::broker::router::{DeliveryLanes, RoutableMessage};
+use mqtt5::broker::storage::{ClientSession, DynamicStorage, QueueHandle};
 use mqtt5::broker::sys_topics::BrokerStats;
 use mqtt5_protocol::error::{MqttError, Result};
 use mqtt5_protocol::packet::publish::PublishPacket;
@@ -56,8 +56,11 @@ pub struct WasmClientHandler {
     pub(super) stats: Arc<BrokerStats>,
     pub(super) resource_monitor: Arc<ResourceMonitor>,
     pub(super) session: Option<ClientSession>,
-    publish_rx: flume::Receiver<RoutableMessage>,
-    publish_tx: flume::Sender<RoutableMessage>,
+    qos1_rx: tokio::sync::mpsc::Receiver<RoutableMessage>,
+    qos1_tx: tokio::sync::mpsc::Sender<RoutableMessage>,
+    qos0_rx: tokio::sync::mpsc::Receiver<RoutableMessage>,
+    qos0_tx: tokio::sync::mpsc::Sender<RoutableMessage>,
+    queue: Option<QueueHandle>,
     pub(super) inflight_publishes: HashMap<u16, PublishPacket>,
     pub(super) outbound_inflight: Rc<RefCell<HashMap<u16, PublishPacket>>>,
     pub(super) next_packet_id: Rc<Cell<u16>>,
@@ -143,7 +146,8 @@ impl WasmClientHandler {
         use futures::channel::mpsc;
         use wasm_bindgen::JsCast;
 
-        let (publish_tx, publish_rx) = flume::bounded(100);
+        let (qos1_tx, qos1_rx) = tokio::sync::mpsc::channel(100);
+        let (qos0_tx, qos0_rx) = tokio::sync::mpsc::channel(100);
         let handler_id = HANDLER_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
         let (msg_tx, msg_rx) = mpsc::unbounded();
@@ -174,8 +178,11 @@ impl WasmClientHandler {
             stats,
             resource_monitor,
             session: None,
-            publish_rx,
-            publish_tx,
+            qos1_rx,
+            qos1_tx,
+            qos0_rx,
+            qos0_tx,
+            queue: None,
             inflight_publishes: HashMap::new(),
             outbound_inflight: Rc::new(RefCell::new(HashMap::new())),
             next_packet_id: Rc::new(Cell::new(1)),
@@ -208,8 +215,18 @@ impl WasmClientHandler {
         let client_id = self.client_id.clone().unwrap();
         let (disconnect_tx, disconnect_rx) = tokio::sync::oneshot::channel();
 
+        let queue = self.router.queue_handle(&client_id);
+        self.queue = Some(queue.clone());
         self.router
-            .register_client(client_id.clone(), self.publish_tx.clone(), disconnect_tx)
+            .register_client(
+                client_id.clone(),
+                DeliveryLanes {
+                    qos1_tx: self.qos1_tx.clone(),
+                    qos0_tx: self.qos0_tx.clone(),
+                },
+                queue,
+                disconnect_tx,
+            )
             .await;
 
         self.stats.client_connected();
@@ -247,8 +264,18 @@ impl WasmClientHandler {
         let client_id = self.client_id.clone().unwrap();
         let (disconnect_tx, disconnect_rx) = tokio::sync::oneshot::channel();
 
+        let queue = self.router.queue_handle(&client_id);
+        self.queue = Some(queue.clone());
         self.router
-            .register_client(client_id.clone(), self.publish_tx.clone(), disconnect_tx)
+            .register_client(
+                client_id.clone(),
+                DeliveryLanes {
+                    qos1_tx: self.qos1_tx.clone(),
+                    qos0_tx: self.qos0_tx.clone(),
+                },
+                queue,
+                disconnect_tx,
+            )
             .await;
 
         self.stats.client_connected();
@@ -272,12 +299,12 @@ impl WasmClientHandler {
 
     fn spawn_disconnect_watcher(
         running: &Rc<RefCell<bool>>,
-        disconnect_rx: tokio::sync::oneshot::Receiver<()>,
+        disconnect_rx: tokio::sync::oneshot::Receiver<mqtt5::broker::router::TakeoverNotice>,
     ) {
         let running_clone = Rc::clone(running);
         spawn_local(async move {
             match disconnect_rx.await {
-                Ok(()) => {
+                Ok(_notice) => {
                     info!("Session takeover signal received");
                     *running_clone.borrow_mut() = false;
                 }
@@ -288,13 +315,61 @@ impl WasmClientHandler {
         });
     }
 
+    /// Writes one outbound publish to the client, assigning a packet id and persisting the
+    /// exactly-once inflight record. Returns `false` on a fatal write error so the forwarder
+    /// stops. Shared by the two delivery lanes and the drained session queue.
+    async fn forward_one(
+        mut publish: PublishPacket,
+        writer: &Rc<RefCell<WasmWriter>>,
+        outbound_inflight: &Rc<RefCell<HashMap<u16, PublishPacket>>>,
+        next_pid: &Rc<Cell<u16>>,
+        storage: &Arc<DynamicStorage>,
+        client_id: &str,
+        handler_id: u32,
+    ) -> bool {
+        use mqtt5::broker::storage::{
+            InflightDirection, InflightMessage, InflightPhase, StorageBackend,
+        };
+
+        if publish.qos != QoS::AtMostOnce {
+            let pid = next_pid.get();
+            next_pid.set(if pid == u16::MAX { 1 } else { pid + 1 });
+            publish.packet_id = Some(pid);
+
+            if publish.qos == QoS::ExactlyOnce {
+                outbound_inflight.borrow_mut().insert(pid, publish.clone());
+                let inflight = InflightMessage::from_publish(
+                    &publish,
+                    client_id.to_string(),
+                    InflightDirection::Outbound,
+                    InflightPhase::AwaitingPubrec,
+                );
+                if let Err(e) = storage.store_inflight_message(inflight).await {
+                    tracing::debug!("failed to persist outbound inflight {pid}: {e}");
+                }
+            }
+        }
+
+        if let Ok(mut writer_guard) = writer.try_borrow_mut() {
+            if let Err(e) = Self::write_publish_packet(&publish, &mut writer_guard) {
+                error!("Handler #{handler_id} error forwarding publish: {e}");
+                return false;
+            }
+        } else {
+            error!("Handler #{handler_id} writer busy, cannot forward");
+        }
+        true
+    }
+
     fn spawn_publish_forwarder(
         &mut self,
         running: &Rc<RefCell<bool>>,
         writer_shared: &Rc<RefCell<WasmWriter>>,
     ) {
         let running_forward = Rc::clone(running);
-        let publish_rx = std::mem::replace(&mut self.publish_rx, flume::bounded(1).1);
+        let mut qos1_rx = std::mem::replace(&mut self.qos1_rx, tokio::sync::mpsc::channel(1).1);
+        let mut qos0_rx = std::mem::replace(&mut self.qos0_rx, tokio::sync::mpsc::channel(1).1);
+        let queue = self.queue.clone();
         let writer_for_forward = Rc::clone(writer_shared);
         let outbound_inflight_fwd = Rc::clone(&self.outbound_inflight);
         let next_pid_fwd = Rc::clone(&self.next_packet_id);
@@ -303,52 +378,63 @@ impl WasmClientHandler {
         let handler_id = self.handler_id;
 
         spawn_local(async move {
-            use mqtt5::broker::storage::{
-                InflightDirection, InflightMessage, InflightPhase, StorageBackend,
-            };
-
-            loop {
+            'outer: loop {
                 if !*running_forward.borrow() {
                     break;
                 }
 
-                match publish_rx.recv_async().await {
-                    Ok(routable) => {
-                        let mut publish = routable.publish;
-                        if publish.qos != QoS::AtMostOnce {
-                            let pid = next_pid_fwd.get();
-                            next_pid_fwd.set(if pid == u16::MAX { 1 } else { pid + 1 });
-                            publish.packet_id = Some(pid);
-
-                            if publish.qos == QoS::ExactlyOnce {
-                                outbound_inflight_fwd
-                                    .borrow_mut()
-                                    .insert(pid, publish.clone());
-                                let inflight = InflightMessage::from_publish(
-                                    &publish,
-                                    client_id_fwd.clone(),
-                                    InflightDirection::Outbound,
-                                    InflightPhase::AwaitingPubrec,
-                                );
-                                if let Err(e) = storage_fwd.store_inflight_message(inflight).await {
-                                    tracing::debug!(
-                                        "failed to persist outbound inflight {pid}: {e}"
-                                    );
+                let publish = tokio::select! {
+                    lane = qos1_rx.recv() => match lane {
+                        Some(routable) => routable.publish,
+                        None => break,
+                    },
+                    lane = qos0_rx.recv() => match lane {
+                        Some(routable) => routable.publish,
+                        None => break,
+                    },
+                    () = async {
+                        match &queue {
+                            Some(queue) => queue.notified().await,
+                            None => std::future::pending().await,
+                        }
+                    } => {
+                        if let Some(queue) = &queue {
+                            for message in queue.take(64).await {
+                                if !Self::forward_one(
+                                    message.to_publish_packet(),
+                                    &writer_for_forward,
+                                    &outbound_inflight_fwd,
+                                    &next_pid_fwd,
+                                    &storage_fwd,
+                                    &client_id_fwd,
+                                    handler_id,
+                                )
+                                .await
+                                {
+                                    break 'outer;
                                 }
                             }
-                        }
-
-                        if let Ok(mut writer_guard) = writer_for_forward.try_borrow_mut() {
-                            let result = Self::write_publish_packet(&publish, &mut writer_guard);
-                            if let Err(e) = result {
-                                error!("Handler #{handler_id} error forwarding publish: {e}");
-                                break;
+                            queue.finish_drain();
+                            if queue.count() > 0 {
+                                queue.notify();
                             }
-                        } else {
-                            error!("Handler #{handler_id} writer busy, cannot forward");
                         }
+                        continue;
                     }
-                    Err(_) => break,
+                };
+
+                if !Self::forward_one(
+                    publish,
+                    &writer_for_forward,
+                    &outbound_inflight_fwd,
+                    &next_pid_fwd,
+                    &storage_fwd,
+                    &client_id_fwd,
+                    handler_id,
+                )
+                .await
+                {
+                    break;
                 }
             }
         });
@@ -388,7 +474,7 @@ impl WasmClientHandler {
         &mut self,
         reader: &mut WasmReader,
         writer: WasmWriter,
-        disconnect_rx: tokio::sync::oneshot::Receiver<()>,
+        disconnect_rx: tokio::sync::oneshot::Receiver<mqtt5::broker::router::TakeoverNotice>,
     ) -> Result<()> {
         use crate::decoder::read_packet;
 

--- a/crates/mqtt5-wasm/src/client_handler/subscribe.rs
+++ b/crates/mqtt5-wasm/src/client_handler/subscribe.rs
@@ -228,26 +228,4 @@ impl WasmClientHandler {
 
         Ok(())
     }
-
-    pub(super) async fn deliver_queued_messages(
-        &mut self,
-        client_id: &str,
-        writer: &mut WasmWriter,
-    ) -> Result<()> {
-        let queued_messages = self.storage.get_queued_messages(client_id).await?;
-        self.storage.remove_queued_messages(client_id).await?;
-
-        if !queued_messages.is_empty() {
-            debug!(
-                "Delivering {} queued messages to {}",
-                queued_messages.len(),
-                client_id
-            );
-            for msg in queued_messages {
-                let publish = msg.to_publish_packet();
-                self.send_publish(publish, writer)?;
-            }
-        }
-        Ok(())
-    }
 }

--- a/crates/mqtt5/Cargo.toml
+++ b/crates/mqtt5/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqtt5"
-version = "0.39.3"
+version = "0.40.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -154,7 +154,7 @@ opentelemetry_sdk = { version = "0.32", features = ["trace", "rt-tokio", "metric
 opentelemetry-otlp = { version = "0.32", features = ["trace", "grpc-tonic", "metrics"], optional = true }
 tracing-opentelemetry = { version = "0.33", optional = true }
 opentelemetry = { version = "0.32", features = ["metrics", "trace"], optional = true }
-mqtt5-protocol = "0.15.0"
+mqtt5-protocol = "0.15.1"
 argon2 = { version = "0.5", optional = true }
 getrandom = "0.4.3"
 bebytes = { version = "3.0", features = ["bytes"] }

--- a/crates/mqtt5/examples/broker_with_monitoring.rs
+++ b/crates/mqtt5/examples/broker_with_monitoring.rs
@@ -28,6 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         backend: StorageBackendType::Memory,
         base_dir: std::path::PathBuf::from("/tmp/mqtt-broker"),
         cleanup_interval: Duration::from_secs(60),
+        ..StorageConfig::default()
     };
 
     let config = BrokerConfig::default()

--- a/crates/mqtt5/src/broker/bridge/config.rs
+++ b/crates/mqtt5/src/broker/bridge/config.rs
@@ -388,6 +388,18 @@ impl BridgeConfig {
             ));
         }
 
+        if self.clean_start {
+            return Err(MqttError::Configuration(
+                "Bridge sessions must persist (clean_start = false) so remote deliveries are acknowledged only once routed locally".into(),
+            ));
+        }
+
+        if self.protocol_version != MqttVersion::V50 {
+            return Err(MqttError::Configuration(
+                "Bridge connections require MQTT 5.0 (session expiry and receive maximum)".into(),
+            ));
+        }
+
         // Validate topic patterns
         for topic in &self.topics {
             if topic.pattern.is_empty() {

--- a/crates/mqtt5/src/broker/bridge/connection.rs
+++ b/crates/mqtt5/src/broker/bridge/connection.rs
@@ -7,18 +7,75 @@ use crate::broker::bridge::{BridgeConfig, BridgeError, BridgeProtocol, BridgeSta
 use crate::broker::router::MessageRouter;
 use crate::client::MqttClient;
 use crate::packet::publish::PublishPacket;
+use crate::protocol::v5::reason_codes::ReasonCode;
 use crate::time::{Duration, Instant};
 use crate::transport::tls::TlsConfig;
 use crate::types::ConnectOptions;
+use crate::validation::topic_matches_filter;
+use crate::{AckToken, QoS, SubscribeOptions};
 use mqtt5_protocol::bridge::{evaluate_forwarding, TopicMappingCore};
 use rand::RngExt;
 use std::collections::VecDeque;
 use std::net::ToSocketAddrs;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
-use tokio::sync::{broadcast, RwLock};
+use std::sync::{Arc, Mutex, OnceLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
+
+/// Bound on remote deliveries a bridge holds unacknowledged; also its Receive Maximum.
+const INGRESS_LANE_CAPACITY: usize = 1024;
+/// How long the remote keeps the bridge's session (and its unacknowledged messages)
+/// across a reconnect.
+const BRIDGE_SESSION_EXPIRY_SECS: u32 = 3600;
+
+/// One incoming delivery from the remote: every local copy it maps to, plus the token
+/// that acknowledges the remote once all of them are routed.
+type IngressItem = (Vec<PublishPacket>, AckToken);
+
+/// Delivery lanes from the remote-facing client into the local router, mirroring the
+/// client handler's gated and ungated lanes.
+struct Ingress {
+    qos1_tx: mpsc::Sender<IngressItem>,
+    qos0_tx: mpsc::Sender<Vec<PublishPacket>>,
+}
+
+/// All incoming mappings that share one remote filter, subscribed once with a
+/// subscription identifier so overlapping filters route each copy exactly once.
+struct IngressFilter {
+    remote_filter: String,
+    qos: QoS,
+    mappings: Vec<TopicMappingCore>,
+}
+
+/// Connect options for the remote-facing client: a persistent deferred-ack session whose
+/// receive maximum equals the ingress lane, so the remote never sends more than the bridge
+/// can hold unacknowledged.
+fn connect_options(config: &BridgeConfig) -> ConnectOptions {
+    let receive_maximum = u16::try_from(INGRESS_LANE_CAPACITY).unwrap_or(u16::MAX);
+    let mut options = ConnectOptions::new(&config.client_id)
+        .with_deferred_ack(true)
+        .with_clean_start(false)
+        .with_session_expiry_interval(BRIDGE_SESSION_EXPIRY_SECS)
+        .with_receive_maximum(receive_maximum);
+    options.keep_alive = Duration::from_secs(u64::from(config.keepalive));
+
+    if let Some(ref username) = config.username {
+        options.username = Some(username.clone());
+    }
+    if let Some(ref password) = config.password {
+        options.password = Some(password.clone().into_bytes());
+    }
+
+    if config.try_private {
+        options
+            .properties
+            .user_properties
+            .push(("bridge".to_string(), config.name.clone()));
+    }
+
+    options
+}
 
 fn apply_jitter(delay: Duration, enable: bool) -> Duration {
     if !enable {
@@ -64,6 +121,10 @@ pub struct BridgeConnection {
     health_check_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
     /// Pending messages to forward when connection is established
     pending_messages: Arc<Mutex<VecDeque<PublishPacket>>>,
+    /// Lanes from the remote-facing client into the local router, created on first use
+    ingress: OnceLock<Ingress>,
+    /// Whether the remote subscriptions have been registered for this connection's lifetime
+    subscribed: AtomicBool,
 }
 
 impl BridgeConnection {
@@ -77,8 +138,7 @@ impl BridgeConnection {
             .validate()
             .map_err(|e| BridgeError::ConfigurationError(e.to_string()))?;
 
-        // Create MQTT client for bridge
-        let client = Arc::new(MqttClient::new(&config.client_id));
+        let client = Arc::new(MqttClient::with_options(connect_options(&config)));
 
         // Create shutdown channel
         let (shutdown_tx, _) = broadcast::channel(1);
@@ -97,6 +157,8 @@ impl BridgeConnection {
             current_broker: Arc::new(RwLock::new(None)),
             health_check_handle: Arc::new(RwLock::new(None)),
             pending_messages: Arc::new(Mutex::new(VecDeque::new())),
+            ingress: OnceLock::new(),
+            subscribed: AtomicBool::new(false),
         })
     }
 
@@ -239,25 +301,7 @@ impl BridgeConnection {
 
     /// Builds connection options from config
     fn build_connect_options(&self) -> ConnectOptions {
-        let mut options = ConnectOptions::new(&self.config.client_id);
-        options.clean_start = self.config.clean_start;
-        options.keep_alive = Duration::from_secs(u64::from(self.config.keepalive));
-
-        if let Some(ref username) = self.config.username {
-            options.username = Some(username.clone());
-        }
-        if let Some(ref password) = self.config.password {
-            options.password = Some(password.clone().into_bytes());
-        }
-
-        if self.config.try_private {
-            options
-                .properties
-                .user_properties
-                .push(("bridge".to_string(), self.config.name.clone()));
-        }
-
-        options
+        connect_options(&self.config)
     }
 
     /// Attempts to connect using TLS to primary and backup brokers
@@ -671,57 +715,192 @@ impl BridgeConnection {
         }
     }
 
-    /// Sets up subscriptions for incoming topics
-    async fn setup_subscriptions(&self) -> Result<()> {
+    /// Groups the incoming mappings by remote filter, in configuration order.
+    fn ingress_filters(&self) -> Vec<IngressFilter> {
+        let mut filters: Vec<IngressFilter> = Vec::new();
         for mapping in &self.config.topics {
-            let core_mapping = TopicMappingCore::from(mapping);
-            if !core_mapping.direction.allows_incoming() {
+            let core = TopicMappingCore::from(mapping);
+            if !core.direction.allows_incoming() {
                 continue;
             }
+            let remote_filter = core.apply_remote_prefix(&core.pattern);
+            match filters
+                .iter_mut()
+                .find(|filter| filter.remote_filter == remote_filter)
+            {
+                Some(filter) => {
+                    if core.qos as u8 > filter.qos as u8 {
+                        filter.qos = core.qos;
+                    }
+                    filter.mappings.push(core);
+                }
+                None => filters.push(IngressFilter {
+                    remote_filter,
+                    qos: core.qos,
+                    mappings: vec![core],
+                }),
+            }
+        }
+        filters
+    }
 
-            let remote_topic = core_mapping.apply_remote_prefix(&core_mapping.pattern);
-            let local_prefix = core_mapping.local_prefix.clone();
-            let qos = core_mapping.qos;
+    fn ingress(&self) -> &Ingress {
+        self.ingress.get_or_init(|| {
+            let (qos1_tx, mut qos1_rx) = mpsc::channel::<IngressItem>(INGRESS_LANE_CAPACITY);
+            let (qos0_tx, mut qos0_rx) = mpsc::channel::<Vec<PublishPacket>>(INGRESS_LANE_CAPACITY);
+            let router = Arc::clone(&self.router);
+            tokio::spawn(async move {
+                loop {
+                    tokio::select! {
+                        biased;
+                        item = qos1_rx.recv() => {
+                            let Some((packets, token)) = item else { break };
+                            for packet in &packets {
+                                router.route_message_local_only(packet, None).await;
+                            }
+                            token.ack();
+                        }
+                        item = qos0_rx.recv() => {
+                            let Some(packets) = item else { break };
+                            for packet in &packets {
+                                router.route_message_local_only(packet, None).await;
+                            }
+                        }
+                    }
+                }
+            });
+            Ingress { qos1_tx, qos0_tx }
+        })
+    }
 
-            let router = self.router.clone();
-            let stats_received = self.messages_received.clone();
-            let stats_bytes = self.bytes_received.clone();
-
+    /// Registers the ingress callback for every remote filter before the first connect, so a
+    /// backlog the remote flushes right after CONNACK (it may still hold this bridge's
+    /// session) is routed instead of being auto-acknowledged and lost.
+    async fn register_ingress_callbacks(&self) -> Result<()> {
+        let filters = Arc::new(self.ingress_filters());
+        let ingress = self.ingress();
+        for filter in filters.iter() {
+            let callback = self.ingress_callback(
+                Arc::clone(&filters),
+                ingress.qos1_tx.clone(),
+                ingress.qos0_tx.clone(),
+            );
             self.client
-                .subscribe(&remote_topic, move |msg| {
-                    let router = router.clone();
-                    let local_prefix = local_prefix.clone();
-                    let stats_received = stats_received.clone();
-                    let stats_bytes = stats_bytes.clone();
-
-                    stats_received.fetch_add(1, Ordering::Relaxed);
-                    stats_bytes.fetch_add(msg.payload.len() as u64, Ordering::Relaxed);
-
-                    let local_topic = match &local_prefix {
-                        Some(prefix) => format!("{prefix}{}", msg.topic),
-                        None => msg.topic.clone(),
-                    };
-
-                    let mut packet = PublishPacket::new(local_topic, msg.payload.clone(), msg.qos);
-                    let pub_props: crate::types::PublishProperties = msg.properties.into();
-                    packet.properties = pub_props.into();
-                    packet.retain = msg.retain;
-                    packet.properties.inject_sender(None);
-                    packet.properties.inject_client_id(None);
-
-                    tokio::spawn(async move {
-                        router.route_message_local_only(&packet, None).await;
-                    });
-                })
+                .register_ack_callback(filter.remote_filter.clone(), callback)
                 .await?;
+        }
+        Ok(())
+    }
 
+    /// Subscribes once per distinct remote filter for the bridge's lifetime; the client
+    /// restores them itself after a lost session.
+    async fn setup_subscriptions(&self) -> Result<()> {
+        if self.subscribed.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let filters = Arc::new(self.ingress_filters());
+        let ingress = self.ingress();
+
+        for (index, filter) in filters.iter().enumerate() {
+            let subscription_id = u32::try_from(index + 1).unwrap_or(u32::MAX);
+            let callback = self.ingress_callback(
+                Arc::clone(&filters),
+                ingress.qos1_tx.clone(),
+                ingress.qos0_tx.clone(),
+            );
+            let options = SubscribeOptions {
+                qos: filter.qos,
+                subscription_identifier: Some(subscription_id),
+                ..SubscribeOptions::default()
+            };
+            self.client
+                .subscribe_with_ack(filter.remote_filter.clone(), options, callback)
+                .await?;
             info!(
-                "Bridge '{}' subscribed to remote topic: {} (QoS: {:?})",
-                self.config.name, remote_topic, qos
+                "Bridge '{}' subscribed to remote topic: {} (QoS: {:?}, {} mapping(s))",
+                self.config.name,
+                filter.remote_filter,
+                filter.qos,
+                filter.mappings.len()
             );
         }
+        self.subscribed.store(true, Ordering::Release);
 
         Ok(())
+    }
+
+    /// The callback every remote filter shares: maps one remote delivery to its local
+    /// copies, then hands them (with the token) to the routing task.
+    fn ingress_callback(
+        &self,
+        filters: Arc<Vec<IngressFilter>>,
+        qos1_tx: mpsc::Sender<IngressItem>,
+        qos0_tx: mpsc::Sender<Vec<PublishPacket>>,
+    ) -> impl Fn(PublishPacket, AckToken) + Send + Sync + 'static {
+        let bridge_name = self.config.name.clone();
+        let stats_received = Arc::clone(&self.messages_received);
+        let stats_bytes = Arc::clone(&self.bytes_received);
+        let warned_missing_ids = Arc::new(AtomicBool::new(false));
+
+        move |mut publish, token| {
+            stats_received.fetch_add(1, Ordering::Relaxed);
+            stats_bytes.fetch_add(publish.payload.len() as u64, Ordering::Relaxed);
+
+            let ids = publish.properties.subscription_identifiers();
+            publish.properties.remove_subscription_identifiers();
+            publish.properties.inject_sender(None);
+            publish.properties.inject_client_id(None);
+
+            let mappings: Vec<&TopicMappingCore> = if ids.is_empty() {
+                if !warned_missing_ids.swap(true, Ordering::Relaxed) {
+                    warn!(
+                        bridge = %bridge_name,
+                        "Remote sends no subscription identifiers; overlapping mappings may deliver copies"
+                    );
+                }
+                filters
+                    .iter()
+                    .filter(|filter| {
+                        topic_matches_filter(&publish.topic_name, &filter.remote_filter)
+                    })
+                    .flat_map(|filter| filter.mappings.iter())
+                    .collect()
+            } else {
+                ids.iter()
+                    .filter_map(|id| usize::try_from(*id).ok())
+                    .filter_map(|id| id.checked_sub(1))
+                    .filter_map(|index| filters.get(index))
+                    .flat_map(|filter| filter.mappings.iter())
+                    .collect()
+            };
+
+            let packets: Vec<PublishPacket> = mappings
+                .into_iter()
+                .map(|mapping| {
+                    let mut packet = publish.clone();
+                    packet.topic_name = mapping.apply_local_prefix(&publish.topic_name);
+                    packet
+                })
+                .collect();
+
+            if publish.qos == QoS::AtMostOnce {
+                if qos0_tx.try_send(packets).is_err() {
+                    debug!(bridge = %bridge_name, "Dropping QoS 0 remote delivery: ingress lane full");
+                }
+                token.ack();
+                return;
+            }
+            match qos1_tx.try_send((packets, token)) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full((_, token))) => {
+                    warn!(bridge = %bridge_name, "Ingress lane full; rejecting remote delivery");
+                    token.reject(ReasonCode::QuotaExceeded);
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    debug!(bridge = %bridge_name, "Bridge stopping; remote delivery dropped");
+                }
+            }
+        }
     }
 
     /// Forwards a message to the remote broker.
@@ -935,6 +1114,7 @@ impl BridgeConnection {
     /// Runs a single connection until disconnected
     async fn run_connection(&self) -> Result<()> {
         if !self.client.is_connected().await {
+            self.register_ingress_callbacks().await?;
             let _ = Box::pin(self.connect()).await?;
             self.setup_subscriptions().await?;
         }

--- a/crates/mqtt5/src/broker/client_handler/auth.rs
+++ b/crates/mqtt5/src/broker/client_handler/auth.rs
@@ -104,11 +104,6 @@ impl ClientHandler {
                     }
 
                     self.write_to_client(Packet::ConnAck(connack)).await?;
-
-                    if session_present {
-                        self.deliver_queued_messages(&pending.connect.client_id)
-                            .await?;
-                    }
                 } else {
                     let success_auth = AuthPacket::success(result.auth_method)?;
                     self.write_to_client(Packet::Auth(success_auth)).await?;

--- a/crates/mqtt5/src/broker/client_handler/connect.rs
+++ b/crates/mqtt5/src/broker/client_handler/connect.rs
@@ -8,11 +8,8 @@ use crate::packet::Packet;
 use crate::protocol::v5::reason_codes::ReasonCode;
 use crate::time::Duration;
 use crate::types::ProtocolVersion;
-use crate::QoS;
 use std::sync::Arc;
 use tracing::{debug, info, trace, warn};
-
-use crate::broker::router::RoutableMessage;
 
 use super::{AuthState, ClientHandler, PendingConnect};
 
@@ -155,11 +152,6 @@ impl ClientHandler {
         trace!("CONNACK properties: {:?}", connack.properties);
         self.write_to_client(Packet::ConnAck(connack)).await?;
         debug!("CONNACK sent successfully");
-
-        if session_present {
-            self.deliver_queued_messages(&connect.client_id).await?;
-            self.resend_inflight_messages().await?;
-        }
 
         Ok(())
     }
@@ -421,17 +413,31 @@ impl ClientHandler {
         }
     }
 
+    /// Decides whether the connection resumes a session; a session that only lives as long
+    /// as its connection (expiry 0) cannot be resumed from a live connection, so taking one
+    /// over is a clean start.
     pub(super) async fn handle_session(&mut self, connect: &ConnectPacket) -> Result<bool> {
         let mut session_present = false;
+        self.clean_start = connect.clean_start;
         if let Some(storage) = self.storage.clone() {
             let existing_session = storage.get_session(&connect.client_id).await?;
+            let connection_bound = existing_session
+                .as_ref()
+                .is_some_and(|session| session.expiry_interval == Some(0));
+            if connection_bound && self.router.is_connected(&connect.client_id).await {
+                self.clean_start = true;
+            }
 
-            if connect.clean_start || existing_session.is_none() {
-                self.create_new_session(connect, &storage).await?;
-            } else if let Some(session) = existing_session {
-                session_present = true;
-                self.restore_existing_session(connect, session, &storage)
-                    .await?;
+            match existing_session {
+                Some(session) if !self.clean_start => {
+                    session_present = true;
+                    self.restore_existing_session(connect, session, &storage)
+                        .await?;
+                }
+                _ => {
+                    self.clean_start = true;
+                    self.create_new_session(connect, &storage).await?;
+                }
             }
         }
         Ok(session_present)
@@ -540,40 +546,6 @@ impl ClientHandler {
         session.touch();
         storage.store_session(session.clone()).await?;
         self.session = Some(session);
-        Ok(())
-    }
-
-    pub(super) async fn deliver_queued_messages(&mut self, client_id: &str) -> Result<()> {
-        let queued_messages = if let Some(ref storage) = self.storage {
-            let messages = storage.get_queued_messages(client_id).await?;
-            storage.remove_queued_messages(client_id).await?;
-            messages
-        } else {
-            Vec::new()
-        };
-
-        if !queued_messages.is_empty() {
-            info!(
-                "Delivering {} queued messages to {}",
-                queued_messages.len(),
-                client_id
-            );
-
-            for msg in queued_messages {
-                let mut publish = msg.to_publish_packet();
-                if publish.qos != QoS::AtMostOnce && publish.packet_id.is_none() {
-                    publish.packet_id = Some(self.next_packet_id());
-                }
-                let routable = RoutableMessage {
-                    publish,
-                    target_flow: None,
-                };
-                if let Err(e) = self.publish_tx.try_send(routable) {
-                    warn!("Failed to deliver queued message to {}: {:?}", client_id, e);
-                }
-            }
-        }
-
         Ok(())
     }
 }

--- a/crates/mqtt5/src/broker/client_handler/mod.rs
+++ b/crates/mqtt5/src/broker/client_handler/mod.rs
@@ -100,7 +100,6 @@ pub struct ClientHandler {
     pub(super) handoff_deadline: Option<Instant>,
     pub(super) handoff_waived: bool,
     pub(super) handoff_baseline: usize,
-    pub(super) cutoff: Option<u64>,
     pub(super) clean_start: bool,
     pub(super) held: Vec<QueuedMessage>,
     pub(super) awaiting_pubcomp: HashSet<u16>,
@@ -213,7 +212,6 @@ impl ClientHandler {
             handoff_deadline: None,
             handoff_waived: false,
             handoff_baseline: 0,
-            cutoff: None,
             clean_start: true,
             held: Vec::new(),
             awaiting_pubcomp: HashSet::new(),
@@ -349,7 +347,6 @@ impl ClientHandler {
             )
             .await;
         self.generation = registration.generation;
-        self.cutoff = registration.cutoff;
         self.handoff_deadline = registration
             .released
             .as_ref()
@@ -443,7 +440,10 @@ impl ClientHandler {
         };
         self.handoff_baseline = queue.handoffs();
         if self.clean_start {
-            let discarded = queue.clear(self.cutoff);
+            // A clean start begins with no session state, so discard the whole queue rather
+            // than a seq cutoff: a stale delivery routed to the prior session during the
+            // hand-off must not survive into the fresh session.
+            let discarded = queue.clear(None);
             if discarded > 0 {
                 debug!(count = discarded, "Clean start discarded queued messages");
             }
@@ -452,7 +452,10 @@ impl ClientHandler {
                     debug!("failed to clear inflight messages on clean start: {e}");
                 }
             }
-        } else {
+        } else if !self.handoff_waived {
+            // Only reload persisted inflight when no live predecessor still owns it. On a
+            // waived hand-off the old handler is still running and will re-queue its inflight
+            // from memory when it exits; reloading here would deliver those messages twice.
             self.load_persisted_inflight(&queue).await?;
         }
         queue.notify();
@@ -919,6 +922,14 @@ impl ClientHandler {
         true
     }
 
+    /// `(delivering, window_open)` for the current loop turn. `delivering` gates the drain;
+    /// `window_open` additionally requires free outbound window before the gated lane yields.
+    fn delivery_gates(&self) -> (bool, bool) {
+        let delivering = self.bound && (self.handoff_waived || !self.handing_off());
+        let window_open = delivering && self.outbound_inflight.len() < usize::from(self.window);
+        (delivering, window_open)
+    }
+
     async fn handle_packets(
         &mut self,
         mut keep_alive_interval: Option<&mut Interval>,
@@ -930,8 +941,7 @@ impl ClientHandler {
         let queue = self.queue.clone();
 
         loop {
-            let delivering = self.bound && (self.handoff_waived || !self.handing_off());
-            let window_open = delivering && self.outbound_inflight.len() < usize::from(self.window);
+            let (delivering, window_open) = self.delivery_gates();
             tokio::select! {
                 quiesced = Self::await_handoff_quiesce(
                     &mut self.released_rx,

--- a/crates/mqtt5/src/broker/client_handler/mod.rs
+++ b/crates/mqtt5/src/broker/client_handler/mod.rs
@@ -8,8 +8,12 @@ use crate::broker::auth::AuthProvider;
 use crate::broker::config::BrokerConfig;
 use crate::broker::events::{ClientConnectEvent, ClientDisconnectEvent};
 use crate::broker::resource_monitor::ResourceMonitor;
-use crate::broker::router::{MessageRouter, RoutableMessage};
-use crate::broker::storage::{ClientSession, DynamicStorage, StorageBackend};
+use crate::broker::router::{
+    DeliveryLanes, MessageRouter, Release, RoutableMessage, TakeoverNotice, ROUTE_BUDGET_MAX,
+};
+use crate::broker::storage::{
+    ClientSession, DynamicStorage, InflightDirection, QueueHandle, QueuedMessage, StorageBackend,
+};
 use crate::broker::sys_topics::BrokerStats;
 use crate::broker::transport::BrokerTransport;
 use crate::error::{MqttError, Result};
@@ -24,12 +28,29 @@ use crate::transport::packet_io::{encode_packet_to_buffer, read_packet_reusing_b
 use crate::transport::PacketIo;
 use bytes::{Bytes, BytesMut};
 use mqtt5_protocol::KeepaliveConfig;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::time::{interval, timeout};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{interval, timeout, timeout_at, Instant, Interval};
 use tracing::{debug, info, warn};
+
+/// Longest a new connection waits for the handler it displaced to hand the session over.
+const HANDOFF_BOUND: Duration = Duration::from_secs(30);
+
+/// Why the packet loop returned.
+#[derive(Debug)]
+pub(super) enum LoopExit {
+    Closed,
+    TakenOver(TakeoverNotice),
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Lane {
+    Qos1,
+    Qos0,
+}
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "transport-quic"))]
 use crate::broker::config::ServerDeliveryStrategy;
@@ -67,8 +88,23 @@ pub struct ClientHandler {
     pub(super) client_id: Option<String>,
     pub(super) user_id: Option<String>,
     pub(super) keep_alive: Duration,
-    pub(super) publish_rx: flume::Receiver<RoutableMessage>,
-    pub(super) publish_tx: flume::Sender<RoutableMessage>,
+    pub(super) qos1_rx: mpsc::Receiver<RoutableMessage>,
+    pub(super) qos1_tx: mpsc::Sender<RoutableMessage>,
+    pub(super) qos0_rx: mpsc::Receiver<RoutableMessage>,
+    pub(super) qos0_tx: mpsc::Sender<RoutableMessage>,
+    pub(super) queue: Option<QueueHandle>,
+    pub(super) window: u16,
+    pub(super) generation: u64,
+    pub(super) bound: bool,
+    pub(super) released_rx: Option<oneshot::Receiver<()>>,
+    pub(super) handoff_deadline: Option<Instant>,
+    pub(super) handoff_waived: bool,
+    pub(super) handoff_baseline: usize,
+    pub(super) cutoff: Option<u64>,
+    pub(super) clean_start: bool,
+    pub(super) held: Vec<QueuedMessage>,
+    pub(super) awaiting_pubcomp: HashSet<u16>,
+    pub(super) inflight_order: VecDeque<u16>,
     pub(super) inflight_publishes: HashMap<u16, InflightPublish>,
     pub(super) session: Option<ClientSession>,
     pub(super) next_packet_id: u16,
@@ -147,8 +183,10 @@ impl ClientHandler {
         shutdown_rx: tokio::sync::broadcast::Receiver<()>,
         external_packet_rx: Option<mpsc::Receiver<(Packet, Option<u64>)>>,
     ) -> Self {
-        let (publish_tx, publish_rx) = flume::bounded(config.client_channel_capacity);
+        let (qos1_tx, qos1_rx) = mpsc::channel(config.client_channel_capacity);
+        let (qos0_tx, qos0_rx) = mpsc::channel(config.client_channel_capacity);
         let server_receive_maximum = config.server_receive_maximum.unwrap_or(65535);
+        let window = config.max_outbound_inflight;
 
         Self {
             transport,
@@ -163,8 +201,23 @@ impl ClientHandler {
             client_id: None,
             user_id: None,
             keep_alive: Duration::from_secs(60),
-            publish_rx,
-            publish_tx,
+            qos1_rx,
+            qos1_tx,
+            qos0_rx,
+            qos0_tx,
+            queue: None,
+            window,
+            generation: 0,
+            bound: false,
+            released_rx: None,
+            handoff_deadline: None,
+            handoff_waived: false,
+            handoff_baseline: 0,
+            cutoff: None,
+            clean_start: true,
+            held: Vec::new(),
+            awaiting_pubcomp: HashSet::new(),
+            inflight_order: VecDeque::new(),
             inflight_publishes: HashMap::new(),
             session: None,
             next_packet_id: 1,
@@ -251,7 +304,14 @@ impl ClientHandler {
                 .route_message_local_only(publish, client_id)
                 .await;
         } else {
-            self.router.route_message(publish, client_id).await;
+            let budget = if self.keep_alive.is_zero() {
+                ROUTE_BUDGET_MAX
+            } else {
+                (self.keep_alive / 2).min(ROUTE_BUDGET_MAX)
+            };
+            self.router
+                .route_message_with_deadline(publish, client_id, Instant::now() + budget)
+                .await;
         }
     }
 
@@ -267,37 +327,160 @@ impl ClientHandler {
     pub async fn run(mut self) -> Result<()> {
         let client_id = self.perform_connect_handshake().await?;
 
-        let (disconnect_tx, mut disconnect_rx) = tokio::sync::oneshot::channel();
+        let (disconnect_tx, mut disconnect_rx) = oneshot::channel();
 
-        self.router
-            .register_client(client_id.clone(), self.publish_tx.clone(), disconnect_tx)
+        let queue = self.router.queue_handle(&client_id);
+        self.queue = Some(Arc::clone(&queue));
+        self.window = self
+            .client_receive_maximum
+            .min(self.config.max_outbound_inflight)
+            .max(1);
+        let registration = self
+            .router
+            .register_session(
+                client_id.clone(),
+                DeliveryLanes {
+                    qos1_tx: self.qos1_tx.clone(),
+                    qos0_tx: self.qos0_tx.clone(),
+                },
+                Arc::clone(&queue),
+                disconnect_tx,
+                self.clean_start,
+            )
             .await;
+        self.generation = registration.generation;
+        self.cutoff = registration.cutoff;
+        self.handoff_deadline = registration
+            .released
+            .as_ref()
+            .map(|_| Instant::now() + HANDOFF_BOUND);
+        self.released_rx = registration.released;
 
         self.fire_connect_event(&client_id).await;
 
-        let (result, session_taken_over) = if self.keep_alive.is_zero() {
-            match self.handle_packets_no_keepalive(&mut disconnect_rx).await {
-                Ok(taken_over) => (Ok(()), taken_over),
-                Err(e) => (Err(e), false),
-            }
+        let (result, exit) = match self.serve(&mut disconnect_rx).await {
+            Ok(exit) => (Ok(()), exit),
+            Err(e) => (Err(e), LoopExit::Closed),
+        };
+
+        let taken_over = if let LoopExit::TakenOver(notice) = exit {
+            self.hand_off(&queue, notice).await;
+            self.release_router_entry(&client_id).await;
+            true
         } else {
-            let mut keep_alive_interval = interval(self.keep_alive);
-            keep_alive_interval.reset();
-            match self
-                .handle_packets(&mut keep_alive_interval, &mut disconnect_rx)
-                .await
-            {
-                Ok(taken_over) => (Ok(()), taken_over),
-                Err(e) => (Err(e), false),
+            // Move this connection's unfinished deliveries back to (or off) the queue BEFORE
+            // releasing the router entry, so a reconnect that races the release still sees this
+            // entry, is handed a notice, and waits for the hand-off instead of binding onto
+            // half-torn-down state and re-delivering.
+            if self.session_preserved() {
+                self.requeue_unsent(&queue).await;
+            } else {
+                self.drop_unsent().await;
+            }
+            match self.release_router_entry(&client_id).await {
+                Release::Owned => {
+                    queue.finish_drain();
+                    if self.session_preserved() {
+                        queue.notify();
+                    } else {
+                        queue.clear(None);
+                    }
+                    false
+                }
+                Release::Displaced => {
+                    // A successor registered during the requeue above. Complete its hand-off
+                    // protocol: this connection's messages are already back on the queue, so
+                    // just release the successor and let its guard balance the count.
+                    if let Ok(notice) = disconnect_rx.try_recv() {
+                        queue.finish_drain();
+                        let TakeoverNotice {
+                            released, guard, ..
+                        } = notice;
+                        drop(guard);
+                        let _ = released.send(());
+                        queue.notify();
+                    } else {
+                        queue.finish_drain();
+                    }
+                    true
+                }
             }
         };
 
-        self.handle_disconnect_cleanup(&client_id, session_taken_over)
-            .await;
+        self.handle_disconnect_cleanup(&client_id, taken_over).await;
 
         info!("Client {} disconnected", client_id);
 
         result
+    }
+
+    async fn serve(
+        &mut self,
+        disconnect_rx: &mut oneshot::Receiver<TakeoverNotice>,
+    ) -> Result<LoopExit> {
+        if self.released_rx.is_none() {
+            self.bind().await?;
+        }
+        if self.keep_alive.is_zero() {
+            self.handle_packets(None, disconnect_rx).await
+        } else {
+            let mut keep_alive_interval = interval(self.keep_alive);
+            keep_alive_interval.reset();
+            self.handle_packets(Some(&mut keep_alive_interval), disconnect_rx)
+                .await
+        }
+    }
+
+    /// Takes ownership of the session's delivery state once no older handler can still be
+    /// touching it: a clean start discards what the old session left, a resumed session
+    /// reloads its persisted inflight messages at the front of the queue.
+    async fn bind(&mut self) -> Result<()> {
+        self.bound = true;
+        self.released_rx = None;
+        self.handoff_deadline = None;
+        let Some(queue) = self.queue.clone() else {
+            return Ok(());
+        };
+        self.handoff_baseline = queue.handoffs();
+        if self.clean_start {
+            let discarded = queue.clear(self.cutoff);
+            if discarded > 0 {
+                debug!(count = discarded, "Clean start discarded queued messages");
+            }
+            if let (Some(storage), Some(client_id)) = (&self.storage, &self.client_id) {
+                if let Err(e) = storage.remove_all_inflight_messages(client_id).await {
+                    debug!("failed to clear inflight messages on clean start: {e}");
+                }
+            }
+        } else {
+            self.load_persisted_inflight(&queue).await?;
+        }
+        queue.notify();
+        Ok(())
+    }
+
+    /// The displaced handler's side of a takeover: give the session queue everything this
+    /// connection still owned (or drop it on a clean start), then let the new handler go.
+    async fn hand_off(&mut self, queue: &QueueHandle, notice: TakeoverNotice) {
+        let TakeoverNotice {
+            discard,
+            released,
+            guard,
+        } = notice;
+        if discard {
+            self.drop_unsent().await;
+        } else {
+            self.requeue_unsent(queue).await;
+        }
+        queue.finish_drain();
+        // Dropping the guard decrements the hand-off count and, when it reaches zero, wakes
+        // the successor waiting to bind — do it before releasing so the successor sees the
+        // session quiesced.
+        drop(guard);
+        if released.send(()).is_err() {
+            debug!("New session handler went away before the hand-off completed");
+        }
+        queue.notify();
     }
 
     async fn perform_connect_handshake(&mut self) -> Result<String> {
@@ -353,10 +536,7 @@ impl ClientHandler {
             let event = ClientConnectEvent {
                 client_id: client_id.to_string().into(),
                 user_id: self.user_id.as_deref().map(Arc::from),
-                clean_start: self
-                    .pending_connect
-                    .as_ref()
-                    .is_none_or(|p| p.connect.clean_start),
+                clean_start: self.clean_start,
                 session_expiry_interval: self
                     .session
                     .as_ref()
@@ -402,14 +582,13 @@ impl ClientHandler {
     }
 
     async fn handle_disconnect_cleanup_inner(&mut self, client_id: &str, session_taken_over: bool) {
-        self.handle_client_unregister(client_id, session_taken_over)
-            .await;
-
         self.resource_monitor
             .unregister_connection(client_id, self.client_addr.ip())
             .await;
 
-        self.cleanup_session_storage(client_id).await;
+        if !session_taken_over {
+            self.cleanup_session_storage(client_id).await;
+        }
 
         if let Some(ref user_id) = self.user_id {
             self.auth_provider.cleanup_session(user_id).await;
@@ -441,27 +620,19 @@ impl ClientHandler {
         self.fire_disconnect_event(client_id).await;
     }
 
-    async fn handle_client_unregister(&self, client_id: &str, session_taken_over: bool) {
-        let preserve_session = if let Some(ref session) = self.session {
-            session.expiry_interval != Some(0)
-        } else {
-            false
-        };
-
-        if session_taken_over {
-            info!(
-                "Skipping unregister for client {} (session taken over)",
+    async fn release_router_entry(&self, client_id: &str) -> Release {
+        let release = self
+            .router
+            .release_client(client_id, self.generation, self.session_preserved())
+            .await;
+        match release {
+            Release::Owned => info!("Unregistered client {} from the router", client_id),
+            Release::Displaced => info!(
+                "Client {} router entry now belongs to the connection that took it over",
                 client_id
-            );
-        } else {
-            info!("Unregistering client {} (not taken over)", client_id);
-
-            if preserve_session {
-                self.router.disconnect_client(client_id).await;
-            } else {
-                self.router.unregister_client(client_id).await;
-            }
+            ),
         }
+        release
     }
 
     async fn cleanup_session_storage(&self, client_id: &str) {
@@ -484,9 +655,7 @@ impl ClientHandler {
                     if let Err(e) = storage.remove_session(client_id).await {
                         warn!("Failed to remove session for {client_id}: {e}");
                     }
-                    if let Err(e) = storage.remove_queued_messages(client_id).await {
-                        warn!("Failed to remove queued messages for {client_id}: {e}");
-                    }
+                    storage.queue_handle(client_id).clear(None);
                     if let Err(e) = storage.remove_all_inflight_messages(client_id).await {
                         warn!("Failed to remove inflight messages for {client_id}: {e}");
                     }
@@ -541,7 +710,18 @@ impl ClientHandler {
                 }
             }
         }
-        self.transport.write_packet(packet).await
+        let write_timeout = self.write_timeout();
+        let packet_name = packet.packet_type_name();
+        timeout(write_timeout, self.transport.write_packet(packet))
+            .await
+            .map_err(|_| {
+                warn!(
+                    packet = packet_name,
+                    timeout = ?write_timeout,
+                    "Transport write stalled; treating the client as gone"
+                );
+                MqttError::Timeout
+            })?
     }
 
     fn packet_properties_mut(packet: &mut Packet) -> Option<&mut Properties> {
@@ -587,120 +767,191 @@ impl ClientHandler {
         }
     }
 
-    async fn handle_packets_no_keepalive(
-        &mut self,
-        disconnect_rx: &mut tokio::sync::oneshot::Receiver<()>,
-    ) -> Result<bool> {
-        let max_size = self.max_packet_size();
-        let zombie_timeout = Duration::from_secs(300);
-        loop {
-            tokio::select! {
-                read_result = timeout(zombie_timeout, read_packet_reusing_buffer(&mut self.transport, self.protocol_version, &mut self.read_buffer, max_size)) => {
-                    let packet_result = read_result.map_err(|_| {
-                        warn!("Zombie connection timeout (no keepalive, no data for {}s)", zombie_timeout.as_secs());
-                        MqttError::Timeout
-                    })?;
-                    match packet_result {
-                        Ok(packet) => {
-                            self.handle_packet(packet).await?;
-                            #[cfg(not(target_arch = "wasm32"))]
-                            self.check_quic_migration().await;
-                        }
-                        Err(e) if e.is_normal_disconnect() => {
-                            debug!("Client disconnected");
-                            return Ok(false);
-                        }
-                        Err(e) => {
-                            return Err(e);
-                        }
-                    }
-                }
+    /// Time one delivery batch may occupy the task before the socket is serviced again.
+    pub(super) fn batch_time_budget(&self) -> Duration {
+        if self.keep_alive.is_zero() {
+            ROUTE_BUDGET_MAX
+        } else {
+            self.keep_alive / 4
+        }
+    }
 
-                external_packet = async {
-                    if let Some(ref mut rx) = self.external_packet_rx {
-                        rx.recv().await
-                    } else {
-                        std::future::pending::<Option<(Packet, Option<u64>)>>().await
-                    }
-                } => {
-                    if let Some((packet, flow_id)) = external_packet {
-                        self.pending_external_flow_id = flow_id;
-                        let result = self.handle_packet(packet).await;
-                        self.pending_external_flow_id = None;
-                        result?;
-                    }
-                }
+    /// Zombie guard for one transport write; never long enough to push a live client past
+    /// its keep-alive limit on its own.
+    pub(super) fn write_timeout(&self) -> Duration {
+        if self.keep_alive.is_zero() {
+            Duration::from_secs(300)
+        } else {
+            KeepaliveConfig::default()
+                .timeout_duration(self.keep_alive)
+                .saturating_sub(self.batch_time_budget())
+                .max(Duration::from_secs(1))
+        }
+    }
 
-                closed_flow_id = async {
-                    if let Some(ref mut rx) = self.flow_closed_rx {
-                        rx.recv().await
-                    } else {
-                        std::future::pending::<Option<u64>>().await
-                    }
-                } => {
-                    if let Some(flow_id) = closed_flow_id {
-                        self.handle_flow_closed(flow_id).await;
-                    }
-                }
+    fn session_preserved(&self) -> bool {
+        self.session
+            .as_ref()
+            .is_some_and(|session| session.expiry_interval != Some(0))
+    }
 
-                publish_result = self.publish_rx.recv_async() => {
-                    if let Ok(routable) = publish_result {
-                        self.send_routable(routable).await?;
-                        while let Ok(more) = self.publish_rx.try_recv() {
-                            self.send_routable(more).await?;
-                        }
-                    } else {
-                        warn!("Publish channel closed unexpectedly");
-                        return Ok(false);
-                    }
-                }
+    /// True while any hand-off is in progress on this client id (this handler's own, or an
+    /// older handler still finishing). Gates whether a not-yet-waived handler delivers.
+    pub(super) fn handing_off(&self) -> bool {
+        self.queue.as_ref().is_some_and(|queue| queue.handoff())
+    }
 
-                _ = &mut *disconnect_rx => {
-                    info!("Session taken over by another client");
-                    let disconnect = Packet::Disconnect(DisconnectPacket {
-                        reason_code: ReasonCode::SessionTakenOver,
-                        properties: Properties::default(),
-                    });
-                    if let Err(e) = self.write_to_client(disconnect).await {
-                        debug!("Failed to send session-taken-over DISCONNECT: {e}");
-                    }
-                    return Ok(true);
+    /// True only when a NEWER connection has displaced THIS handler — i.e. the hand-off count
+    /// has risen above what it was when this handler bound. A handler that merely waited out an
+    /// older predecessor (equal count) is not displaced and must keep delivering, not stash.
+    pub(super) fn being_displaced(&self) -> bool {
+        self.queue
+            .as_ref()
+            .is_some_and(|queue| queue.handoffs() > self.handoff_baseline)
+    }
+
+    /// Discards everything this connection still owned: a clean-start takeover starts empty.
+    async fn drop_unsent(&mut self) {
+        self.qos1_rx.close();
+        self.qos0_rx.close();
+        while self.qos0_rx.try_recv().is_ok() {}
+        while self.qos1_rx.recv().await.is_some() {}
+        self.inflight_order.clear();
+        self.held.clear();
+        self.awaiting_pubcomp.clear();
+        let unacked: Vec<u16> = self.outbound_inflight.drain().map(|(id, _)| id).collect();
+        if let (Some(storage), Some(client_id)) = (self.storage.clone(), self.client_id.clone()) {
+            for packet_id in unacked {
+                if let Err(e) = storage
+                    .remove_inflight_message(&client_id, packet_id, InflightDirection::Outbound)
+                    .await
+                {
+                    debug!("failed to remove discarded inflight {packet_id}: {e}");
                 }
             }
         }
     }
 
+    /// Moves everything this handler still owns for the session — unacked QoS>0 messages in
+    /// first-send order, then the undelivered QoS>0 lane contents — to the front of the
+    /// session's queue, so the next connection (or the one that took over) resumes in order.
+    async fn requeue_unsent(&mut self, queue: &QueueHandle) {
+        let Some(client_id) = self.client_id.clone() else {
+            return;
+        };
+        self.qos1_rx.close();
+        self.qos0_rx.close();
+        while self.qos0_rx.try_recv().is_ok() {}
+
+        let mut unsent = Vec::new();
+        let mut unacked_ids = Vec::new();
+        for packet_id in std::mem::take(&mut self.inflight_order) {
+            if self.awaiting_pubcomp.contains(&packet_id) {
+                continue;
+            }
+            if let Some(publish) = self.outbound_inflight.remove(&packet_id) {
+                let qos = publish.qos;
+                let mut queued =
+                    QueuedMessage::new(publish, client_id.clone(), qos, Some(packet_id));
+                queued.dup = true;
+                unsent.push(queued);
+                unacked_ids.push(packet_id);
+            }
+        }
+        self.outbound_inflight.clear();
+        self.awaiting_pubcomp.clear();
+        unsent.append(&mut self.held);
+        while let Some(routable) = self.qos1_rx.recv().await {
+            let qos = routable.publish.qos;
+            unsent.push(
+                QueuedMessage::new(routable.publish, client_id.clone(), qos, None)
+                    .with_target_flow(routable.target_flow),
+            );
+        }
+        if unsent.is_empty() {
+            return;
+        }
+        debug!(
+            client_id = %client_id,
+            count = unsent.len(),
+            "Re-queued undelivered messages for the session"
+        );
+        queue.requeue_front(unsent);
+        if let Some(storage) = self.storage.clone() {
+            for packet_id in unacked_ids {
+                if let Err(e) = storage
+                    .remove_inflight_message(&client_id, packet_id, InflightDirection::Outbound)
+                    .await
+                {
+                    debug!("failed to remove re-queued inflight {packet_id}: {e}");
+                }
+            }
+        }
+    }
+
+    /// Waits until this connection may take over the session: the immediate predecessor has
+    /// released (or the deadline passed), then the whole hand-off chain has drained to zero.
+    /// Returns `true` if it quiesced, `false` if the deadline forced a waive. Never resolves
+    /// once bound (`deadline` is cleared in `bind`), so the select arm goes quiet afterward.
+    async fn await_handoff_quiesce(
+        released_rx: &mut Option<oneshot::Receiver<()>>,
+        queue: Option<&QueueHandle>,
+        deadline: Option<Instant>,
+    ) -> bool {
+        let Some(deadline) = deadline else {
+            return std::future::pending::<bool>().await;
+        };
+        if let Some(rx) = released_rx.as_mut() {
+            let _ = timeout_at(deadline, rx).await;
+            *released_rx = None;
+        }
+        let Some(queue) = queue else {
+            return true;
+        };
+        while queue.handoffs() != 0 {
+            if timeout_at(deadline, queue.handoff_quiesced())
+                .await
+                .is_err()
+            {
+                return false;
+            }
+        }
+        true
+    }
+
     async fn handle_packets(
         &mut self,
-        keep_alive_interval: &mut tokio::time::Interval,
-        disconnect_rx: &mut tokio::sync::oneshot::Receiver<()>,
-    ) -> Result<bool> {
-        let mut last_packet_time = tokio::time::Instant::now();
+        mut keep_alive_interval: Option<&mut Interval>,
+        disconnect_rx: &mut oneshot::Receiver<TakeoverNotice>,
+    ) -> Result<LoopExit> {
+        let mut last_packet_time = Instant::now();
         let max_size = self.max_packet_size();
-        let read_timeout = self.keep_alive.mul_f32(1.5);
+        let read_timeout = self.read_timeout();
+        let queue = self.queue.clone();
 
         loop {
+            let delivering = self.bound && (self.handoff_waived || !self.handing_off());
+            let window_open = delivering && self.outbound_inflight.len() < usize::from(self.window);
             tokio::select! {
-                read_result = timeout(read_timeout, read_packet_reusing_buffer(&mut self.transport, self.protocol_version, &mut self.read_buffer, max_size)) => {
-                    let packet_result = read_result.map_err(|_| {
-                        warn!("Read timeout (no data for {:?})", read_timeout);
-                        MqttError::Timeout
-                    })?;
-                    match packet_result {
-                        Ok(packet) => {
-                            last_packet_time = tokio::time::Instant::now();
-                            self.handle_packet(packet).await?;
-                            #[cfg(not(target_arch = "wasm32"))]
-                            self.check_quic_migration().await;
-                        }
-                        Err(e) if e.is_normal_disconnect() => {
-                            debug!("Client disconnected");
-                            return Ok(false);
-                        }
-                        Err(e) => {
-                            return Err(e);
-                        }
+                quiesced = Self::await_handoff_quiesce(
+                    &mut self.released_rx,
+                    self.queue.as_ref(),
+                    self.handoff_deadline,
+                ) => {
+                    if quiesced {
+                        debug!("Hand-off chain drained; binding the session");
+                    } else {
+                        warn!("Hand-off did not drain in time; proceeding without it");
+                        self.handoff_waived = true;
                     }
+                    self.bind().await?;
+                }
+
+                read_result = timeout(read_timeout, read_packet_reusing_buffer(&mut self.transport, self.protocol_version, &mut self.read_buffer, max_size)) => {
+                    if let Some(exit) = self.handle_read(read_result, read_timeout).await? {
+                        return Ok(exit);
+                    }
+                    last_packet_time = Instant::now();
                 }
 
                 external_packet = async {
@@ -710,12 +961,8 @@ impl ClientHandler {
                         std::future::pending::<Option<(Packet, Option<u64>)>>().await
                     }
                 } => {
-                    if let Some((packet, flow_id)) = external_packet {
-                        last_packet_time = tokio::time::Instant::now();
-                        self.pending_external_flow_id = flow_id;
-                        let result = self.handle_packet(packet).await;
-                        self.pending_external_flow_id = None;
-                        result?;
+                    if self.handle_external_packet(external_packet).await? {
+                        last_packet_time = Instant::now();
                     }
                 }
 
@@ -731,49 +978,183 @@ impl ClientHandler {
                     }
                 }
 
-                publish_result = self.publish_rx.recv_async() => {
-                    if let Ok(routable) = publish_result {
-                        self.send_routable(routable).await?;
-                        while let Ok(more) = self.publish_rx.try_recv() {
-                            self.send_routable(more).await?;
-                        }
+                routable = async {
+                    if window_open {
+                        self.qos1_rx.recv().await
                     } else {
-                        warn!("Publish channel closed unexpectedly in handle_packets");
-                        return Ok(false);
+                        std::future::pending::<Option<RoutableMessage>>().await
+                    }
+                } => {
+                    if let Some(exit) = self.deliver_from_lane(routable, Lane::Qos1).await? {
+                        return Ok(exit);
                     }
                 }
 
-                _ = keep_alive_interval.tick() => {
-                    let elapsed = last_packet_time.elapsed();
-                    let timeout_duration = KeepaliveConfig::default().timeout_duration(self.keep_alive);
-                    if elapsed > timeout_duration {
-                        warn!("Keep-alive timeout");
-                        return Err(MqttError::KeepAliveTimeout);
+                routable = self.qos0_rx.recv() => {
+                    if let Some(exit) = self.deliver_from_lane(routable, Lane::Qos0).await? {
+                        return Ok(exit);
                     }
                 }
 
-                _ = &mut *disconnect_rx => {
-                    info!("Session taken over by another client");
-                    let disconnect = Packet::Disconnect(DisconnectPacket {
-                        reason_code: ReasonCode::SessionTakenOver,
-                        properties: Properties::default(),
-                    });
-                    if let Err(e) = self.write_to_client(disconnect).await {
-                        debug!("Failed to send session-taken-over DISCONNECT: {e}");
+                () = async {
+                    match &queue {
+                        Some(queue) if delivering => queue.notified().await,
+                        _ => std::future::pending::<()>().await,
                     }
-                    return Ok(true);
+                } => {
+                    self.drain_backlog().await?;
+                }
+
+                () = async {
+                    match keep_alive_interval.as_deref_mut() {
+                        Some(interval) => {
+                            interval.tick().await;
+                        }
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    self.check_keep_alive(last_packet_time)?;
+                }
+
+                notice = &mut *disconnect_rx => {
+                    let Ok(notice) = notice else {
+                        debug!("Router dropped this connection's entry");
+                        return Ok(LoopExit::Closed);
+                    };
+                    self.send_taken_over().await;
+                    return Ok(LoopExit::TakenOver(notice));
                 }
 
                 _ = self.shutdown_rx.recv() => {
-                    debug!("Shutdown signal received");
-                    if self.protocol_version == 5 {
-                        let disconnect = DisconnectPacket::new(ReasonCode::ServerShuttingDown);
-                        let _ = self.write_to_client(Packet::Disconnect(disconnect)).await;
-                    }
-                    return Ok(false);
+                    self.send_shutting_down().await;
+                    return Ok(LoopExit::Shutdown);
                 }
             }
         }
+    }
+
+    fn read_timeout(&self) -> Duration {
+        if self.keep_alive.is_zero() {
+            Duration::from_secs(300)
+        } else {
+            self.keep_alive.mul_f32(1.5)
+        }
+    }
+
+    async fn handle_external_packet(
+        &mut self,
+        external_packet: Option<(Packet, Option<u64>)>,
+    ) -> Result<bool> {
+        let Some((packet, flow_id)) = external_packet else {
+            return Ok(false);
+        };
+        self.pending_external_flow_id = flow_id;
+        let result = self.handle_packet(packet).await;
+        self.pending_external_flow_id = None;
+        result.map(|()| true)
+    }
+
+    async fn deliver_from_lane(
+        &mut self,
+        routable: Option<RoutableMessage>,
+        lane: Lane,
+    ) -> Result<Option<LoopExit>> {
+        let Some(routable) = routable else {
+            warn!(?lane, "Delivery lane closed unexpectedly");
+            return Ok(Some(LoopExit::Closed));
+        };
+        self.send_lane_batch(routable, lane).await?;
+        Ok(None)
+    }
+
+    fn check_keep_alive(&self, last_packet_time: Instant) -> Result<()> {
+        let timeout_duration = KeepaliveConfig::default().timeout_duration(self.keep_alive);
+        if last_packet_time.elapsed() > timeout_duration {
+            warn!("Keep-alive timeout");
+            return Err(MqttError::KeepAliveTimeout);
+        }
+        Ok(())
+    }
+
+    async fn handle_read(
+        &mut self,
+        read_result: std::result::Result<Result<Packet>, tokio::time::error::Elapsed>,
+        read_timeout: Duration,
+    ) -> Result<Option<LoopExit>> {
+        let packet_result = read_result.map_err(|_| {
+            warn!("Read timeout (no data for {:?})", read_timeout);
+            MqttError::Timeout
+        })?;
+        match packet_result {
+            Ok(packet) => {
+                self.handle_packet(packet).await?;
+                #[cfg(not(target_arch = "wasm32"))]
+                self.check_quic_migration().await;
+                Ok(None)
+            }
+            Err(e) if e.is_normal_disconnect() => {
+                debug!("Client disconnected");
+                Ok(Some(LoopExit::Closed))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    async fn send_taken_over(&mut self) {
+        info!("Session taken over by another client");
+        let disconnect = Packet::Disconnect(DisconnectPacket {
+            reason_code: ReasonCode::SessionTakenOver,
+            properties: Properties::default(),
+        });
+        if let Err(e) = self.write_to_client(disconnect).await {
+            debug!("Failed to send session-taken-over DISCONNECT: {e}");
+        }
+    }
+
+    async fn send_shutting_down(&mut self) {
+        debug!("Shutdown signal received");
+        if self.protocol_version == 5 {
+            let disconnect = DisconnectPacket::new(ReasonCode::ServerShuttingDown);
+            if let Err(e) = self.write_to_client(Packet::Disconnect(disconnect)).await {
+                debug!("Failed to send server-shutting-down DISCONNECT: {e}");
+            }
+        }
+    }
+
+    /// Sends `first` and up to `drain_batch - 1` more messages already waiting on the lane,
+    /// stopping when the window closes (QoS>0 lane) or the time budget is spent, so the
+    /// socket is serviced between batches.
+    async fn send_lane_batch(&mut self, first: RoutableMessage, lane: Lane) -> Result<()> {
+        let started = Instant::now();
+        let budget = self.batch_time_budget();
+        let batch = self.config.drain_batch.max(1);
+        self.send_routable(first).await?;
+        for _ in 1..batch {
+            if started.elapsed() > budget || self.being_displaced() {
+                break;
+            }
+            let next = match lane {
+                Lane::Qos1 => {
+                    if self.outbound_inflight.len() >= usize::from(self.window) {
+                        break;
+                    }
+                    self.qos1_rx.try_recv()
+                }
+                Lane::Qos0 => self.qos0_rx.try_recv(),
+            };
+            match next {
+                Ok(routable) => self.send_routable(routable).await?,
+                Err(_) => break,
+            }
+        }
+        if lane == Lane::Qos1 && self.qos1_rx.is_empty() {
+            if let Some(queue) = &self.queue {
+                if queue.count() > 0 {
+                    queue.notify();
+                }
+            }
+        }
+        Ok(())
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "transport-quic"))]

--- a/crates/mqtt5/src/broker/client_handler/publish.rs
+++ b/crates/mqtt5/src/broker/client_handler/publish.rs
@@ -1,6 +1,6 @@
 use crate::broker::events::{ClientPublishEvent, MessageDeliveredEvent, PublishAction};
 use crate::broker::storage::{
-    InflightDirection, InflightMessage, InflightPhase, QueuedMessage, StorageBackend,
+    InflightDirection, InflightMessage, InflightPhase, QueueHandle, QueuedMessage, StorageBackend,
 };
 use crate::error::{MqttError, Result};
 use crate::packet::disconnect::DisconnectPacket;
@@ -485,7 +485,8 @@ impl ClientHandler {
                 }
             }
 
-            self.drain_queued_messages().await;
+            self.inflight_order.retain(|id| *id != puback.packet_id);
+            self.notify_queue();
         }
     }
 
@@ -512,13 +513,16 @@ impl ClientHandler {
                         );
                     }
                 }
-                self.drain_queued_messages().await;
+                self.inflight_order.retain(|id| *id != pubrec.packet_id);
+                self.awaiting_pubcomp.remove(&pubrec.packet_id);
+                self.notify_queue();
             }
             return Ok(());
         }
 
-        if let Some(ref storage) = self.storage {
-            if let Some(publish) = self.outbound_inflight.get(&pubrec.packet_id) {
+        if let Some(publish) = self.outbound_inflight.get(&pubrec.packet_id) {
+            self.awaiting_pubcomp.insert(pubrec.packet_id);
+            if let Some(ref storage) = self.storage {
                 let inflight = InflightMessage::from_publish(
                     publish,
                     self.client_id.as_ref().unwrap().clone(),
@@ -608,62 +612,9 @@ impl ClientHandler {
                 }
             }
 
-            self.drain_queued_messages().await;
-        }
-    }
-
-    async fn drain_queued_messages(&mut self) {
-        let Some(storage) = self.storage.clone() else {
-            return;
-        };
-        let Some(client_id) = self.client_id.clone() else {
-            return;
-        };
-
-        let available_slots =
-            usize::from(self.client_receive_maximum).saturating_sub(self.outbound_inflight.len());
-        if available_slots == 0 {
-            return;
-        }
-
-        let queued = match storage.get_queued_messages(&client_id).await {
-            Ok(msgs) => msgs,
-            Err(e) => {
-                debug!("failed to load queued messages for {client_id}: {e}");
-                return;
-            }
-        };
-
-        if queued.is_empty() {
-            return;
-        }
-
-        let send_count = available_slots.min(queued.len());
-        let mut sent = 0;
-        for msg in queued.iter().take(send_count) {
-            let publish = msg.to_publish_packet();
-            if let Err(e) = self.send_publish(publish).await {
-                debug!("failed to send queued message to {client_id}: {e}");
-                break;
-            }
-            sent += 1;
-        }
-
-        if sent == queued.len() {
-            if let Err(e) = storage.remove_queued_messages(&client_id).await {
-                debug!("failed to remove queued messages for {client_id}: {e}");
-            }
-        } else {
-            if let Err(e) = storage.remove_queued_messages(&client_id).await {
-                debug!("failed to remove queued messages for {client_id}: {e}");
-                return;
-            }
-            for msg in queued.into_iter().skip(sent) {
-                if let Err(e) = storage.queue_message(msg).await {
-                    debug!("failed to re-queue unsent message for {client_id}: {e}");
-                    break;
-                }
-            }
+            self.inflight_order.retain(|id| *id != pubcomp.packet_id);
+            self.awaiting_pubcomp.remove(&pubcomp.packet_id);
+            self.notify_queue();
         }
     }
 
@@ -676,41 +627,17 @@ impl ClientHandler {
 
     pub(super) async fn send_publish(&mut self, mut publish: PublishPacket) -> Result<()> {
         if publish.qos != QoS::AtMostOnce {
-            if self.outbound_inflight.len() >= usize::from(self.client_receive_maximum) {
-                if let Some(ref storage) = self.storage {
-                    let client_id = self.client_id.as_ref().unwrap();
-                    let queued_msg =
-                        QueuedMessage::new(publish.clone(), client_id.clone(), publish.qos, None);
-                    storage.queue_message(queued_msg).await?;
-                    debug!(
-                        client_id = %client_id,
-                        inflight = self.outbound_inflight.len(),
-                        max = self.client_receive_maximum,
-                        "Message queued due to receive maximum limit"
-                    );
-                }
-                return Ok(());
-            }
-
-            if publish.packet_id.is_none() {
+            debug_assert!(
+                self.outbound_inflight.len() < usize::from(self.window),
+                "QoS>0 send outside the outbound window"
+            );
+            let reusable = publish.packet_id.is_some_and(|id| {
+                id != 0
+                    && !self.outbound_inflight.contains_key(&id)
+                    && !self.inflight_publishes.contains_key(&id)
+            });
+            if !reusable {
                 publish.packet_id = Some(self.next_packet_id());
-            }
-
-            if let Some(packet_id) = publish.packet_id {
-                self.outbound_inflight.insert(packet_id, publish.clone());
-                if publish.qos == QoS::ExactlyOnce {
-                    if let Some(ref storage) = self.storage {
-                        let inflight = InflightMessage::from_publish(
-                            &publish,
-                            self.client_id.as_ref().unwrap().clone(),
-                            InflightDirection::Outbound,
-                            InflightPhase::AwaitingPubrec,
-                        );
-                        if let Err(e) = storage.store_inflight_message(inflight).await {
-                            debug!("failed to persist outbound inflight {packet_id}: {e}");
-                        }
-                    }
-                }
             }
         }
 
@@ -726,7 +653,8 @@ impl ClientHandler {
         );
         let qos = publish.qos;
         self.write_buffer.clear();
-        encode_packet_to_buffer(&Packet::Publish(publish), &mut self.write_buffer)?;
+        let packet = Packet::Publish(publish);
+        encode_packet_to_buffer(&packet, &mut self.write_buffer)?;
         if let Some(max) = self.client_max_packet_size {
             if self.write_buffer.len() > max as usize {
                 debug!(
@@ -737,8 +665,88 @@ impl ClientHandler {
                 return Ok(());
             }
         }
-        self.write_publish_bytes(&topic_name, qos).await?;
+        if let Packet::Publish(publish) = packet {
+            if let (Some(packet_id), true) = (publish.packet_id, qos != QoS::AtMostOnce) {
+                if let Some(ref storage) = self.storage {
+                    let inflight = InflightMessage::from_publish(
+                        &publish,
+                        self.client_id.as_ref().unwrap().clone(),
+                        InflightDirection::Outbound,
+                        InflightPhase::AwaitingPubrec,
+                    );
+                    if let Err(e) = storage.store_inflight_message(inflight).await {
+                        debug!("failed to persist outbound inflight {packet_id}: {e}");
+                    }
+                }
+                self.inflight_order.retain(|id| *id != packet_id);
+                self.inflight_order.push_back(packet_id);
+                self.outbound_inflight.insert(packet_id, publish);
+            }
+        }
+        let write_timeout = self.write_timeout();
+        tokio::time::timeout(write_timeout, self.write_publish_bytes(&topic_name, qos))
+            .await
+            .map_err(|_| {
+                warn!(
+                    topic = %topic_name,
+                    timeout = ?write_timeout,
+                    "Transport write stalled; treating the client as gone"
+                );
+                MqttError::Timeout
+            })??;
         self.stats.publish_sent(payload_size);
+        Ok(())
+    }
+
+    /// Wakes this handler's drain; every trigger goes through the queue's Notify.
+    pub(super) fn notify_queue(&self) {
+        if let Some(queue) = &self.queue {
+            queue.notify();
+        }
+    }
+
+    /// One drain batch: at most `min(free window, drain_batch)` messages from the front of
+    /// the session queue, only when the QoS>0 lane is empty (it is older than the queue).
+    /// Re-arms itself through the Notify when anything is left, so the socket is serviced in
+    /// between batches.
+    pub(super) async fn drain_backlog(&mut self) -> Result<()> {
+        let Some(queue) = self.queue.clone() else {
+            return Ok(());
+        };
+        if queue.count() == 0 || !self.qos1_rx.is_empty() {
+            return Ok(());
+        }
+        let free = usize::from(self.window).saturating_sub(self.outbound_inflight.len());
+        if free == 0 {
+            return Ok(());
+        }
+        let batch = queue.take(free.min(self.config.drain_batch.max(1))).await;
+        let started = tokio::time::Instant::now();
+        let budget = self.batch_time_budget();
+        let mut pending = batch.into_iter();
+        while let Some(message) = pending.next() {
+            if self.being_displaced() {
+                self.held.push(message);
+                self.held.extend(pending);
+                return Ok(());
+            }
+            let routable = RoutableMessage {
+                target_flow: message.target_flow,
+                publish: message.to_publish_packet(),
+            };
+            if let Err(e) = self.send_routable(routable).await {
+                self.held.extend(pending);
+                return Err(e);
+            }
+            if started.elapsed() > budget {
+                queue.requeue_front(pending.collect());
+                break;
+            }
+        }
+        queue.finish_drain();
+        if queue.count() > 0 {
+            queue.notify();
+        }
         Ok(())
     }
 
@@ -796,50 +804,75 @@ impl ClientHandler {
         self.transport.write(&self.write_buffer).await
     }
 
-    pub(super) async fn resend_inflight_messages(&mut self) -> Result<()> {
-        if let Some(ref storage) = self.storage {
-            let client_id = self.client_id.as_ref().unwrap();
-            let inflights = match storage.get_inflight_messages(client_id).await {
-                Ok(msgs) => msgs,
-                Err(e) => {
-                    warn!("failed to load inflight messages for {client_id}: {e}");
-                    return Ok(());
-                }
-            };
+    /// Reloads the session's persisted inflight state after a restart: unacknowledged
+    /// publishes go back to the front of the queue and are re-sent as duplicates through the
+    /// normal window, outbound exactly-once messages awaiting completion get their release
+    /// packet again, and inbound exactly-once state is restored so a repeated publish is not
+    /// delivered twice.
+    pub(super) async fn load_persisted_inflight(&mut self, queue: &QueueHandle) -> Result<()> {
+        let (Some(storage), Some(client_id)) = (self.storage.clone(), self.client_id.clone())
+        else {
+            return Ok(());
+        };
+        let mut inflights = match storage.get_inflight_messages(&client_id).await {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                warn!("failed to load inflight messages for {client_id}: {e}");
+                return Ok(());
+            }
+        };
+        inflights.sort_by_key(|msg| (msg.stored_at_secs, msg.packet_id));
 
-            for msg in inflights {
-                match msg.direction {
-                    InflightDirection::Outbound => match msg.phase {
-                        InflightPhase::AwaitingPubrec => {
-                            let mut publish = msg.to_publish_packet();
-                            publish.dup = true;
-                            self.outbound_inflight
-                                .insert(msg.packet_id, publish.clone());
-                            self.write_buffer.clear();
-                            encode_packet_to_buffer(
-                                &Packet::Publish(publish),
-                                &mut self.write_buffer,
-                            )?;
-                            self.transport.write(&self.write_buffer).await?;
-                        }
-                        InflightPhase::AwaitingPubcomp => {
-                            let publish = msg.to_publish_packet();
-                            self.outbound_inflight.insert(msg.packet_id, publish);
-                            let mut pubrel = PubRelPacket::new(msg.packet_id);
-                            pubrel.reason_code = ReasonCode::Success;
-                            self.write_to_client(Packet::PubRel(pubrel)).await?;
-                        }
-                        InflightPhase::AwaitingPubrel => {}
-                    },
-                    InflightDirection::Inbound => {
-                        let publish = msg.to_publish_packet();
-                        self.inflight_publishes
-                            .insert(msg.packet_id, InflightPublish::Pending(publish));
+        let mut requeue = Vec::new();
+        for msg in inflights {
+            match msg.direction {
+                InflightDirection::Outbound => match msg.phase {
+                    InflightPhase::AwaitingPubrec => {
+                        let mut queued = QueuedMessage::new(
+                            msg.to_publish_packet(),
+                            client_id.clone(),
+                            msg.qos,
+                            Some(msg.packet_id),
+                        );
+                        queued.dup = true;
+                        requeue.push(queued);
                     }
+                    InflightPhase::AwaitingPubcomp => {
+                        let publish = msg.to_publish_packet();
+                        self.inflight_order.push_back(msg.packet_id);
+                        self.outbound_inflight.insert(msg.packet_id, publish);
+                        self.awaiting_pubcomp.insert(msg.packet_id);
+                        let mut pubrel = PubRelPacket::new(msg.packet_id);
+                        pubrel.reason_code = ReasonCode::Success;
+                        self.write_to_client(Packet::PubRel(pubrel)).await?;
+                    }
+                    InflightPhase::AwaitingPubrel => {}
+                },
+                InflightDirection::Inbound => {
+                    let publish = msg.to_publish_packet();
+                    self.inflight_publishes
+                        .insert(msg.packet_id, InflightPublish::Pending(publish));
                 }
             }
-            self.advance_packet_id_past_inflight();
         }
+        if !requeue.is_empty() {
+            let packet_ids: Vec<u16> = requeue.iter().filter_map(|m| m.packet_id).collect();
+            debug!(
+                client_id = %client_id,
+                count = requeue.len(),
+                "Re-queued persisted inflight messages for redelivery"
+            );
+            queue.requeue_front(requeue);
+            for packet_id in packet_ids {
+                if let Err(e) = storage
+                    .remove_inflight_message(&client_id, packet_id, InflightDirection::Outbound)
+                    .await
+                {
+                    debug!("failed to remove reloaded inflight {packet_id}: {e}");
+                }
+            }
+        }
+        self.advance_packet_id_past_inflight();
         Ok(())
     }
 }

--- a/crates/mqtt5/src/broker/client_handler/subscribe.rs
+++ b/crates/mqtt5/src/broker/client_handler/subscribe.rs
@@ -1,7 +1,7 @@
 use crate::broker::events::{
     ClientSubscribeEvent, ClientUnsubscribeEvent, SubAckReasonCode, SubscriptionInfo,
 };
-use crate::broker::storage::{StorageBackend, StoredSubscription};
+use crate::broker::storage::{QueuedMessage, StorageBackend, StoredSubscription};
 use crate::error::{MqttError, Result};
 use crate::packet::disconnect::DisconnectPacket;
 use crate::packet::suback::SubAckPacket;
@@ -10,13 +10,12 @@ use crate::packet::unsuback::UnsubAckPacket;
 use crate::packet::unsubscribe::UnsubscribePacket;
 use crate::packet::Packet;
 use crate::protocol::v5::reason_codes::ReasonCode;
-use crate::transport::PacketIo;
 use crate::types::ProtocolVersion;
 use crate::validation::{parse_shared_subscription, topic_matches_filter, validate_topic_filter};
 use crate::QoS;
 use tracing::{debug, warn};
 
-use crate::broker::router::RoutableMessage;
+use crate::broker::router::{RoutableMessage, Subscribed, Unsubscribed};
 
 use super::ClientHandler;
 
@@ -51,9 +50,10 @@ impl ClientHandler {
                     .any(|pattern| topic_matches_filter(&filter.filter, pattern));
 
             let flow_id = self.pending_external_flow_id;
-            let is_new = self
+            let outcome = self
                 .router
-                .subscribe(
+                .subscribe_as(
+                    Some(self.generation),
                     client_id.clone(),
                     filter.filter.clone(),
                     QoS::from(granted_qos),
@@ -66,6 +66,14 @@ impl ClientHandler {
                     flow_id,
                 )
                 .await?;
+            let is_new = match outcome {
+                Subscribed::New => true,
+                Subscribed::Updated => false,
+                Subscribed::Fenced => {
+                    debug!("Ignoring SUBSCRIBE from a connection whose session was taken over");
+                    return Ok(());
+                }
+            };
 
             self.persist_subscription(
                 &filter.filter,
@@ -252,12 +260,40 @@ impl ClientHandler {
                     publish: msg,
                     target_flow: None,
                 };
-                self.publish_tx.send_async(routable).await.map_err(|_| {
-                    MqttError::InvalidState("Failed to queue retained message".to_string())
-                })?;
+                self.offer_retained(routable);
             }
         }
         Ok(())
+    }
+
+    /// Hands a retained message to this client's own delivery lanes without ever awaiting
+    /// them: the handler task is their only consumer, so an await here would never complete.
+    fn offer_retained(&self, routable: RoutableMessage) {
+        let Some(client_id) = self.client_id.as_ref() else {
+            return;
+        };
+        if routable.publish.qos == QoS::AtMostOnce {
+            if self.qos0_tx.try_send(routable).is_err() {
+                debug!(client_id = %client_id, "Dropping QoS 0 retained message: lane full");
+            }
+            return;
+        }
+        let queue_behind = |publish: crate::packet::publish::PublishPacket| {
+            if let Some(queue) = self.queue.as_ref() {
+                let qos = publish.qos;
+                queue.push(QueuedMessage::new(publish, client_id.clone(), qos, None));
+                queue.notify();
+            } else {
+                warn!(client_id = %client_id, "Dropping retained message: no session queue");
+            }
+        };
+        if self.queue.as_ref().is_some_and(|queue| queue.behind()) {
+            queue_behind(routable.publish);
+            return;
+        }
+        if let Err(rejected) = self.qos1_tx.try_send(routable) {
+            queue_behind(rejected.into_inner().publish);
+        }
     }
 
     async fn build_and_send_suback(
@@ -311,7 +347,10 @@ impl ClientHandler {
             return;
         };
 
-        let removed_filters = self.router.unsubscribe_by_flow(client_id, flow_id).await;
+        let removed_filters = self
+            .router
+            .unsubscribe_by_flow(Some(self.generation), client_id, flow_id)
+            .await;
         if removed_filters.is_empty() {
             return;
         }
@@ -366,14 +405,27 @@ impl ClientHandler {
         &mut self,
         unsubscribe: UnsubscribePacket,
     ) -> Result<()> {
-        let client_id = self.client_id.as_ref().unwrap();
+        let client_id = self.client_id.clone().unwrap();
         let mut reason_codes = Vec::new();
 
         for topic_filter in &unsubscribe.filters {
-            let removed = self
+            let removed = match self
                 .router
-                .unsubscribe(client_id, topic_filter, self.pending_external_flow_id)
-                .await;
+                .unsubscribe_as(
+                    Some(self.generation),
+                    &client_id,
+                    topic_filter,
+                    self.pending_external_flow_id,
+                )
+                .await
+            {
+                Unsubscribed::Removed => true,
+                Unsubscribed::Absent => false,
+                Unsubscribed::Fenced => {
+                    debug!("Ignoring UNSUBSCRIBE from a connection whose session was taken over");
+                    return Ok(());
+                }
+            };
 
             if removed {
                 if let Some(ref mut session) = self.session {
@@ -404,10 +456,7 @@ impl ClientHandler {
             UnsubAckPacket::new(unsubscribe.packet_id)
         };
         unsuback.reason_codes = reason_codes;
-        let result = self
-            .transport
-            .write_packet(Packet::UnsubAck(unsuback))
-            .await;
+        let result = self.write_to_client(Packet::UnsubAck(unsuback)).await;
 
         if let Some(ref handler) = self.config.event_handler {
             let event = ClientUnsubscribeEvent {

--- a/crates/mqtt5/src/broker/config/mod.rs
+++ b/crates/mqtt5/src/broker/config/mod.rs
@@ -35,6 +35,14 @@ fn default_client_channel_capacity() -> usize {
     10000
 }
 
+fn default_max_outbound_inflight() -> u16 {
+    64
+}
+
+fn default_drain_batch() -> usize {
+    64
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoadBalancerConfig {
     pub backends: Vec<String>,
@@ -86,6 +94,10 @@ pub struct BrokerConfig {
     pub max_retained_message_size: usize,
     #[serde(default = "default_client_channel_capacity")]
     pub client_channel_capacity: usize,
+    #[serde(default = "default_max_outbound_inflight")]
+    pub max_outbound_inflight: u16,
+    #[serde(default = "default_drain_batch")]
+    pub drain_batch: usize,
     #[cfg_attr(not(target_arch = "wasm32"), serde(with = "humantime_serde"))]
     pub server_keep_alive: Option<Duration>,
     #[serde(default)]
@@ -154,6 +166,8 @@ impl std::fmt::Debug for BrokerConfig {
             .field("max_retained_messages", &self.max_retained_messages)
             .field("max_retained_message_size", &self.max_retained_message_size)
             .field("client_channel_capacity", &self.client_channel_capacity)
+            .field("max_outbound_inflight", &self.max_outbound_inflight)
+            .field("drain_batch", &self.drain_batch)
             .field("server_keep_alive", &self.server_keep_alive)
             .field("server_receive_maximum", &self.server_receive_maximum)
             .field("response_information", &self.response_information)
@@ -211,6 +225,8 @@ impl Default for BrokerConfig {
             max_retained_messages: 0,
             max_retained_message_size: 0,
             client_channel_capacity: default_client_channel_capacity(),
+            max_outbound_inflight: default_max_outbound_inflight(),
+            drain_batch: default_drain_batch(),
             server_keep_alive: None,
             server_receive_maximum: None,
             response_information: None,
@@ -314,6 +330,18 @@ impl BrokerConfig {
     #[must_use]
     pub fn with_client_channel_capacity(mut self, capacity: usize) -> Self {
         self.client_channel_capacity = capacity;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_outbound_inflight(mut self, window: u16) -> Self {
+        self.max_outbound_inflight = window;
+        self
+    }
+
+    #[must_use]
+    pub fn with_drain_batch(mut self, batch: usize) -> Self {
+        self.drain_batch = batch;
         self
     }
 

--- a/crates/mqtt5/src/broker/config/storage.rs
+++ b/crates/mqtt5/src/broker/config/storage.rs
@@ -10,6 +10,8 @@ pub struct StorageConfig {
     #[cfg_attr(not(target_arch = "wasm32"), serde(with = "humantime_serde"))]
     pub cleanup_interval: Duration,
     pub enable_persistence: bool,
+    pub max_queued_messages_per_client: usize,
+    pub max_queued_bytes_per_client: usize,
 }
 
 impl Default for StorageConfig {
@@ -19,6 +21,8 @@ impl Default for StorageConfig {
             base_dir: PathBuf::from("./mqtt_storage"),
             cleanup_interval: Duration::from_secs(3600),
             enable_persistence: true,
+            max_queued_messages_per_client: 10_000,
+            max_queued_bytes_per_client: 64 * 1024 * 1024,
         }
     }
 }
@@ -50,6 +54,18 @@ impl StorageConfig {
     #[must_use]
     pub fn with_persistence(mut self, enabled: bool) -> Self {
         self.enable_persistence = enabled;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_queued_messages_per_client(mut self, max_messages: usize) -> Self {
+        self.max_queued_messages_per_client = max_messages;
+        self
+    }
+
+    #[must_use]
+    pub fn with_max_queued_bytes_per_client(mut self, max_bytes: usize) -> Self {
+        self.max_queued_bytes_per_client = max_bytes;
         self
     }
 }

--- a/crates/mqtt5/src/broker/router.rs
+++ b/crates/mqtt5/src/broker/router.rs
@@ -2,7 +2,8 @@
 use crate::broker::bridge::BridgeManager;
 use crate::broker::events::{BrokerEventHandler, RetainedSetEvent};
 use crate::broker::storage::{
-    ChangeOnlyState, DynamicStorage, QueuedMessage, RetainedMessage, StorageBackend,
+    ChangeOnlyState, DynamicStorage, QueueHandle, QueueLimits, QueueRegistry, QueuedMessage,
+    RetainedMessage, StorageBackend,
 };
 use crate::packet::publish::PublishPacket;
 use crate::types::ProtocolVersion;
@@ -14,8 +15,12 @@ use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Weak;
-use tokio::sync::RwLock;
-use tracing::{debug, error, info, trace, warn};
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tokio::time::{Duration, Instant};
+use tracing::{debug, error, info, trace};
+
+/// Upper bound on how long one publish may wait for slow subscribers' delivery channels.
+pub const ROUTE_BUDGET_MAX: Duration = Duration::from_secs(2);
 
 struct OutboundRateState {
     count: AtomicU32,
@@ -92,13 +97,147 @@ pub struct MessageRouter {
     echo_suppression_key: Arc<RwLock<Option<String>>>,
     outbound_rates: parking_lot::RwLock<HashMap<String, OutboundRateState>>,
     max_outbound_rate: AtomicU32,
+    fallback_queues: QueueRegistry,
+    next_generation: std::sync::atomic::AtomicU64,
 }
 
 /// Information about a connected client
 #[derive(Debug)]
 pub struct ClientInfo {
-    pub sender: flume::Sender<RoutableMessage>,
-    pub disconnect_tx: tokio::sync::oneshot::Sender<()>,
+    pub generation: u64,
+    pub qos1_tx: mpsc::Sender<RoutableMessage>,
+    pub qos0_tx: mpsc::Sender<RoutableMessage>,
+    pub queue: QueueHandle,
+    pub disconnect_tx: oneshot::Sender<TakeoverNotice>,
+}
+
+/// Balances one `begin_handoff`: whoever ends up holding the `TakeoverNotice` decrements the
+/// count when it completes the hand-off or is dropped, so a displaced handler that panics
+/// before handing off (its `disconnect_rx`, and the notice inside it, unwind with the task)
+/// can never leave the count stuck above zero and wedge the client id forever.
+#[derive(Debug)]
+pub struct HandoffGuard {
+    queue: QueueHandle,
+}
+
+impl HandoffGuard {
+    fn new(queue: QueueHandle) -> Self {
+        queue.begin_handoff();
+        Self { queue }
+    }
+}
+
+impl Drop for HandoffGuard {
+    fn drop(&mut self) {
+        self.queue.end_handoff();
+    }
+}
+
+/// Delivered to the handler a newer connection with the same client id displaces.
+///
+/// The displaced handler hands its unfinished deliveries back to the session queue (or drops
+/// them when `discard` is set), then signals `released` so the new handler may start delivering.
+/// The `guard` decrements the queue's hand-off count when the notice is completed or dropped.
+#[derive(Debug)]
+pub struct TakeoverNotice {
+    pub discard: bool,
+    pub released: oneshot::Sender<()>,
+    pub guard: HandoffGuard,
+}
+
+/// What a handler learns when it registers its connection.
+#[derive(Debug)]
+pub struct Registration {
+    pub generation: u64,
+    pub released: Option<oneshot::Receiver<()>>,
+    pub cutoff: Option<u64>,
+}
+
+/// Whether the releasing handler still owned the router entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Release {
+    Owned,
+    Displaced,
+}
+
+/// Outcome of a generation-fenced subscribe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Subscribed {
+    New,
+    Updated,
+    Fenced,
+}
+
+/// Outcome of a generation-fenced unsubscribe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unsubscribed {
+    Removed,
+    Absent,
+    Fenced,
+}
+
+/// Senders for one client's two delivery lanes.
+#[derive(Debug, Clone)]
+pub struct DeliveryLanes {
+    pub qos1_tx: mpsc::Sender<RoutableMessage>,
+    pub qos0_tx: mpsc::Sender<RoutableMessage>,
+}
+
+impl DeliveryLanes {
+    /// Creates both lanes with the given capacity each.
+    #[must_use]
+    pub fn channel(capacity: usize) -> (Self, LaneReceivers) {
+        let (qos1_tx, qos1_rx) = mpsc::channel(capacity);
+        let (qos0_tx, qos0_rx) = mpsc::channel(capacity);
+        (
+            Self { qos1_tx, qos0_tx },
+            LaneReceivers {
+                qos1: qos1_rx,
+                qos0: qos0_rx,
+            },
+        )
+    }
+}
+
+/// Receivers for one client's two delivery lanes, with helpers that read either lane.
+#[derive(Debug)]
+pub struct LaneReceivers {
+    pub qos1: mpsc::Receiver<RoutableMessage>,
+    pub qos0: mpsc::Receiver<RoutableMessage>,
+}
+
+impl LaneReceivers {
+    /// Takes the next message from the gated lane, then the ungated lane, without waiting.
+    ///
+    /// # Errors
+    /// Returns the ungated lane's error when both lanes are empty or closed.
+    pub fn try_recv(&mut self) -> std::result::Result<RoutableMessage, mpsc::error::TryRecvError> {
+        self.qos1.try_recv().or_else(|_| self.qos0.try_recv())
+    }
+
+    /// Waits for the next message on either lane.
+    pub async fn recv(&mut self) -> Option<RoutableMessage> {
+        tokio::select! {
+            message = self.qos1.recv() => message,
+            message = self.qos0.recv() => message,
+        }
+    }
+}
+
+enum DeliveryPlan {
+    Online {
+        client_id: String,
+        message: PublishPacket,
+        target_flow: Option<u64>,
+        lanes: DeliveryLanes,
+        queue: QueueHandle,
+    },
+    Behind {
+        client_id: String,
+        message: PublishPacket,
+        target_flow: Option<u64>,
+        queue: QueueHandle,
+    },
 }
 
 impl MessageRouter {
@@ -122,7 +261,18 @@ impl MessageRouter {
             echo_suppression_key: Arc::new(RwLock::new(None)),
             outbound_rates: parking_lot::RwLock::new(HashMap::new()),
             max_outbound_rate: AtomicU32::new(0),
+            fallback_queues: QueueRegistry::new(QueueLimits::default(), None),
+            next_generation: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// The client's queue: from storage when persistence is on, else an in-memory one.
+    #[must_use]
+    pub fn queue_handle(&self, client_id: &str) -> QueueHandle {
+        self.storage.as_ref().map_or_else(
+            || self.fallback_queues.handle(client_id),
+            |storage| storage.queue_handle(client_id),
+        )
     }
 
     /// Creates a new message router with storage backend
@@ -145,6 +295,8 @@ impl MessageRouter {
             echo_suppression_key: Arc::new(RwLock::new(None)),
             outbound_rates: parking_lot::RwLock::new(HashMap::new()),
             max_outbound_rate: AtomicU32::new(0),
+            fallback_queues: QueueRegistry::new(QueueLimits::default(), None),
+            next_generation: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -221,30 +373,122 @@ impl MessageRouter {
         Ok(())
     }
 
+    /// Registers a connection that resumes (or starts) a session without a clean start.
     pub async fn register_client(
         &self,
         client_id: String,
-        sender: flume::Sender<RoutableMessage>,
-        new_disconnect_tx: tokio::sync::oneshot::Sender<()>,
-    ) {
-        let mut clients = self.clients.write().await;
+        lanes: DeliveryLanes,
+        queue: QueueHandle,
+        disconnect_tx: oneshot::Sender<TakeoverNotice>,
+    ) -> Registration {
+        self.register_session(client_id, lanes, queue, disconnect_tx, false)
+            .await
+    }
 
-        if let Some(old_client) = clients.remove(&client_id) {
-            info!("Client ID takeover: {}", client_id);
-            let _ = old_client.disconnect_tx.send(());
-        }
+    /// Registers a connection, displacing any live handler for the same client id.
+    ///
+    /// While a displaced handler is still handing its deliveries back, the queue's hand-off
+    /// flag keeps routers queueing behind it; the returned `released` receiver fires when the
+    /// old handler is done. `cutoff` is the first queue sequence a clean start must keep.
+    /// A clean start also drops every subscription the client id still holds.
+    pub async fn register_session(
+        &self,
+        client_id: String,
+        lanes: DeliveryLanes,
+        queue: QueueHandle,
+        disconnect_tx: oneshot::Sender<TakeoverNotice>,
+        clean_start: bool,
+    ) -> Registration {
+        let subscription_maps = if clean_start {
+            let mut exact = self.exact_subscriptions.write().await;
+            let mut wildcard = self.wildcard_subscriptions.write().await;
+            Self::strip_client(&mut exact, &client_id);
+            Self::strip_client(&mut wildcard, &client_id);
+            Some((exact, wildcard))
+        } else {
+            None
+        };
+
+        let mut clients = self.clients.write().await;
+        let generation = self
+            .next_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
+        let (released, cutoff) = match clients.remove(&client_id) {
+            Some(old_client) => {
+                info!("Client ID takeover: {}", client_id);
+                let cutoff = queue.next_seq();
+                let (released_tx, released_rx) = oneshot::channel();
+                let notice = TakeoverNotice {
+                    discard: clean_start,
+                    released: released_tx,
+                    guard: HandoffGuard::new(Arc::clone(&queue)),
+                };
+                if old_client.disconnect_tx.send(notice).is_ok() {
+                    (Some(released_rx), Some(cutoff))
+                } else {
+                    (None, None)
+                }
+            }
+            None => (None, None),
+        };
 
         clients.insert(
             client_id.clone(),
             ClientInfo {
-                sender,
-                disconnect_tx: new_disconnect_tx,
+                generation,
+                qos1_tx: lanes.qos1_tx,
+                qos0_tx: lanes.qos0_tx,
+                queue,
+                disconnect_tx,
             },
         );
+        drop(clients);
+        drop(subscription_maps);
+        if clean_start {
+            self.change_only_states.write().await.remove(&client_id);
+        }
         self.outbound_rates
             .write()
             .insert(client_id.clone(), OutboundRateState::new());
         info!("Registered client: {}", client_id);
+        Registration {
+            generation,
+            released,
+            cutoff,
+        }
+    }
+
+    /// Removes the handler's router entry if it still owns it; a displaced handler's entry
+    /// already belongs to its successor and is left alone.
+    pub async fn release_client(
+        &self,
+        client_id: &str,
+        generation: u64,
+        preserve_session: bool,
+    ) -> Release {
+        {
+            let mut clients = self.clients.write().await;
+            match clients.get(client_id) {
+                Some(info) if info.generation == generation => {
+                    clients.remove(client_id);
+                }
+                Some(_) => return Release::Displaced,
+                None => {}
+            }
+        }
+        self.outbound_rates.write().remove(client_id);
+        if preserve_session {
+            debug!("Disconnected client (keeping subscriptions): {}", client_id);
+        } else {
+            self.remove_client_subscriptions(client_id).await;
+            debug!("Unregistered client: {}", client_id);
+        }
+        Release::Owned
+    }
+
+    pub async fn is_connected(&self, client_id: &str) -> bool {
+        self.clients.read().await.contains_key(client_id)
     }
 
     pub async fn disconnect_client(&self, client_id: &str) {
@@ -255,32 +499,35 @@ impl MessageRouter {
     }
 
     pub async fn unregister_client(&self, client_id: &str) {
-        let mut clients = self.clients.write().await;
-        clients.remove(client_id);
+        {
+            let mut clients = self.clients.write().await;
+            clients.remove(client_id);
+        }
         self.outbound_rates.write().remove(client_id);
-
-        {
-            let mut exact = self.exact_subscriptions.write().await;
-            for subs in exact.values_mut() {
-                subs.retain(|sub| sub.client_id != client_id);
-            }
-            exact.retain(|_, subs| !subs.is_empty());
-        }
-
-        {
-            let mut wildcard = self.wildcard_subscriptions.write().await;
-            for subs in wildcard.values_mut() {
-                subs.retain(|sub| sub.client_id != client_id);
-            }
-            wildcard.retain(|_, subs| !subs.is_empty());
-        }
-
+        self.remove_client_subscriptions(client_id).await;
         debug!("Unregistered client: {}", client_id);
     }
 
-    pub async fn cleanup_stale_subscriptions(&self) {
-        let clients = self.clients.read().await;
+    async fn remove_client_subscriptions(&self, client_id: &str) {
+        {
+            let mut exact = self.exact_subscriptions.write().await;
+            Self::strip_client(&mut exact, client_id);
+        }
+        {
+            let mut wildcard = self.wildcard_subscriptions.write().await;
+            Self::strip_client(&mut wildcard, client_id);
+        }
+    }
 
+    fn strip_client(map: &mut HashMap<String, Vec<Subscription>>, client_id: &str) {
+        for subs in map.values_mut() {
+            subs.retain(|sub| sub.client_id != client_id);
+        }
+        map.retain(|_, subs| !subs.is_empty());
+    }
+
+    pub async fn cleanup_stale_subscriptions(&self) {
+        self.fallback_queues.evict_idle();
         let subscribed_ids: HashSet<String> = {
             let exact = self.exact_subscriptions.read().await;
             let wildcard = self.wildcard_subscriptions.read().await;
@@ -292,11 +539,13 @@ impl MessageRouter {
                 .collect()
         };
 
+        let connected: HashSet<String> = self.clients.read().await.keys().cloned().collect();
+
         let mut stale: Vec<String> = Vec::new();
         let storage = self.storage.as_ref();
 
         for client_id in &subscribed_ids {
-            if clients.contains_key(client_id) {
+            if connected.contains(client_id) {
                 continue;
             }
             let has_session = if let Some(storage) = storage {
@@ -308,8 +557,6 @@ impl MessageRouter {
                 stale.push(client_id.clone());
             }
         }
-
-        drop(clients);
 
         if stale.is_empty() {
             return;
@@ -338,12 +585,8 @@ impl MessageRouter {
             }
         }
 
-        if let Some(storage) = storage {
-            for client_id in &stale {
-                if let Err(e) = storage.remove_queued_messages(client_id).await {
-                    debug!("failed to remove queued messages for stale client {client_id}: {e}");
-                }
-            }
+        for client_id in &stale {
+            self.queue_handle(client_id).clear(None);
         }
 
         info!(
@@ -370,6 +613,44 @@ impl MessageRouter {
         change_only: bool,
         flow_id: Option<u64>,
     ) -> Result<bool> {
+        let outcome = self
+            .subscribe_as(
+                None,
+                client_id,
+                topic_filter,
+                qos,
+                subscription_id,
+                no_local,
+                retain_as_published,
+                retain_handling,
+                protocol_version,
+                change_only,
+                flow_id,
+            )
+            .await?;
+        Ok(outcome == Subscribed::New)
+    }
+
+    /// Adds a subscription on behalf of the handler holding `generation`; a handler whose
+    /// registration has been displaced gets `Fenced` and changes nothing.
+    ///
+    /// # Errors
+    /// Returns an error when `retain_handling` is invalid.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn subscribe_as(
+        &self,
+        generation: Option<u64>,
+        client_id: String,
+        topic_filter: String,
+        qos: QoS,
+        subscription_id: Option<u32>,
+        no_local: bool,
+        retain_as_published: bool,
+        retain_handling: u8,
+        protocol_version: ProtocolVersion,
+        change_only: bool,
+        flow_id: Option<u64>,
+    ) -> Result<Subscribed> {
         if retain_handling > 2 {
             return Err(crate::MqttError::ProtocolError(format!(
                 "Invalid retain_handling value: {retain_handling} (must be 0, 1, or 2)"
@@ -392,46 +673,32 @@ impl MessageRouter {
             flow_id,
         };
 
-        let is_new = if Self::has_wildcards(actual_filter) {
-            let mut wildcard = self.wildcard_subscriptions.write().await;
-            let subs = wildcard.entry(actual_filter.to_string()).or_default();
-            let existing_pos = subs
-                .iter()
-                .position(|s| s.client_id == client_id && s.flow_id == flow_id);
-            if let Some(pos) = existing_pos {
-                subs[pos] = subscription;
-                debug!(
-                    "Client {} updated wildcard subscription to {}",
-                    client_id, topic_filter
-                );
-                false
-            } else {
-                subs.push(subscription);
-                debug!(
-                    "Client {} subscribed to wildcard {}",
-                    client_id, topic_filter
-                );
-                true
-            }
+        let subscriptions = if Self::has_wildcards(actual_filter) {
+            &self.wildcard_subscriptions
         } else {
-            let mut exact = self.exact_subscriptions.write().await;
-            let subs = exact.entry(actual_filter.to_string()).or_default();
-            let existing_pos = subs
-                .iter()
-                .position(|s| s.client_id == client_id && s.flow_id == flow_id);
-            if let Some(pos) = existing_pos {
-                subs[pos] = subscription;
-                debug!(
-                    "Client {} updated subscription to {}",
-                    client_id, topic_filter
-                );
-                false
-            } else {
-                subs.push(subscription);
-                debug!("Client {} subscribed to {}", client_id, topic_filter);
-                true
-            }
+            &self.exact_subscriptions
         };
+        let mut subs_map = subscriptions.write().await;
+        if !self.generation_is_current(generation, &client_id).await {
+            return Ok(Subscribed::Fenced);
+        }
+        let subs = subs_map.entry(actual_filter.to_string()).or_default();
+        let existing_pos = subs
+            .iter()
+            .position(|s| s.client_id == client_id && s.flow_id == flow_id);
+        let outcome = if let Some(pos) = existing_pos {
+            subs[pos] = subscription;
+            debug!(
+                "Client {} updated subscription to {}",
+                client_id, topic_filter
+            );
+            Subscribed::Updated
+        } else {
+            subs.push(subscription);
+            debug!("Client {} subscribed to {}", client_id, topic_filter);
+            Subscribed::New
+        };
+        drop(subs_map);
 
         if let Some(group) = share_group {
             let mut counters = self.share_group_counters.write().await;
@@ -440,7 +707,19 @@ impl MessageRouter {
                 .or_insert_with(|| Arc::new(AtomicUsize::new(0)));
         }
 
-        Ok(is_new)
+        Ok(outcome)
+    }
+
+    async fn generation_is_current(&self, generation: Option<u64>, client_id: &str) -> bool {
+        match generation {
+            None => true,
+            Some(generation) => self
+                .clients
+                .read()
+                .await
+                .get(client_id)
+                .is_some_and(|info| info.generation == generation),
+        }
     }
 
     pub async fn unsubscribe(
@@ -449,6 +728,20 @@ impl MessageRouter {
         topic_filter: &str,
         flow_id: Option<u64>,
     ) -> bool {
+        self.unsubscribe_as(None, client_id, topic_filter, flow_id)
+            .await
+            == Unsubscribed::Removed
+    }
+
+    /// Removes a subscription on behalf of the handler holding `generation`; a displaced
+    /// handler gets `Fenced` and changes nothing.
+    pub async fn unsubscribe_as(
+        &self,
+        generation: Option<u64>,
+        client_id: &str,
+        topic_filter: &str,
+        flow_id: Option<u64>,
+    ) -> Unsubscribed {
         let (actual_filter, _) = parse_shared_subscription(topic_filter);
 
         let subscriptions = if Self::has_wildcards(actual_filter) {
@@ -458,6 +751,9 @@ impl MessageRouter {
         };
 
         let mut subs_map = subscriptions.write().await;
+        if !self.generation_is_current(generation, client_id).await {
+            return Unsubscribed::Fenced;
+        }
 
         if let Some(subs) = subs_map.get_mut(actual_filter) {
             let initial_len = subs.len();
@@ -470,39 +766,42 @@ impl MessageRouter {
             }
             if removed {
                 debug!("Client {} unsubscribed from {}", client_id, topic_filter);
+                Unsubscribed::Removed
+            } else {
+                Unsubscribed::Absent
             }
-            removed
         } else {
-            false
+            Unsubscribed::Absent
         }
     }
 
-    pub async fn unsubscribe_by_flow(&self, client_id: &str, flow_id: u64) -> Vec<String> {
+    /// Removes every subscription the handler holding `generation` bound to `flow_id`;
+    /// a displaced handler removes nothing.
+    pub async fn unsubscribe_by_flow(
+        &self,
+        generation: Option<u64>,
+        client_id: &str,
+        flow_id: u64,
+    ) -> Vec<String> {
         let mut removed_filters = Vec::new();
 
-        {
-            let mut exact = self.exact_subscriptions.write().await;
-            for (filter, subs) in exact.iter_mut() {
+        let mut exact = self.exact_subscriptions.write().await;
+        let mut wildcard = self.wildcard_subscriptions.write().await;
+        if !self.generation_is_current(generation, client_id).await {
+            return removed_filters;
+        }
+        for map in [&mut *exact, &mut *wildcard] {
+            for (filter, subs) in map.iter_mut() {
                 let before = subs.len();
                 subs.retain(|sub| !(sub.client_id == client_id && sub.flow_id == Some(flow_id)));
                 if subs.len() < before {
                     removed_filters.push(filter.clone());
                 }
             }
-            exact.retain(|_, subs| !subs.is_empty());
+            map.retain(|_, subs| !subs.is_empty());
         }
-
-        {
-            let mut wildcard = self.wildcard_subscriptions.write().await;
-            for (filter, subs) in wildcard.iter_mut() {
-                let before = subs.len();
-                subs.retain(|sub| !(sub.client_id == client_id && sub.flow_id == Some(flow_id)));
-                if subs.len() < before {
-                    removed_filters.push(filter.clone());
-                }
-            }
-            wildcard.retain(|_, subs| !subs.is_empty());
-        }
+        drop(wildcard);
+        drop(exact);
 
         if !removed_filters.is_empty() {
             debug!(
@@ -517,6 +816,22 @@ impl MessageRouter {
 
     /// Routes a publish message to all matching subscribers and forwards to bridges.
     pub async fn route_message(&self, publish: &PublishPacket, publishing_client_id: Option<&str>) {
+        self.route_message_with_deadline(
+            publish,
+            publishing_client_id,
+            Instant::now() + ROUTE_BUDGET_MAX,
+        )
+        .await;
+    }
+
+    /// Routes a publish message; `deadline` bounds the total time spent waiting on slow
+    /// subscribers' delivery channels for this one publish.
+    pub async fn route_message_with_deadline(
+        &self,
+        publish: &PublishPacket,
+        publishing_client_id: Option<&str>,
+        deadline: Instant,
+    ) {
         #[cfg(feature = "opentelemetry")]
         {
             use tracing::Instrument;
@@ -526,12 +841,12 @@ impl MessageRouter {
                 mqtt.qos = publish.qos as u8,
                 mqtt.retain = publish.retain,
             );
-            self.route_message_internal(publish, publishing_client_id, true)
+            self.route_message_internal(publish, publishing_client_id, true, deadline)
                 .instrument(span)
                 .await;
         }
         #[cfg(not(feature = "opentelemetry"))]
-        self.route_message_internal(publish, publishing_client_id, true)
+        self.route_message_internal(publish, publishing_client_id, true, deadline)
             .await;
     }
 
@@ -544,6 +859,7 @@ impl MessageRouter {
         publish: &PublishPacket,
         publishing_client_id: Option<&str>,
     ) {
+        let deadline = Instant::now() + ROUTE_BUDGET_MAX;
         #[cfg(feature = "opentelemetry")]
         {
             use tracing::Instrument;
@@ -554,12 +870,12 @@ impl MessageRouter {
                 mqtt.retain = publish.retain,
                 mqtt.bridge_forward = false,
             );
-            self.route_message_internal(publish, publishing_client_id, false)
+            self.route_message_internal(publish, publishing_client_id, false, deadline)
                 .instrument(span)
                 .await;
         }
         #[cfg(not(feature = "opentelemetry"))]
-        self.route_message_internal(publish, publishing_client_id, false)
+        self.route_message_internal(publish, publishing_client_id, false, deadline)
             .await;
     }
 
@@ -568,6 +884,7 @@ impl MessageRouter {
         publish: &PublishPacket,
         publishing_client_id: Option<&str>,
         forward_to_bridges: bool,
+        deadline: Instant,
     ) {
         if forward_to_bridges {
             trace!("Routing message to topic: {}", publish.topic_name);
@@ -582,49 +899,31 @@ impl MessageRouter {
             self.handle_retain_storage(publish).await;
         }
 
-        let exact = self.exact_subscriptions.read().await;
-        let wildcard = self.wildcard_subscriptions.read().await;
-        let clients = self.clients.read().await;
+        let plans = {
+            let exact = self.exact_subscriptions.read().await;
+            let wildcard = self.wildcard_subscriptions.read().await;
+            let clients = self.clients.read().await;
 
-        let (share_groups, regular_subs) =
-            Self::collect_matching_subscriptions(&exact, &wildcard, &publish.topic_name);
+            let (share_groups, regular_subs) =
+                Self::collect_matching_subscriptions(&exact, &wildcard, &publish.topic_name);
 
-        self.deliver_share_groups(&share_groups, publish, &clients, publishing_client_id)
-            .await;
-
-        for sub in &regular_subs {
-            #[cfg(feature = "opentelemetry")]
-            {
-                use tracing::Instrument;
-                let span = tracing::info_span!(
-                    "mqtt.deliver",
-                    mqtt.subscriber = %sub.client_id,
-                    mqtt.topic = %publish.topic_name,
-                );
-                self.deliver_to_subscriber(
-                    sub,
-                    publish,
-                    &clients,
-                    self.storage.as_ref(),
-                    publishing_client_id,
-                )
-                .instrument(span)
+            let mut plans = self
+                .plan_share_groups(&share_groups, publish, &clients, publishing_client_id)
                 .await;
+            for sub in &regular_subs {
+                if let Some(plan) = self
+                    .plan_delivery(sub, publish, &clients, publishing_client_id)
+                    .await
+                {
+                    plans.push(plan);
+                }
             }
-            #[cfg(not(feature = "opentelemetry"))]
-            self.deliver_to_subscriber(
-                sub,
-                publish,
-                &clients,
-                self.storage.as_ref(),
-                publishing_client_id,
-            )
-            .await;
-        }
+            plans
+        };
 
-        drop(exact);
-        drop(wildcard);
-        drop(clients);
+        for plan in plans {
+            Self::execute_plan(plan, publishing_client_id, deadline).await;
+        }
 
         if forward_to_bridges {
             #[cfg(feature = "opentelemetry")]
@@ -721,13 +1020,14 @@ impl MessageRouter {
         (share_groups, regular_subs)
     }
 
-    async fn deliver_share_groups(
+    async fn plan_share_groups(
         &self,
         share_groups: &HashMap<String, Vec<&Subscription>>,
         publish: &PublishPacket,
         clients: &HashMap<String, ClientInfo>,
         publishing_client_id: Option<&str>,
-    ) {
+    ) -> Vec<DeliveryPlan> {
+        let mut plans = Vec::new();
         for (group_name, group_subs) in share_groups {
             let online_subs: Vec<&&Subscription> = group_subs
                 .iter()
@@ -742,57 +1042,37 @@ impl MessageRouter {
                     .get(group_name)
                     .cloned();
                 if let Some(counter) = counter {
-                    let index = counter.fetch_add(1, Ordering::Relaxed) % online_subs.len();
-                    let chosen_sub = online_subs[index];
-
-                    #[cfg(feature = "opentelemetry")]
+                    let start = counter.fetch_add(1, Ordering::Relaxed) % online_subs.len();
+                    let chosen_sub = (0..online_subs.len())
+                        .map(|offset| online_subs[(start + offset) % online_subs.len()])
+                        .find(|sub| {
+                            clients
+                                .get(&sub.client_id)
+                                .is_some_and(|info| !info.queue.behind())
+                        })
+                        .unwrap_or(online_subs[start]);
+                    if let Some(plan) = self
+                        .plan_delivery(chosen_sub, publish, clients, publishing_client_id)
+                        .await
                     {
-                        use tracing::Instrument;
-                        let span = tracing::info_span!(
-                            "mqtt.deliver",
-                            mqtt.subscriber = %chosen_sub.client_id,
-                            mqtt.topic = %publish.topic_name,
-                            mqtt.shared_group = %group_name,
-                        );
-                        self.deliver_to_subscriber(
-                            chosen_sub,
-                            publish,
-                            clients,
-                            self.storage.as_ref(),
-                            publishing_client_id,
-                        )
-                        .instrument(span)
-                        .await;
+                        plans.push(plan);
                     }
-                    #[cfg(not(feature = "opentelemetry"))]
-                    self.deliver_to_subscriber(
-                        chosen_sub,
-                        publish,
-                        clients,
-                        self.storage.as_ref(),
-                        publishing_client_id,
-                    )
-                    .await;
                 }
             } else if !group_subs.is_empty() {
                 let sub = group_subs[0];
                 if self.storage.is_some() && sub.qos != QoS::AtMostOnce {
-                    if let Some(ref storage) = self.storage {
-                        let mut message = publish.clone();
-                        message.qos = sub.qos;
-
-                        let queued_msg =
-                            QueuedMessage::new(message, sub.client_id.clone(), sub.qos, None);
-                        if let Err(e) = storage.queue_message(queued_msg).await {
-                            error!(
-                                "Failed to queue message for offline shared subscriber {}: {}",
-                                sub.client_id, e
-                            );
-                        }
-                    }
+                    let mut message = publish.clone();
+                    message.qos = sub.qos;
+                    plans.push(DeliveryPlan::Behind {
+                        client_id: sub.client_id.clone(),
+                        message,
+                        target_flow: sub.flow_id,
+                        queue: self.queue_handle(&sub.client_id),
+                    });
                 }
             }
         }
+        plans
     }
 
     async fn forward_to_bridges(&self, publish: &PublishPacket) {
@@ -828,6 +1108,7 @@ impl MessageRouter {
 
     fn prepare_message(publish: &PublishPacket, sub: &Subscription, qos: QoS) -> PublishPacket {
         let mut message = publish.clone();
+        message.packet_id = None;
         message.qos = qos;
         message.dup = false;
         message.protocol_version = sub.protocol_version.as_u8();
@@ -840,34 +1121,102 @@ impl MessageRouter {
         message
     }
 
-    async fn queue_message(
-        storage: &Arc<DynamicStorage>,
+    fn queue_behind(
+        queue: &QueueHandle,
         message: PublishPacket,
         client_id: &str,
-        qos: QoS,
+        target_flow: Option<u64>,
     ) {
-        let queued_msg = QueuedMessage::new(message, client_id.to_string(), qos, None);
-        if let Err(e) = storage.queue_message(queued_msg).await {
-            error!("Failed to queue message for offline client {client_id}: {e}");
-        } else {
-            debug!("Queued message for client {client_id}");
+        let qos = message.qos;
+        let outcome = queue.push(
+            QueuedMessage::new(message, client_id.to_string(), qos, None)
+                .with_target_flow(target_flow),
+        );
+        queue.notify();
+        trace!(
+            client_id,
+            seq = outcome.seq,
+            dropped = outcome.dropped_oldest,
+            "Queued message behind the client's backlog"
+        );
+    }
+
+    async fn execute_plan(
+        plan: DeliveryPlan,
+        publishing_client_id: Option<&str>,
+        deadline: Instant,
+    ) {
+        match plan {
+            DeliveryPlan::Behind {
+                client_id,
+                message,
+                target_flow,
+                queue,
+            } => Self::queue_behind(&queue, message, &client_id, target_flow),
+            DeliveryPlan::Online {
+                client_id,
+                message,
+                target_flow,
+                lanes,
+                queue,
+            } => {
+                let routable = RoutableMessage {
+                    publish: message,
+                    target_flow,
+                };
+                if routable.publish.qos == QoS::AtMostOnce {
+                    if lanes.qos0_tx.try_send(routable).is_err() {
+                        trace!(client_id, "Dropped QoS 0 message: delivery lane full");
+                    }
+                    return;
+                }
+                if queue.behind() {
+                    Self::queue_behind(&queue, routable.publish, &client_id, routable.target_flow);
+                    return;
+                }
+                let routable = match lanes.qos1_tx.try_send(routable) {
+                    Ok(()) => return,
+                    Err(mpsc::error::TrySendError::Closed(rejected)) => {
+                        Self::queue_behind(
+                            &queue,
+                            rejected.publish,
+                            &client_id,
+                            rejected.target_flow,
+                        );
+                        return;
+                    }
+                    Err(mpsc::error::TrySendError::Full(rejected)) => rejected,
+                };
+                if publishing_client_id == Some(client_id.as_str()) {
+                    Self::queue_behind(&queue, routable.publish, &client_id, routable.target_flow);
+                    return;
+                }
+                match tokio::time::timeout_at(deadline, lanes.qos1_tx.reserve()).await {
+                    Ok(Ok(permit)) => permit.send(routable),
+                    Ok(Err(_)) | Err(_) => Self::queue_behind(
+                        &queue,
+                        routable.publish,
+                        &client_id,
+                        routable.target_flow,
+                    ),
+                }
+            }
         }
     }
 
-    async fn deliver_to_subscriber(
+    async fn plan_delivery(
         &self,
         sub: &Subscription,
         publish: &PublishPacket,
         clients: &HashMap<String, ClientInfo>,
-        storage: Option<&Arc<DynamicStorage>>,
         publishing_client_id: Option<&str>,
-    ) {
+    ) -> Option<DeliveryPlan> {
         if sub.no_local && publishing_client_id == Some(&sub.client_id) {
             trace!(
                 "Skipping delivery to {} due to No Local flag",
                 sub.client_id
             );
-            return;
+            return None;
         }
 
         {
@@ -876,7 +1225,7 @@ impl MessageRouter {
                 if let Some(origin) = publish.properties.get_user_property_value(key) {
                     if origin == sub.client_id {
                         trace!("Skipping echo delivery to {}", sub.client_id);
-                        return;
+                        return None;
                     }
                 }
             }
@@ -891,7 +1240,7 @@ impl MessageRouter {
                         sub.client_id,
                         publish.topic_name
                     );
-                    return;
+                    return None;
                 }
             }
             drop(change_only_states);
@@ -907,54 +1256,56 @@ impl MessageRouter {
             };
             if rate_exceeded {
                 let qos = Self::effective_qos(publish.qos, sub.qos);
-                if qos != QoS::AtMostOnce {
-                    if let Some(storage) = storage {
-                        let message = Self::prepare_message(publish, sub, qos);
-                        Self::queue_message(storage, message, &sub.client_id, qos).await;
-                    }
+                if qos == QoS::AtMostOnce || self.storage.is_none() {
+                    return None;
                 }
-                return;
+                return Some(DeliveryPlan::Behind {
+                    client_id: sub.client_id.clone(),
+                    message: Self::prepare_message(publish, sub, qos),
+                    target_flow: sub.flow_id,
+                    queue: self.queue_handle(&sub.client_id),
+                });
             }
         }
 
         if let Some(client_info) = clients.get(&sub.client_id) {
             let qos = Self::effective_qos(publish.qos, sub.qos);
             let message = Self::prepare_message(publish, sub, qos);
-
-            let routable = RoutableMessage {
-                publish: message,
-                target_flow: sub.flow_id,
-            };
-            if let Err(e) = client_info.sender.try_send(routable) {
-                warn!(
-                    client_id = %sub.client_id,
-                    topic = %publish.topic_name,
-                    "Channel send failed - message may be dropped"
-                );
-                if let Some(storage) = storage {
-                    if qos != QoS::AtMostOnce {
-                        Self::queue_message(storage, e.into_inner().publish, &sub.client_id, qos)
-                            .await;
-                    }
-                }
-            } else if sub.change_only {
+            if sub.change_only {
                 let mut change_only_states = self.change_only_states.write().await;
                 change_only_states
                     .entry(sub.client_id.clone())
                     .or_default()
                     .update_hash(&publish.topic_name, &publish.payload);
             }
-        } else if let Some(storage) = storage {
-            if sub.qos != QoS::AtMostOnce {
-                let message = Self::prepare_message(publish, sub, sub.qos);
-                Self::queue_message(storage, message, &sub.client_id, sub.qos).await;
-            }
-        } else {
+            return Some(DeliveryPlan::Online {
+                client_id: sub.client_id.clone(),
+                message,
+                target_flow: sub.flow_id,
+                lanes: DeliveryLanes {
+                    qos1_tx: client_info.qos1_tx.clone(),
+                    qos0_tx: client_info.qos0_tx.clone(),
+                },
+                queue: Arc::clone(&client_info.queue),
+            });
+        }
+
+        if sub.qos == QoS::AtMostOnce {
+            return None;
+        }
+        if self.storage.is_none() {
             debug!(
                 "No storage configured, cannot queue message for offline client {}",
                 sub.client_id
             );
+            return None;
         }
+        Some(DeliveryPlan::Behind {
+            client_id: sub.client_id.clone(),
+            message: Self::prepare_message(publish, sub, sub.qos),
+            target_flow: sub.flow_id,
+            queue: self.queue_handle(&sub.client_id),
+        })
     }
 
     pub async fn get_retained_messages(&self, topic_filter: &str) -> Vec<PublishPacket> {
@@ -1041,13 +1392,56 @@ mod tests {
     use super::*;
     use bytes::Bytes;
 
+    struct TestLanes {
+        qos1_rx: mpsc::Receiver<RoutableMessage>,
+        qos0_rx: mpsc::Receiver<RoutableMessage>,
+        lanes: DeliveryLanes,
+    }
+
+    impl TestLanes {
+        fn new(capacity: usize) -> Self {
+            let (qos1_tx, qos1_rx) = mpsc::channel(capacity);
+            let (qos0_tx, qos0_rx) = mpsc::channel(capacity);
+            Self {
+                qos1_rx,
+                qos0_rx,
+                lanes: DeliveryLanes { qos1_tx, qos0_tx },
+            }
+        }
+
+        fn lanes(&self) -> DeliveryLanes {
+            self.lanes.clone()
+        }
+
+        fn try_recv(&mut self) -> std::result::Result<RoutableMessage, ()> {
+            self.qos1_rx
+                .try_recv()
+                .or_else(|_| self.qos0_rx.try_recv())
+                .map_err(|_| ())
+        }
+
+        async fn recv_async(&mut self) -> std::result::Result<RoutableMessage, ()> {
+            tokio::select! {
+                message = self.qos1_rx.recv() => message.ok_or(()),
+                message = self.qos0_rx.recv() => message.ok_or(()),
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_client_registration() {
         let router = MessageRouter::new();
-        let (tx, _rx) = flume::bounded(100);
+        let rx = TestLanes::new(100);
 
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("client1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "client1".to_string(),
+                rx.lanes(),
+                router.queue_handle("client1"),
+                dtx,
+            )
+            .await;
         assert_eq!(router.client_count().await, 1);
 
         router.unregister_client("client1").await;
@@ -1057,10 +1451,17 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_management() {
         let router = MessageRouter::new();
-        let (tx, _rx) = flume::bounded(100);
+        let rx = TestLanes::new(100);
 
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("client1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "client1".to_string(),
+                rx.lanes(),
+                router.queue_handle("client1"),
+                dtx,
+            )
+            .await;
         router
             .subscribe(
                 "client1".to_string(),
@@ -1087,17 +1488,27 @@ mod tests {
     #[tokio::test]
     async fn test_message_routing() {
         let router = MessageRouter::new();
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
 
         // Register clients
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
 
         router
@@ -1147,6 +1558,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn routed_publish_never_carries_the_publisher_packet_id() {
+        let router = MessageRouter::new();
+        let mut rx = TestLanes::new(100);
+        let (dtx, _drx) = tokio::sync::oneshot::channel();
+        router
+            .register_client(
+                "sub".to_string(),
+                rx.lanes(),
+                router.queue_handle("sub"),
+                dtx,
+            )
+            .await;
+        router
+            .subscribe(
+                "sub".to_string(),
+                "ids/#".to_string(),
+                QoS::AtLeastOnce,
+                None,
+                false,
+                false,
+                0,
+                ProtocolVersion::V5,
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        for publisher_packet_id in [7u16, 7, 9] {
+            let mut publish = PublishPacket::new("ids/a", &b"x"[..], QoS::AtLeastOnce);
+            publish.packet_id = Some(publisher_packet_id);
+            router.route_message(&publish, Some("pub")).await;
+            let delivered = rx.try_recv().unwrap();
+            assert_eq!(delivered.publish.packet_id, None);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn routing_and_unregistration_never_deadlock() {
+        let router = Arc::new(MessageRouter::new());
+        let sub_rx = TestLanes::new(10_000);
+        let (dtx, _drx) = tokio::sync::oneshot::channel();
+        router
+            .register_client(
+                "subscriber".to_string(),
+                sub_rx.lanes(),
+                router.queue_handle("subscriber"),
+                dtx,
+            )
+            .await;
+        router
+            .subscribe(
+                "subscriber".to_string(),
+                "lock/#".to_string(),
+                QoS::AtLeastOnce,
+                None,
+                false,
+                false,
+                0,
+                ProtocolVersion::V5,
+                false,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let publisher = {
+            let router = Arc::clone(&router);
+            tokio::spawn(async move {
+                let publish = PublishPacket::new("lock/step", &b"m"[..], QoS::AtLeastOnce);
+                for _ in 0..2_000 {
+                    router.route_message(&publish, Some("publisher")).await;
+                }
+            })
+        };
+        let churn = {
+            let router = Arc::clone(&router);
+            tokio::spawn(async move {
+                for round in 0..2_000 {
+                    let id = format!("churn-{}", round % 8);
+                    let rx = TestLanes::new(1);
+                    let (dtx, _drx) = tokio::sync::oneshot::channel();
+                    router
+                        .register_client(id.clone(), rx.lanes(), router.queue_handle(&id), dtx)
+                        .await;
+                    router
+                        .subscribe(
+                            id.clone(),
+                            "lock/#".to_string(),
+                            QoS::AtLeastOnce,
+                            None,
+                            false,
+                            false,
+                            0,
+                            ProtocolVersion::V5,
+                            false,
+                            None,
+                        )
+                        .await
+                        .unwrap();
+                    router.unregister_client(&id).await;
+                }
+            })
+        };
+        let cleanup = {
+            let router = Arc::clone(&router);
+            tokio::spawn(async move {
+                for _ in 0..500 {
+                    router.cleanup_stale_subscriptions().await;
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        tokio::time::timeout(std::time::Duration::from_secs(30), async {
+            publisher.await.unwrap();
+            churn.await.unwrap();
+            cleanup.await.unwrap();
+        })
+        .await
+        .expect("router lock order must not deadlock");
+    }
+
+    #[tokio::test]
     async fn test_retained_messages() {
         let router = MessageRouter::new();
 
@@ -1173,22 +1708,37 @@ mod tests {
     #[tokio::test]
     async fn test_shared_subscription_round_robin() {
         let router = MessageRouter::new();
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
-        let (tx3, rx3) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
+        let mut rx3 = TestLanes::new(100);
 
         // Register three clients
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
         let (dtx3, _drx3) = tokio::sync::oneshot::channel();
         router
-            .register_client("client3".to_string(), tx3, dtx3)
+            .register_client(
+                "client3".to_string(),
+                rx3.lanes(),
+                router.queue_handle("client3"),
+                dtx3,
+            )
             .await;
 
         router
@@ -1270,22 +1820,37 @@ mod tests {
     #[tokio::test]
     async fn test_shared_and_regular_subscriptions() {
         let router = MessageRouter::new();
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
-        let (tx3, rx3) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
+        let mut rx3 = TestLanes::new(100);
 
         // Register clients
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
-            .register_client("shared1".to_string(), tx1, dtx1)
+            .register_client(
+                "shared1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("shared1"),
+                dtx1,
+            )
             .await;
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("shared2".to_string(), tx2, dtx2)
+            .register_client(
+                "shared2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("shared2"),
+                dtx2,
+            )
             .await;
         let (dtx3, _drx3) = tokio::sync::oneshot::channel();
         router
-            .register_client("regular".to_string(), tx3, dtx3)
+            .register_client(
+                "regular".to_string(),
+                rx3.lanes(),
+                router.queue_handle("regular"),
+                dtx3,
+            )
             .await;
 
         router
@@ -1353,16 +1918,26 @@ mod tests {
     #[tokio::test]
     async fn test_route_message_local_only_delivers_to_subscribers() {
         let router = MessageRouter::new();
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
 
         router
@@ -1414,16 +1989,26 @@ mod tests {
     #[tokio::test]
     async fn test_echo_suppression_skips_matching_client() {
         let router = MessageRouter::new().with_echo_suppression_key("x-origin".to_string());
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
 
         router
@@ -1473,16 +2058,26 @@ mod tests {
     #[tokio::test]
     async fn test_echo_suppression_disabled_delivers_all() {
         let router = MessageRouter::new();
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
+        let mut rx1 = TestLanes::new(100);
+        let mut rx2 = TestLanes::new(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                rx1.lanes(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                rx2.lanes(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
 
         router
@@ -1546,9 +2141,16 @@ mod tests {
     #[tokio::test]
     async fn test_outbound_rate_qos0_dropped_when_exceeded() {
         let router = MessageRouter::new().with_max_outbound_rate(5);
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("sub1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "sub1".to_string(),
+                rx.lanes(),
+                router.queue_handle("sub1"),
+                dtx,
+            )
+            .await;
         router
             .subscribe(
                 "sub1".to_string(),
@@ -1585,9 +2187,16 @@ mod tests {
             crate::broker::storage::MemoryBackend::new(),
         ));
         let router = MessageRouter::with_storage(Arc::clone(&storage)).with_max_outbound_rate(3);
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("sub1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "sub1".to_string(),
+                rx.lanes(),
+                router.queue_handle("sub1"),
+                dtx,
+            )
+            .await;
         router
             .subscribe(
                 "sub1".to_string(),
@@ -1634,9 +2243,16 @@ mod tests {
     #[tokio::test]
     async fn test_outbound_rate_zero_means_unlimited() {
         let router = MessageRouter::new().with_max_outbound_rate(0);
-        let (tx, rx) = flume::bounded(1000);
+        let mut rx = TestLanes::new(1000);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("sub1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "sub1".to_string(),
+                rx.lanes(),
+                router.queue_handle("sub1"),
+                dtx,
+            )
+            .await;
         router
             .subscribe(
                 "sub1".to_string(),
@@ -1669,9 +2285,16 @@ mod tests {
     #[tokio::test]
     async fn test_outbound_rate_cleanup_on_unregister() {
         let router = MessageRouter::new().with_max_outbound_rate(10);
-        let (tx, _rx) = flume::bounded(100);
+        let rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("sub1".to_string(), tx, dtx).await;
+        router
+            .register_client(
+                "sub1".to_string(),
+                rx.lanes(),
+                router.queue_handle("sub1"),
+                dtx,
+            )
+            .await;
         assert!(router.outbound_rates.read().contains_key("sub1"));
 
         router.unregister_client("sub1").await;
@@ -1681,9 +2304,11 @@ mod tests {
     #[tokio::test]
     async fn test_flow_bound_subscription_delivers_with_target_flow() {
         let router = MessageRouter::new();
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("c1".to_string(), tx, dtx).await;
+        router
+            .register_client("c1".to_string(), rx.lanes(), router.queue_handle("c1"), dtx)
+            .await;
 
         router
             .subscribe(
@@ -1712,9 +2337,11 @@ mod tests {
     #[tokio::test]
     async fn test_flow_and_control_subscriptions_coexist() {
         let router = MessageRouter::new();
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("c1".to_string(), tx, dtx).await;
+        router
+            .register_client("c1".to_string(), rx.lanes(), router.queue_handle("c1"), dtx)
+            .await;
 
         router
             .subscribe(
@@ -1761,9 +2388,11 @@ mod tests {
     #[tokio::test]
     async fn test_unsubscribe_by_flow_removes_only_flow_subs() {
         let router = MessageRouter::new();
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("c1".to_string(), tx, dtx).await;
+        router
+            .register_client("c1".to_string(), rx.lanes(), router.queue_handle("c1"), dtx)
+            .await;
 
         router
             .subscribe(
@@ -1813,7 +2442,7 @@ mod tests {
             .await
             .unwrap();
 
-        let removed = router.unsubscribe_by_flow("c1", 10).await;
+        let removed = router.unsubscribe_by_flow(None, "c1", 10).await;
         assert_eq!(removed.len(), 2);
         assert!(removed.contains(&"topic/a".to_string()));
         assert!(removed.contains(&"topic/b".to_string()));
@@ -1829,9 +2458,11 @@ mod tests {
     #[tokio::test]
     async fn test_flow_dedup_same_topic_same_flow() {
         let router = MessageRouter::new();
-        let (tx, rx) = flume::bounded(100);
+        let mut rx = TestLanes::new(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
-        router.register_client("c1".to_string(), tx, dtx).await;
+        router
+            .register_client("c1".to_string(), rx.lanes(), router.queue_handle("c1"), dtx)
+            .await;
 
         router
             .subscribe(

--- a/crates/mqtt5/src/broker/router.rs
+++ b/crates/mqtt5/src/broker/router.rs
@@ -532,6 +532,12 @@ impl MessageRouter {
     }
 
     pub async fn cleanup_stale_subscriptions(&self) {
+        // Purge expired entries first (the storage backends do this for their own queues in
+        // cleanup_expired, but the router's fallback queues, used when persistence is off, have
+        // no backend sweep), then reclaim the now-empty ones.
+        for queue in self.fallback_queues.handles() {
+            queue.purge_expired();
+        }
         self.fallback_queues.evict_idle();
         let subscribed_ids: HashSet<String> = {
             let exact = self.exact_subscriptions.read().await;

--- a/crates/mqtt5/src/broker/router.rs
+++ b/crates/mqtt5/src/broker/router.rs
@@ -150,7 +150,6 @@ pub struct TakeoverNotice {
 pub struct Registration {
     pub generation: u64,
     pub released: Option<oneshot::Receiver<()>>,
-    pub cutoff: Option<u64>,
 }
 
 /// Whether the releasing handler still owned the router entry.
@@ -300,6 +299,14 @@ impl MessageRouter {
         }
     }
 
+    /// Sets the per-client limits for the in-memory fallback queues used when persistence is
+    /// off, so a persistence-less broker honours the configured caps instead of the defaults.
+    #[must_use]
+    pub fn with_fallback_queue_limits(mut self, limits: QueueLimits) -> Self {
+        self.fallback_queues = QueueRegistry::new(limits, None);
+        self
+    }
+
     #[must_use]
     pub fn with_event_handler(mut self, handler: Arc<dyn BrokerEventHandler>) -> Self {
         self.event_handler = Some(handler);
@@ -389,8 +396,8 @@ impl MessageRouter {
     ///
     /// While a displaced handler is still handing its deliveries back, the queue's hand-off
     /// flag keeps routers queueing behind it; the returned `released` receiver fires when the
-    /// old handler is done. `cutoff` is the first queue sequence a clean start must keep.
-    /// A clean start also drops every subscription the client id still holds.
+    /// old handler is done. A clean start also drops every subscription the client id still
+    /// holds; its handler discards the whole queue when it binds.
     pub async fn register_session(
         &self,
         client_id: String,
@@ -414,10 +421,9 @@ impl MessageRouter {
             .next_generation
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
             + 1;
-        let (released, cutoff) = match clients.remove(&client_id) {
+        let released = match clients.remove(&client_id) {
             Some(old_client) => {
                 info!("Client ID takeover: {}", client_id);
-                let cutoff = queue.next_seq();
                 let (released_tx, released_rx) = oneshot::channel();
                 let notice = TakeoverNotice {
                     discard: clean_start,
@@ -425,12 +431,12 @@ impl MessageRouter {
                     guard: HandoffGuard::new(Arc::clone(&queue)),
                 };
                 if old_client.disconnect_tx.send(notice).is_ok() {
-                    (Some(released_rx), Some(cutoff))
+                    Some(released_rx)
                 } else {
-                    (None, None)
+                    None
                 }
             }
-            None => (None, None),
+            None => None,
         };
 
         clients.insert(
@@ -455,7 +461,6 @@ impl MessageRouter {
         Registration {
             generation,
             released,
-            cutoff,
         }
     }
 

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -8,7 +8,9 @@ use crate::broker::config::{BrokerConfig, StorageBackend as StorageBackendType};
 use crate::broker::hot_reload::HotReloadManager;
 use crate::broker::resource_monitor::{ResourceLimits, ResourceMonitor};
 use crate::broker::router::MessageRouter;
-use crate::broker::storage::{DynamicStorage, FileBackend, MemoryBackend, StorageBackend};
+use crate::broker::storage::{
+    DynamicStorage, FileBackend, MemoryBackend, QueueLimits, StorageBackend,
+};
 use crate::broker::sys_topics::{BrokerStats, SysTopicsProvider};
 use crate::broker::tls_acceptor::{accept_tls_connection, TlsAcceptorConfig};
 use crate::broker::transport::BrokerTransport;
@@ -844,11 +846,21 @@ impl MqttBroker {
     ) -> Result<Arc<DynamicStorage>> {
         match storage_config.backend {
             StorageBackendType::File => {
-                let backend = FileBackend::new(&storage_config.base_dir).await?;
+                let backend = FileBackend::with_queue_limits(
+                    &storage_config.base_dir,
+                    QueueLimits {
+                        max_messages: storage_config.max_queued_messages_per_client,
+                        max_bytes: storage_config.max_queued_bytes_per_client,
+                    },
+                )
+                .await?;
                 Ok(Arc::new(DynamicStorage::File(backend)))
             }
             StorageBackendType::Memory => {
-                let backend = MemoryBackend::new();
+                let backend = MemoryBackend::with_queue_limits(QueueLimits {
+                    max_messages: storage_config.max_queued_messages_per_client,
+                    max_bytes: storage_config.max_queued_bytes_per_client,
+                });
                 Ok(Arc::new(DynamicStorage::Memory(backend)))
             }
         }

--- a/crates/mqtt5/src/broker/server.rs
+++ b/crates/mqtt5/src/broker/server.rs
@@ -809,7 +809,11 @@ impl MqttBroker {
             MessageRouter::with_storage(Arc::clone(storage))
         } else {
             MessageRouter::new()
-        };
+        }
+        .with_fallback_queue_limits(QueueLimits {
+            max_messages: config.storage_config.max_queued_messages_per_client,
+            max_bytes: config.storage_config.max_queued_bytes_per_client,
+        });
         let with_handler = if let Some(ref handler) = config.event_handler {
             base.with_event_handler(Arc::clone(handler))
         } else {
@@ -899,10 +903,14 @@ impl MqttBroker {
         shutdown_tx: &tokio::sync::broadcast::Sender<()>,
         task_handles: &mut Vec<tokio::task::JoinHandle<()>>,
     ) -> Result<()> {
-        if let Some(ref storage) = self.storage {
-            storage.cleanup_expired().await?;
-
-            let storage_clone = Arc::clone(storage);
+        // The periodic cleanup runs whether or not persistence is on: it also evicts the
+        // router's in-memory fallback queues, which otherwise leak one entry per distinct
+        // client id when storage is off.
+        {
+            if let Some(ref storage) = self.storage {
+                storage.cleanup_expired().await?;
+            }
+            let storage_clone = self.storage.clone();
             let router_clone = Arc::clone(&self.router);
             let cleanup_interval = self.config.storage_config.cleanup_interval;
             let mut shutdown_rx = shutdown_tx.subscribe();
@@ -912,8 +920,10 @@ impl MqttBroker {
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {
-                            if let Err(e) = storage_clone.cleanup_expired().await {
-                                error!("Storage cleanup error: {e}");
+                            if let Some(ref storage) = storage_clone {
+                                if let Err(e) = storage.cleanup_expired().await {
+                                    error!("Storage cleanup error: {e}");
+                                }
                             }
                             router_clone.cleanup_stale_subscriptions().await;
                         }
@@ -924,7 +934,9 @@ impl MqttBroker {
                     }
                 }
             }));
+        }
 
+        if let Some(ref storage) = self.storage {
             let storage_clone = Arc::clone(storage);
             let mut shutdown_rx = shutdown_tx.subscribe();
             let flush_interval = std::time::Duration::from_secs(5);

--- a/crates/mqtt5/src/broker/storage/client_queue.rs
+++ b/crates/mqtt5/src/broker/storage/client_queue.rs
@@ -1,0 +1,783 @@
+//! Per-client offline/overflow queue shared by the storage backends.
+//!
+//! A client is behind exactly when its queue is non-empty; the count is the queue length,
+//! written at the end of every mutation under the queue lock, so it can never drift from the
+//! entries. The lock never covers file I/O: the file backend persists through a write-behind
+//! lane and keeps the message body in memory until the file exists.
+
+use super::{InflightDirection, InflightMessage, QueuedMessage};
+use crate::time::SystemTime;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio::sync::Notify;
+use tracing::{debug, warn};
+
+/// Sender side of the file backend's write-behind lane. Unbounded: every op corresponds to a
+/// queue entry or an inflight row, both already bounded per client, and a dropped op would
+/// either lose a message or resurrect one on restart.
+pub type QueueWriter = mpsc::UnboundedSender<QueueOp>;
+
+/// Sequence numbers start high so a front re-queue always has room below the oldest entry.
+pub const SEQ_FLOOR: u64 = 1 << 62;
+
+/// Bounds on one client's queue; the oldest entries are dropped when either is exceeded.
+#[derive(Debug, Clone, Copy)]
+pub struct QueueLimits {
+    pub max_messages: usize,
+    pub max_bytes: usize,
+}
+
+impl Default for QueueLimits {
+    fn default() -> Self {
+        Self {
+            max_messages: 10_000,
+            max_bytes: 64 * 1024 * 1024,
+        }
+    }
+}
+
+/// Work handed to the file backend's write-behind task, in per-client FIFO order.
+#[derive(Debug)]
+pub enum QueueOp {
+    Write {
+        client_id: String,
+        seq: u64,
+        body: Arc<QueuedMessage>,
+    },
+    Delete {
+        client_id: String,
+        seq: u64,
+    },
+    StoreInflight(Box<InflightMessage>),
+    RemoveInflight {
+        client_id: String,
+        packet_id: u16,
+        direction: InflightDirection,
+    },
+    RemoveAllInflight {
+        client_id: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+struct QueueEntry {
+    seq: u64,
+    bytes: usize,
+    expires_at: Option<SystemTime>,
+    body: Option<Arc<QueuedMessage>>,
+    path: Option<PathBuf>,
+}
+
+impl QueueEntry {
+    fn is_expired(&self) -> bool {
+        self.expires_at
+            .is_some_and(|expiry| SystemTime::now() > expiry)
+    }
+}
+
+#[derive(Debug, Default)]
+struct QueueInner {
+    entries: VecDeque<QueueEntry>,
+    bytes: usize,
+}
+
+/// Shared handle to one client's queue.
+pub type QueueHandle = Arc<ClientQueue>;
+
+/// One client's queue: entries, the count that the router reads without locking, the
+/// reconnect hand-off flag, and the Notify that wakes whichever handler serves the client.
+#[derive(Debug)]
+pub struct ClientQueue {
+    client_id: String,
+    inner: parking_lot::Mutex<QueueInner>,
+    count: AtomicUsize,
+    handoffs: AtomicUsize,
+    draining: AtomicBool,
+    notify: Notify,
+    handoff_done: Notify,
+    seq: Arc<AtomicU64>,
+    limits: QueueLimits,
+    writer: Option<QueueWriter>,
+}
+
+/// What `push` did with the message.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PushOutcome {
+    pub seq: u64,
+    pub dropped_oldest: usize,
+}
+
+impl ClientQueue {
+    pub(crate) fn new(
+        client_id: String,
+        seq: Arc<AtomicU64>,
+        limits: QueueLimits,
+        writer: Option<QueueWriter>,
+    ) -> Self {
+        Self {
+            client_id,
+            inner: parking_lot::Mutex::new(QueueInner::default()),
+            count: AtomicUsize::new(0),
+            handoffs: AtomicUsize::new(0),
+            draining: AtomicBool::new(false),
+            notify: Notify::new(),
+            handoff_done: Notify::new(),
+            seq,
+            limits,
+            writer,
+        }
+    }
+
+    #[must_use]
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    /// Number of queued messages; the router's "behind" check.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+
+    /// True while at least one displaced handler still has deliveries to hand back.
+    #[must_use]
+    pub fn handoff(&self) -> bool {
+        self.handoffs() > 0
+    }
+
+    /// Number of displaced handlers still to hand back their deliveries. A handler compares
+    /// this against the value it saw when it bound to tell "someone displaced me" (must stop
+    /// and hand off) from "an older handler is still finishing" (must keep delivering).
+    #[must_use]
+    pub fn handoffs(&self) -> usize {
+        self.handoffs.load(Ordering::Acquire)
+    }
+
+    pub fn begin_handoff(&self) {
+        self.handoffs.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub fn end_handoff(&self) {
+        let previous = self
+            .handoffs
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                Some(n.saturating_sub(1))
+            });
+        match previous {
+            Ok(1) => self.handoff_done.notify_one(),
+            Ok(0) => {
+                debug!(client_id = %self.client_id, "Hand-off ended more often than it began");
+            }
+            _ => {}
+        }
+    }
+
+    /// Resolves once the hand-off count reaches zero (a permit is stored if the count is
+    /// already zero when a later waiter arrives). A successor waits on this before binding so
+    /// it never touches the session while an older handler could still re-queue into it.
+    pub async fn handoff_quiesced(&self) {
+        self.handoff_done.notified().await;
+    }
+
+    /// True while a handler holds a batch it took from the queue and has not finished with.
+    #[must_use]
+    pub fn draining(&self) -> bool {
+        self.draining.load(Ordering::Acquire)
+    }
+
+    /// Marks the batch taken by `take` as fully sent or returned, so routers may use the
+    /// delivery channel again.
+    pub fn finish_drain(&self) {
+        self.draining.store(false, Ordering::Release);
+    }
+
+    /// Behind: the router must queue instead of using the delivery channel, because the
+    /// queue holds older messages, a handler still holds a batch taken from it, or a
+    /// displaced handler is about to hand its deliveries back.
+    #[must_use]
+    pub fn behind(&self) -> bool {
+        self.count() > 0 || self.draining() || self.handoff()
+    }
+
+    /// Wakes the handler that serves this client; a permit is stored if none is waiting.
+    pub fn notify(&self) {
+        self.notify.notify_one();
+    }
+
+    pub async fn notified(&self) {
+        self.notify.notified().await;
+    }
+
+    /// The next sequence number that will be assigned; used as the clean-start cutoff.
+    #[must_use]
+    pub fn next_seq(&self) -> u64 {
+        self.seq.load(Ordering::Acquire)
+    }
+
+    /// Appends a message. Drops the oldest entries first when a limit is exceeded.
+    pub fn push(&self, message: QueuedMessage) -> PushOutcome {
+        let body = Arc::new(message);
+        let (seq, dropped, evicted) = {
+            let mut inner = self.inner.lock();
+            let seq = self.seq.fetch_add(1, Ordering::AcqRel);
+            let entry = QueueEntry {
+                seq,
+                bytes: body.payload.len(),
+                expires_at: body.expires_at,
+                body: Some(Arc::clone(&body)),
+                path: None,
+            };
+            inner.bytes += entry.bytes;
+            inner.entries.push_back(entry);
+            let evicted = self.enforce_limits(&mut inner);
+            self.count.store(inner.entries.len(), Ordering::Release);
+            (seq, evicted.len(), evicted)
+        };
+        let mut self_evicted = false;
+        for old in evicted {
+            if old.seq == seq {
+                self_evicted = true;
+            } else {
+                self.enqueue_delete(old.seq);
+            }
+        }
+        if !self_evicted {
+            self.enqueue_write(seq, body);
+        }
+        if dropped > 0 {
+            warn!(
+                client_id = %self.client_id,
+                dropped,
+                "Dropped oldest queued messages: per-client queue limit reached"
+            );
+        }
+        PushOutcome {
+            seq,
+            dropped_oldest: dropped,
+        }
+    }
+
+    /// Removes and returns at most `limit` live messages from the front, in order.
+    ///
+    /// Expired and unreadable entries are discarded inside the take, so an empty result means
+    /// the queue was empty at that instant.
+    pub async fn take(&self, limit: usize) -> Vec<QueuedMessage> {
+        let taken: Vec<QueueEntry> = {
+            let mut inner = self.inner.lock();
+            let mut taken = Vec::new();
+            while taken.len() < limit {
+                let Some(entry) = inner.entries.pop_front() else {
+                    break;
+                };
+                inner.bytes -= entry.bytes;
+                if entry.is_expired() {
+                    self.enqueue_delete(entry.seq);
+                    continue;
+                }
+                taken.push(entry);
+            }
+            self.count.store(inner.entries.len(), Ordering::Release);
+            if !taken.is_empty() {
+                self.draining.store(true, Ordering::Release);
+            }
+            taken
+        };
+        let mut messages = Vec::with_capacity(taken.len());
+        for entry in taken {
+            let message = match entry.body {
+                Some(body) => Some(Arc::unwrap_or_clone(body)),
+                None => match entry.path {
+                    Some(path) => read_scanned(path).await,
+                    None => None,
+                },
+            };
+            self.enqueue_delete(entry.seq);
+            if let Some(mut message) = message {
+                message.recompute_expiry();
+                if !message.is_expired() {
+                    messages.push(message);
+                }
+            }
+        }
+        messages
+    }
+
+    /// Puts messages back at the front, in order, with sequence numbers below the current head.
+    pub fn requeue_front(&self, messages: Vec<QueuedMessage>) {
+        if messages.is_empty() {
+            return;
+        }
+        let bodies: Vec<Arc<QueuedMessage>> = messages.into_iter().map(Arc::new).collect();
+        let entries: Vec<(QueueEntry, Arc<QueuedMessage>)> = {
+            let mut inner = self.inner.lock();
+            let base = inner
+                .entries
+                .front()
+                .map_or_else(|| self.seq.load(Ordering::Acquire), |front| front.seq);
+            let len = bodies.len() as u64;
+            let first = base.checked_sub(len).unwrap_or_else(|| {
+                warn!(
+                    client_id = %self.client_id,
+                    base,
+                    len,
+                    "Sequence space exhausted below the queue head; re-queued order is best effort"
+                );
+                0
+            });
+            let mut entries = Vec::with_capacity(bodies.len());
+            for (index, body) in bodies.iter().enumerate() {
+                entries.push(QueueEntry {
+                    seq: first + index as u64,
+                    bytes: body.payload.len(),
+                    expires_at: body.expires_at,
+                    body: Some(Arc::clone(body)),
+                    path: None,
+                });
+            }
+            for entry in entries.iter().rev() {
+                inner.bytes += entry.bytes;
+                inner.entries.push_front(entry.clone());
+            }
+            let evicted = self.enforce_limits(&mut inner);
+            self.count.store(inner.entries.len(), Ordering::Release);
+            let evicted_seqs: Vec<u64> = evicted.iter().map(|old| old.seq).collect();
+            let batch_seqs: Vec<u64> = entries.iter().map(|entry| entry.seq).collect();
+            for old in evicted_seqs.iter().filter(|seq| !batch_seqs.contains(seq)) {
+                self.enqueue_delete(*old);
+            }
+            entries
+                .into_iter()
+                .zip(bodies)
+                .filter(|(entry, _)| !evicted_seqs.contains(&entry.seq))
+                .collect::<Vec<_>>()
+        };
+        for (entry, body) in entries {
+            self.enqueue_write(entry.seq, body);
+        }
+    }
+
+    /// Removes every entry, or only those with a sequence number below `cutoff`.
+    pub fn clear(&self, cutoff: Option<u64>) -> usize {
+        let removed: Vec<u64> = {
+            let mut inner = self.inner.lock();
+            let mut removed = Vec::new();
+            inner.entries.retain(|entry| {
+                let drop_it = cutoff.is_none_or(|cutoff| entry.seq < cutoff);
+                if drop_it {
+                    removed.push(entry.seq);
+                }
+                !drop_it
+            });
+            inner.bytes = inner.entries.iter().map(|entry| entry.bytes).sum();
+            self.count.store(inner.entries.len(), Ordering::Release);
+            removed
+        };
+        for seq in &removed {
+            self.enqueue_delete(*seq);
+        }
+        removed.len()
+    }
+
+    /// Drops expired entries whose expiry is known in memory. Returns how many were removed.
+    pub fn purge_expired(&self) -> usize {
+        let removed: Vec<u64> = {
+            let mut inner = self.inner.lock();
+            let mut removed = Vec::new();
+            inner.entries.retain(|entry| {
+                if entry.is_expired() {
+                    removed.push(entry.seq);
+                    false
+                } else {
+                    true
+                }
+            });
+            inner.bytes = inner.entries.iter().map(|entry| entry.bytes).sum();
+            self.count.store(inner.entries.len(), Ordering::Release);
+            removed
+        };
+        for seq in &removed {
+            self.enqueue_delete(*seq);
+        }
+        removed.len()
+    }
+
+    /// Entries whose expiry is unknown in memory (found by the startup scan), with their files.
+    #[must_use]
+    pub fn scanned_entries(&self) -> Vec<(u64, PathBuf)> {
+        let inner = self.inner.lock();
+        inner
+            .entries
+            .iter()
+            .filter(|entry| entry.body.is_none())
+            .filter_map(|entry| entry.path.clone().map(|path| (entry.seq, path)))
+            .collect()
+    }
+
+    /// Removes one entry by sequence number, e.g. after its file turned out to be expired.
+    pub fn remove_seq(&self, seq: u64) -> bool {
+        let removed = {
+            let mut inner = self.inner.lock();
+            let before = inner.entries.len();
+            inner.entries.retain(|entry| entry.seq != seq);
+            inner.bytes = inner.entries.iter().map(|entry| entry.bytes).sum();
+            self.count.store(inner.entries.len(), Ordering::Release);
+            before != inner.entries.len()
+        };
+        if removed {
+            self.enqueue_delete(seq);
+        }
+        removed
+    }
+
+    /// Non-destructive snapshot of the live messages, in order.
+    pub async fn peek_all(&self) -> Vec<QueuedMessage> {
+        let entries: Vec<QueueEntry> = {
+            let inner = self.inner.lock();
+            inner
+                .entries
+                .iter()
+                .filter(|entry| !entry.is_expired())
+                .cloned()
+                .collect()
+        };
+        let mut messages = Vec::with_capacity(entries.len());
+        for entry in entries {
+            let message = match entry.body {
+                Some(body) => Some((*body).clone()),
+                None => match entry.path {
+                    Some(path) => read_scanned(path).await,
+                    None => None,
+                },
+            };
+            if let Some(mut message) = message {
+                message.recompute_expiry();
+                if !message.is_expired() {
+                    messages.push(message);
+                }
+            }
+        }
+        messages
+    }
+
+    /// Adds an entry discovered on disk at startup; its body is read on take. Only the file
+    /// backend scans a directory, so this is unused on wasm.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn push_scanned(&self, seq: u64, path: PathBuf, bytes: usize) {
+        let mut inner = self.inner.lock();
+        inner.bytes += bytes;
+        inner.entries.push_back(QueueEntry {
+            seq,
+            bytes,
+            expires_at: None,
+            body: None,
+            path: Some(path),
+        });
+        self.count.store(inner.entries.len(), Ordering::Release);
+    }
+
+    /// True when the queue is empty and only the backend map still refers to it.
+    pub(crate) fn is_evictable(self: &Arc<Self>) -> bool {
+        Arc::strong_count(self) == 1 && self.is_empty()
+    }
+
+    fn enforce_limits(&self, inner: &mut QueueInner) -> Vec<QueueEntry> {
+        let mut evicted = Vec::new();
+        while inner.entries.len() > self.limits.max_messages
+            || (inner.bytes > self.limits.max_bytes && inner.entries.len() > 1)
+        {
+            let Some(oldest) = inner.entries.pop_front() else {
+                break;
+            };
+            inner.bytes -= oldest.bytes;
+            evicted.push(oldest);
+        }
+        evicted
+    }
+
+    fn enqueue_write(&self, seq: u64, body: Arc<QueuedMessage>) {
+        let Some(writer) = &self.writer else {
+            return;
+        };
+        if writer
+            .send(QueueOp::Write {
+                client_id: self.client_id.clone(),
+                seq,
+                body,
+            })
+            .is_err()
+        {
+            debug!(client_id = %self.client_id, seq, "Storage writer stopped; queued message kept in memory only");
+        }
+    }
+
+    fn enqueue_delete(&self, seq: u64) {
+        let Some(writer) = &self.writer else {
+            return;
+        };
+        if writer
+            .send(QueueOp::Delete {
+                client_id: self.client_id.clone(),
+                seq,
+            })
+            .is_err()
+        {
+            debug!(client_id = %self.client_id, seq, "Storage writer stopped; queued message file may remain");
+        }
+    }
+}
+
+/// Reads a queued message whose body was left on disk by the startup scan. Only the file
+/// backend ever populates a scanned entry, so on wasm (no file backend) there is nothing to
+/// read and the stub simply reports the entry as gone.
+#[cfg(not(target_arch = "wasm32"))]
+async fn read_scanned(path: PathBuf) -> Option<QueuedMessage> {
+    match tokio::fs::read(&path).await {
+        Ok(data) => match serde_json::from_slice::<QueuedMessage>(&data) {
+            Ok(message) => Some(message),
+            Err(e) => {
+                warn!(
+                    "Skipping unreadable queued message {} ({e}); it will be deleted",
+                    path.display()
+                );
+                None
+            }
+        },
+        Err(e) => {
+            debug!(
+                "Queued message file {} is gone before it was taken: {e}",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn read_scanned(_path: PathBuf) -> Option<QueuedMessage> {
+    std::future::ready(None).await
+}
+
+/// Registry of per-client queues owned by a backend.
+#[derive(Debug)]
+pub struct QueueRegistry {
+    queues: parking_lot::RwLock<std::collections::HashMap<String, QueueHandle>>,
+    seq: Arc<AtomicU64>,
+    limits: QueueLimits,
+    writer: Option<QueueWriter>,
+}
+
+impl QueueRegistry {
+    pub(crate) fn new(limits: QueueLimits, writer: Option<QueueWriter>) -> Self {
+        Self {
+            queues: parking_lot::RwLock::new(std::collections::HashMap::new()),
+            seq: Arc::new(AtomicU64::new(SEQ_FLOOR)),
+            limits,
+            writer,
+        }
+    }
+
+    /// Returns the client's queue, creating it on first touch. Entries are never unlinked
+    /// while a handle is held elsewhere.
+    pub fn handle(&self, client_id: &str) -> QueueHandle {
+        if let Some(handle) = self.queues.read().get(client_id) {
+            return Arc::clone(handle);
+        }
+        let mut queues = self.queues.write();
+        Arc::clone(queues.entry(client_id.to_string()).or_insert_with(|| {
+            Arc::new(ClientQueue::new(
+                client_id.to_string(),
+                Arc::clone(&self.seq),
+                self.limits,
+                self.writer.clone(),
+            ))
+        }))
+    }
+
+    /// Every queue currently registered.
+    pub fn handles(&self) -> Vec<QueueHandle> {
+        self.queues.read().values().map(Arc::clone).collect()
+    }
+
+    /// Raises the sequence counter above everything found on disk. Only the file backend
+    /// scans a directory, so this is unused on wasm.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn seed_seq(&self, max_seen: u64) {
+        self.seq
+            .fetch_max(max_seen.saturating_add(1).max(SEQ_FLOOR), Ordering::AcqRel);
+    }
+
+    /// Drops registry entries that are empty and referenced by nobody else.
+    pub fn evict_idle(&self) -> usize {
+        let mut queues = self.queues.write();
+        let before = queues.len();
+        queues.retain(|_, handle| !handle.is_evictable());
+        before - queues.len()
+    }
+
+    #[must_use]
+    pub fn limits(&self) -> QueueLimits {
+        self.limits
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packet::publish::PublishPacket;
+    use crate::QoS;
+
+    fn message(client: &str, tag: &str) -> QueuedMessage {
+        QueuedMessage::new(
+            PublishPacket::new(
+                format!("t/{tag}"),
+                tag.as_bytes().to_vec(),
+                QoS::AtLeastOnce,
+            ),
+            client.to_string(),
+            QoS::AtLeastOnce,
+            None,
+        )
+    }
+
+    fn registry(limits: QueueLimits) -> QueueRegistry {
+        QueueRegistry::new(limits, None)
+    }
+
+    #[tokio::test]
+    async fn take_returns_front_first_and_keeps_count_exact() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        for tag in ["a", "b", "c"] {
+            queue.push(message("c", tag));
+        }
+        assert_eq!(queue.count(), 3);
+        assert!(queue.behind());
+
+        let first = queue.take(2).await;
+        assert_eq!(
+            first.iter().map(|m| m.topic.as_str()).collect::<Vec<_>>(),
+            ["t/a", "t/b"]
+        );
+        assert_eq!(queue.count(), 1);
+
+        let rest = queue.take(10).await;
+        assert_eq!(rest.len(), 1);
+        assert_eq!(rest[0].topic, "t/c");
+        assert_eq!(queue.count(), 0);
+        assert!(
+            queue.behind(),
+            "a batch taken but not yet sent keeps the client behind"
+        );
+        queue.finish_drain();
+        assert!(!queue.behind());
+        assert!(queue.take(1).await.is_empty());
+        assert!(!queue.behind(), "an empty take does not start a drain");
+    }
+
+    #[tokio::test]
+    async fn requeue_front_goes_ahead_of_existing_entries_in_order() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        queue.push(message("c", "later"));
+        queue.requeue_front(vec![message("c", "old1"), message("c", "old2")]);
+        assert_eq!(queue.count(), 3);
+        let taken = queue.take(3).await;
+        assert_eq!(
+            taken.iter().map(|m| m.topic.as_str()).collect::<Vec<_>>(),
+            ["t/old1", "t/old2", "t/later"]
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_with_cutoff_keeps_messages_queued_after_the_cutoff() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        queue.push(message("c", "before1"));
+        queue.push(message("c", "before2"));
+        let cutoff = queue.next_seq();
+        queue.push(message("c", "after"));
+        assert_eq!(queue.clear(Some(cutoff)), 2);
+        assert_eq!(queue.count(), 1);
+        assert_eq!(queue.take(5).await[0].topic, "t/after");
+    }
+
+    #[tokio::test]
+    async fn push_drops_oldest_when_the_message_limit_is_exceeded() {
+        let registry = registry(QueueLimits {
+            max_messages: 2,
+            max_bytes: usize::MAX,
+        });
+        let queue = registry.handle("c");
+        queue.push(message("c", "one"));
+        queue.push(message("c", "two"));
+        let outcome = queue.push(message("c", "three"));
+        assert_eq!(outcome.dropped_oldest, 1);
+        assert_eq!(queue.count(), 2);
+        let taken = queue.take(5).await;
+        assert_eq!(
+            taken.iter().map(|m| m.topic.as_str()).collect::<Vec<_>>(),
+            ["t/two", "t/three"]
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_expired_removes_only_expired_entries() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        let mut expired = message("c", "expired");
+        expired.expires_at = Some(SystemTime::UNIX_EPOCH);
+        queue.push(expired);
+        queue.push(message("c", "live"));
+        assert_eq!(queue.purge_expired(), 1);
+        assert_eq!(queue.count(), 1);
+        assert_eq!(queue.take(5).await[0].topic, "t/live");
+    }
+
+    #[tokio::test]
+    async fn take_skips_expired_entries_and_reports_them_as_absent() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        let mut expired = message("c", "expired");
+        expired.expires_at = Some(SystemTime::UNIX_EPOCH);
+        queue.push(expired);
+        assert_eq!(queue.count(), 1);
+        assert!(queue.take(1).await.is_empty());
+        assert_eq!(queue.count(), 0);
+    }
+
+    #[test]
+    fn registry_pins_entries_while_a_handle_is_held() {
+        let registry = registry(QueueLimits::default());
+        let held = registry.handle("c");
+        assert_eq!(registry.evict_idle(), 0);
+        let again = registry.handle("c");
+        assert!(Arc::ptr_eq(&held, &again));
+        drop(again);
+        drop(held);
+        assert_eq!(registry.evict_idle(), 1);
+    }
+
+    #[test]
+    fn notify_stores_a_permit_for_a_later_waiter() {
+        let registry = registry(QueueLimits::default());
+        let queue = registry.handle("c");
+        queue.notify();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            tokio::time::timeout(std::time::Duration::from_millis(100), queue.notified())
+                .await
+                .expect("stored permit must wake the first waiter");
+        });
+    }
+}

--- a/crates/mqtt5/src/broker/storage/client_queue.rs
+++ b/crates/mqtt5/src/broker/storage/client_queue.rs
@@ -307,6 +307,11 @@ impl ClientQueue {
                 }
             }
         }
+        // Everything popped turned out to be expired: nothing is being delivered, so this
+        // take must not leave the client marked "draining".
+        if messages.is_empty() {
+            self.draining.store(false, Ordering::Release);
+        }
         messages
     }
 
@@ -346,7 +351,7 @@ impl ClientQueue {
                 inner.bytes += entry.bytes;
                 inner.entries.push_front(entry.clone());
             }
-            let evicted = self.enforce_limits(&mut inner);
+            let evicted = self.enforce_limits_dir(&mut inner, true);
             self.count.store(inner.entries.len(), Ordering::Release);
             let evicted_seqs: Vec<u64> = evicted.iter().map(|old| old.seq).collect();
             let batch_seqs: Vec<u64> = entries.iter().map(|entry| entry.seq).collect();
@@ -468,15 +473,27 @@ impl ClientQueue {
     }
 
     fn enforce_limits(&self, inner: &mut QueueInner) -> Vec<QueueEntry> {
+        self.enforce_limits_dir(inner, false)
+    }
+
+    /// Drops entries until the queue is within its limits. `keep_front` drops from the back
+    /// (the newest messages) instead of the front, so a `requeue_front` of unacknowledged
+    /// in-flight messages keeps those and sheds newer overflow rather than the reverse.
+    fn enforce_limits_dir(&self, inner: &mut QueueInner, keep_front: bool) -> Vec<QueueEntry> {
         let mut evicted = Vec::new();
         while inner.entries.len() > self.limits.max_messages
             || (inner.bytes > self.limits.max_bytes && inner.entries.len() > 1)
         {
-            let Some(oldest) = inner.entries.pop_front() else {
+            let dropped = if keep_front {
+                inner.entries.pop_back()
+            } else {
+                inner.entries.pop_front()
+            };
+            let Some(dropped) = dropped else {
                 break;
             };
-            inner.bytes -= oldest.bytes;
-            evicted.push(oldest);
+            inner.bytes -= dropped.bytes;
+            evicted.push(dropped);
         }
         evicted
     }
@@ -628,6 +645,28 @@ mod tests {
 
     fn registry(limits: QueueLimits) -> QueueRegistry {
         QueueRegistry::new(limits, None)
+    }
+
+    #[tokio::test]
+    async fn requeue_front_over_capacity_keeps_the_requeued_and_drops_newest() {
+        let registry = registry(QueueLimits {
+            max_messages: 3,
+            max_bytes: usize::MAX,
+        });
+        let queue = registry.handle("c");
+        for tag in ["n1", "n2", "n3"] {
+            queue.push(message("c", tag));
+        }
+        // Re-queue two unacked in-flight messages to the front of a full queue: the queue is
+        // now over its 3-message cap, and the newest (n2, n3) must be shed, not the just
+        // re-queued in-flight (old1, old2).
+        queue.requeue_front(vec![message("c", "old1"), message("c", "old2")]);
+        assert_eq!(queue.count(), 3);
+        let taken = queue.take(10).await;
+        assert_eq!(
+            taken.iter().map(|m| m.topic.as_str()).collect::<Vec<_>>(),
+            ["t/old1", "t/old2", "t/n1"]
+        );
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/broker/storage/client_queue.rs
+++ b/crates/mqtt5/src/broker/storage/client_queue.rs
@@ -216,7 +216,7 @@ impl ClientQueue {
         self.notify.notified().await;
     }
 
-    /// The next sequence number that will be assigned; used as the clean-start cutoff.
+    /// The next sequence number that will be assigned.
     #[must_use]
     pub fn next_seq(&self) -> u64 {
         self.seq.load(Ordering::Acquire)
@@ -409,34 +409,6 @@ impl ClientQueue {
         removed.len()
     }
 
-    /// Entries whose expiry is unknown in memory (found by the startup scan), with their files.
-    #[must_use]
-    pub fn scanned_entries(&self) -> Vec<(u64, PathBuf)> {
-        let inner = self.inner.lock();
-        inner
-            .entries
-            .iter()
-            .filter(|entry| entry.body.is_none())
-            .filter_map(|entry| entry.path.clone().map(|path| (entry.seq, path)))
-            .collect()
-    }
-
-    /// Removes one entry by sequence number, e.g. after its file turned out to be expired.
-    pub fn remove_seq(&self, seq: u64) -> bool {
-        let removed = {
-            let mut inner = self.inner.lock();
-            let before = inner.entries.len();
-            inner.entries.retain(|entry| entry.seq != seq);
-            inner.bytes = inner.entries.iter().map(|entry| entry.bytes).sum();
-            self.count.store(inner.entries.len(), Ordering::Release);
-            before != inner.entries.len()
-        };
-        if removed {
-            self.enqueue_delete(seq);
-        }
-        removed
-    }
-
     /// Non-destructive snapshot of the live messages, in order.
     pub async fn peek_all(&self) -> Vec<QueuedMessage> {
         let entries: Vec<QueueEntry> = {
@@ -467,16 +439,23 @@ impl ClientQueue {
         messages
     }
 
-    /// Adds an entry discovered on disk at startup; its body is read on take. Only the file
+    /// Adds an entry discovered on disk at startup; its body is read on take, but its byte
+    /// size (payload length, matching `push`) and expiry are recorded now. Only the file
     /// backend scans a directory, so this is unused on wasm.
     #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn push_scanned(&self, seq: u64, path: PathBuf, bytes: usize) {
+    pub(crate) fn push_scanned(
+        &self,
+        seq: u64,
+        path: PathBuf,
+        bytes: usize,
+        expires_at: Option<SystemTime>,
+    ) {
         let mut inner = self.inner.lock();
         inner.bytes += bytes;
         inner.entries.push_back(QueueEntry {
             seq,
             bytes,
-            expires_at: None,
+            expires_at,
             body: None,
             path: Some(path),
         });

--- a/crates/mqtt5/src/broker/storage/file_backend.rs
+++ b/crates/mqtt5/src/broker/storage/file_backend.rs
@@ -334,10 +334,22 @@ impl FileBackend {
             new_format.sort_by_key(|(seq, _)| *seq);
             let queue = self.queues.handle(client_id);
             for (seq, path) in new_format {
-                let bytes = fs::metadata(&path)
-                    .await
-                    .map_or(0, |m| usize::try_from(m.len()).unwrap_or(usize::MAX));
-                queue.push_scanned(seq, path, bytes);
+                // Parse each file once so the entry is accounted by payload length (matching
+                // push) and carries its expiry in memory. Metadata length would count the
+                // pretty-printed JSON (~6-9x the payload) and wrongly evict most of a
+                // within-cap backlog on the first push after restart.
+                let (bytes, expires_at) = match self.read_file::<QueuedMessage>(path.clone()).await
+                {
+                    Ok(Some(mut message)) => {
+                        message.recompute_expiry();
+                        (message.payload.len(), message.expires_at)
+                    }
+                    _ => {
+                        // Unreadable/corrupt: quarantined by read_file; skip the entry.
+                        continue;
+                    }
+                };
+                queue.push_scanned(seq, path, bytes, expires_at);
                 max_seq = max_seq.max(seq);
             }
         }
@@ -1028,20 +1040,9 @@ impl StorageBackend for FileBackend {
         }
 
         for queue in self.queues.handles() {
+            // Scanned entries carry their expiry in memory (recorded during scan_queues), so
+            // purge_expired covers them too; no per-tick re-read of every queued file.
             removed_count += queue.purge_expired();
-            for (seq, path) in queue.scanned_entries() {
-                match self.read_file::<QueuedMessage>(path).await? {
-                    Some(mut message) => {
-                        message.recompute_expiry();
-                        if message.is_expired() && queue.remove_seq(seq) {
-                            removed_count += 1;
-                        }
-                    }
-                    None => {
-                        queue.remove_seq(seq);
-                    }
-                }
-            }
         }
         self.queues.evict_idle();
 
@@ -1132,6 +1133,50 @@ mod tests {
         assert_eq!(topics(&taken), ["q/r1", "q/r2", "q/c", "q/d", "q/e"]);
         queue.push(queued("persist", "after"));
         assert!(queue.next_seq() > SEQ_FLOOR);
+    }
+
+    #[tokio::test]
+    async fn restart_accounts_scanned_bytes_by_payload_not_file_size() {
+        // Payloads total 1000 bytes, well under the 4000-byte cap, but each pretty-JSON file
+        // is several times its payload. If the scan counted file size the whole backlog would
+        // be evicted on the first push after restart.
+        let limits = QueueLimits {
+            max_messages: 1000,
+            max_bytes: 4000,
+        };
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let backend = FileBackend::with_queue_limits(dir.path(), limits)
+                .await
+                .unwrap();
+            let queue = backend.queue_handle("c");
+            for tag in ["a", "b", "c", "d", "e"] {
+                queue.push(QueuedMessage::new(
+                    PublishPacket::new(format!("q/{tag}"), vec![b'x'; 200], QoS::AtLeastOnce),
+                    "c".to_string(),
+                    QoS::AtLeastOnce,
+                    None,
+                ));
+            }
+            assert_eq!(queue.count(), 5);
+            backend.flush_queue_writes().await;
+        }
+        let reopened = FileBackend::with_queue_limits(dir.path(), limits)
+            .await
+            .unwrap();
+        let queue = reopened.queue_handle("c");
+        assert_eq!(
+            queue.count(),
+            5,
+            "restart must not evict a within-cap backlog"
+        );
+        queue.push(QueuedMessage::new(
+            PublishPacket::new("q/f", vec![b'x'; 200], QoS::AtLeastOnce),
+            "c".to_string(),
+            QoS::AtLeastOnce,
+            None,
+        ));
+        assert_eq!(queue.count(), 6, "one more within-cap push evicts nothing");
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/broker/storage/file_backend.rs
+++ b/crates/mqtt5/src/broker/storage/file_backend.rs
@@ -3,8 +3,8 @@
 //! Provides durable storage using organized file structure with atomic operations.
 
 use super::{
-    ClientSession, InflightDirection, InflightMessage, QueuedMessage, RetainedMessage,
-    StorageBackend,
+    ClientSession, InflightDirection, InflightMessage, QueueHandle, QueueLimits, QueueOp,
+    QueueRegistry, QueueWriter, QueuedMessage, RetainedMessage, StorageBackend, SEQ_FLOOR,
 };
 use crate::error::{MqttError, Result};
 use crate::validation::topic_matches_filter;
@@ -15,8 +15,151 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::fs::{self, File};
 use tokio::io::AsyncWriteExt;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, info, warn};
+
+/// How long an inflight or queued row may sit unwritten so that its remove can cancel it.
+const INFLIGHT_SETTLE: std::time::Duration = std::time::Duration::from_millis(250);
+/// Total pending rows (queue + inflight) that force a write-out before the settle window ends.
+const INFLIGHT_SETTLE_MAX: usize = 8192;
+
+type InflightKey = (String, u16, InflightDirection);
+type QueueKey = (String, u64);
+
+/// Queued-message writes waiting for the settle window, coalesced so a write immediately
+/// followed by its delete never touches the disk. Applying an op only mutates this map, so the
+/// writer drains its unbounded channel at memory speed and the map stays bounded by the number
+/// of distinct live sequence numbers (already capped per client).
+#[derive(Default)]
+struct PendingQueue {
+    pending: HashMap<QueueKey, Option<Arc<QueuedMessage>>>,
+    on_disk: HashSet<QueueKey>,
+}
+
+impl PendingQueue {
+    fn store(&mut self, client_id: String, seq: u64, body: Arc<QueuedMessage>) {
+        self.pending.insert((client_id, seq), Some(body));
+    }
+
+    fn remove(&mut self, client_id: String, seq: u64) {
+        let key = (client_id, seq);
+        if matches!(self.pending.get(&key), Some(Some(_))) && !self.on_disk.contains(&key) {
+            self.pending.remove(&key);
+        } else {
+            self.pending.insert(key, None);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.pending.len()
+    }
+
+    async fn write_out(&mut self, queues_dir: &Path) {
+        for (key, op) in self.pending.drain() {
+            let path = queues_dir.join(&key.0).join(format!("{:020}.json", key.1));
+            if let Some(body) = op {
+                if let Err(e) = FileBackend::write_atomic(path, &*body, false).await {
+                    warn!(
+                        client_id = key.0,
+                        seq = key.1,
+                        "Failed to persist queued message: {e}"
+                    );
+                } else {
+                    self.on_disk.insert(key);
+                }
+            } else {
+                FileBackend::remove_if_present(&path, || {
+                    warn!(
+                        client_id = key.0,
+                        seq = key.1,
+                        "Failed to delete queued message file"
+                    );
+                })
+                .await;
+                self.on_disk.remove(&key);
+            }
+        }
+    }
+}
+
+/// Inflight rows waiting for the settle window: `Some` is a store that has not reached the
+/// disk, `None` a remove that must delete whatever an earlier write-out (or boot) left there.
+///
+/// A remove may cancel a pending store only when nothing for that key has ever reached the
+/// disk; once a row is written out (or was found on disk at boot) its remove must always
+/// produce a delete, otherwise a stale row survives and is redelivered on restart.
+#[derive(Default)]
+struct PendingInflight {
+    pending: HashMap<InflightKey, Option<Box<InflightMessage>>>,
+    on_disk: HashSet<InflightKey>,
+}
+
+impl PendingInflight {
+    fn store(&mut self, message: Box<InflightMessage>) {
+        let key = (
+            message.client_id.clone(),
+            message.packet_id,
+            message.direction,
+        );
+        self.pending.insert(key, Some(message));
+    }
+
+    fn remove(&mut self, client_id: String, packet_id: u16, direction: InflightDirection) {
+        let key = (client_id, packet_id, direction);
+        if matches!(self.pending.get(&key), Some(Some(_))) && !self.on_disk.contains(&key) {
+            self.pending.remove(&key);
+        } else {
+            self.pending.insert(key, None);
+        }
+    }
+
+    fn forget_client(&mut self, client_id: &str) {
+        self.pending.retain(|key, _| key.0 != client_id);
+        self.on_disk.retain(|key| key.0 != client_id);
+    }
+
+    async fn write_out(&mut self, inflight_dir: &Path) {
+        for (key, op) in self.pending.drain() {
+            let path = FileBackend::inflight_path(inflight_dir, &key);
+            if let Some(message) = op {
+                if let Err(e) = FileBackend::write_atomic(path, &*message, false).await {
+                    warn!(
+                        client_id = key.0,
+                        packet_id = key.1,
+                        "Failed to persist inflight message: {e}"
+                    );
+                } else {
+                    self.on_disk.insert(key);
+                }
+            } else {
+                FileBackend::remove_if_present(&path, || {
+                    warn!(
+                        client_id = key.0,
+                        packet_id = key.1,
+                        "Failed to delete inflight file"
+                    );
+                })
+                .await;
+                self.on_disk.remove(&key);
+            }
+        }
+    }
+}
+
+enum QueueFileName {
+    Seq(u64),
+    Legacy { ts: u64, seq: u64 },
+}
+
+fn parse_queue_file_stem(stem: &str) -> Option<QueueFileName> {
+    match stem.split_once('_') {
+        Some((ts, seq)) => Some(QueueFileName::Legacy {
+            ts: ts.parse().ok()?,
+            seq: seq.parse().ok()?,
+        }),
+        None => stem.parse().ok().map(QueueFileName::Seq),
+    }
+}
 
 /// Disambiguates concurrent writes to the same destination path.
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -42,7 +185,9 @@ pub struct FileBackend {
     sessions_cache: Arc<RwLock<HashMap<String, ClientSession>>>,
     dirty_sessions: Arc<RwLock<HashSet<String>>>,
     shutdown: Arc<AtomicBool>,
-    queue_seq: AtomicU64,
+    queues: QueueRegistry,
+    queue_writer: QueueWriter,
+    queue_flush: mpsc::Sender<oneshot::Sender<()>>,
 }
 
 impl FileBackend {
@@ -52,6 +197,16 @@ impl FileBackend {
     ///
     /// Returns error if directories cannot be created or version mismatch detected
     pub async fn new(base_dir: impl AsRef<Path>) -> Result<Self> {
+        Self::with_queue_limits(base_dir, QueueLimits::default()).await
+    }
+
+    /// # Errors
+    ///
+    /// Returns error if directories cannot be created or version mismatch detected
+    pub async fn with_queue_limits(
+        base_dir: impl AsRef<Path>,
+        limits: QueueLimits,
+    ) -> Result<Self> {
         let base_dir = base_dir.as_ref().to_path_buf();
         let retained_dir = base_dir.join("retained");
         let sessions_dir = base_dir.join("sessions");
@@ -66,13 +221,17 @@ impl FileBackend {
             })?;
         }
 
-        info!(
-            "Initialized file storage backend at: {}",
-            base_dir.display()
-        );
+        let (writer_tx, writer_rx) = mpsc::unbounded_channel();
+        let (flush_tx, flush_rx) = mpsc::channel(4);
+        tokio::spawn(Self::run_queue_writer(
+            queues_dir.clone(),
+            inflight_dir.clone(),
+            writer_rx,
+            flush_rx,
+        ));
 
-        Ok(Self {
-            _base_dir: base_dir,
+        let backend = Self {
+            _base_dir: base_dir.clone(),
             retained_dir,
             sessions_dir,
             queues_dir,
@@ -80,8 +239,203 @@ impl FileBackend {
             sessions_cache: Arc::new(RwLock::new(HashMap::new())),
             dirty_sessions: Arc::new(RwLock::new(HashSet::new())),
             shutdown: Arc::new(AtomicBool::new(false)),
-            queue_seq: AtomicU64::new(0),
-        })
+            queues: QueueRegistry::new(limits, Some(writer_tx.clone())),
+            queue_writer: writer_tx,
+            queue_flush: flush_tx,
+        };
+        backend.scan_queues().await?;
+
+        info!(
+            "Initialized file storage backend at: {}",
+            base_dir.display()
+        );
+
+        Ok(backend)
+    }
+
+    /// Rebuilds every client's queue index from disk, migrating legacy `{ts}_{seq}` names to
+    /// `{seq:020}` so directory order is sequence order, and raises the sequence counter above
+    /// everything found.
+    async fn scan_queues(&self) -> Result<()> {
+        let mut max_seq = 0u64;
+        let mut client_dirs = match fs::read_dir(&self.queues_dir).await {
+            Ok(dirs) => dirs,
+            Err(e) => {
+                warn!(
+                    "Queues directory {} is unreadable ({e}); starting with empty queues",
+                    self.queues_dir.display()
+                );
+                return Ok(());
+            }
+        };
+        loop {
+            let entry = match client_dirs.next_entry().await {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(e) => {
+                    warn!("Stopped scanning queue directories: {e}");
+                    break;
+                }
+            };
+            let client_dir = entry.path();
+            if !fs::metadata(&client_dir).await.is_ok_and(|m| m.is_dir()) {
+                continue;
+            }
+            let Some(client_id) = client_dir.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            let files = match self.list_files(&client_dir, "json").await {
+                Ok(files) => files,
+                Err(e) => {
+                    warn!(client_id, "Skipping unreadable queue directory: {e}");
+                    continue;
+                }
+            };
+            let mut new_format: Vec<(u64, PathBuf)> = Vec::new();
+            let mut legacy: Vec<(u64, u64, PathBuf)> = Vec::new();
+            for path in files {
+                let Some(stem) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                    continue;
+                };
+                match parse_queue_file_stem(stem) {
+                    Some(QueueFileName::Seq(seq)) => new_format.push((seq, path)),
+                    Some(QueueFileName::Legacy { ts, seq }) => legacy.push((ts, seq, path)),
+                    None => warn!("Ignoring unrecognised queue file {}", path.display()),
+                }
+            }
+            if !legacy.is_empty() {
+                let floor = new_format
+                    .iter()
+                    .map(|(seq, _)| *seq)
+                    .min()
+                    .unwrap_or(SEQ_FLOOR)
+                    .min(SEQ_FLOOR);
+                legacy.sort_by_key(|(ts, seq, _)| (*ts, *seq));
+                let count = legacy.len() as u64;
+                let first = floor.checked_sub(count).unwrap_or(SEQ_FLOOR);
+                for (index, (_, _, path)) in legacy.into_iter().enumerate() {
+                    let seq = first + index as u64;
+                    let target = client_dir.join(format!("{seq:020}.json"));
+                    match fs::rename(&path, &target).await {
+                        Ok(()) => new_format.push((seq, target)),
+                        Err(e) => warn!(
+                            "Could not migrate queue file {} to {}: {e}",
+                            path.display(),
+                            target.display()
+                        ),
+                    }
+                }
+                info!(
+                    client_id,
+                    migrated = count,
+                    "Migrated legacy queue file names"
+                );
+            }
+            new_format.sort_by_key(|(seq, _)| *seq);
+            let queue = self.queues.handle(client_id);
+            for (seq, path) in new_format {
+                let bytes = fs::metadata(&path)
+                    .await
+                    .map_or(0, |m| usize::try_from(m.len()).unwrap_or(usize::MAX));
+                queue.push_scanned(seq, path, bytes);
+                max_seq = max_seq.max(seq);
+            }
+        }
+        self.queues.seed_seq(max_seq);
+        Ok(())
+    }
+
+    /// Applies queue writes and deletes as they arrive, and batches inflight rows: a store
+    /// followed by its remove within one settle window never touches the disk, which is the
+    /// normal life of an at-least-once message, so only rows that stay open long enough are
+    /// written.
+    async fn run_queue_writer(
+        queues_dir: PathBuf,
+        inflight_dir: PathBuf,
+        mut ops: mpsc::UnboundedReceiver<QueueOp>,
+        mut flushes: mpsc::Receiver<oneshot::Sender<()>>,
+    ) {
+        let mut inflight = PendingInflight::default();
+        let mut queue = PendingQueue::default();
+        let mut settle = tokio::time::interval(INFLIGHT_SETTLE);
+        settle.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                op = ops.recv() => {
+                    let Some(op) = op else { break };
+                    Self::apply_queue_op(&inflight_dir, &mut inflight, &mut queue, op).await;
+                    if inflight.pending.len() + queue.len() >= INFLIGHT_SETTLE_MAX {
+                        queue.write_out(&queues_dir).await;
+                        inflight.write_out(&inflight_dir).await;
+                    }
+                }
+                flush = flushes.recv() => {
+                    let Some(done) = flush else { break };
+                    while let Ok(op) = ops.try_recv() {
+                        Self::apply_queue_op(&inflight_dir, &mut inflight, &mut queue, op).await;
+                    }
+                    queue.write_out(&queues_dir).await;
+                    inflight.write_out(&inflight_dir).await;
+                    let _ = done.send(());
+                }
+                _ = settle.tick() => {
+                    queue.write_out(&queues_dir).await;
+                    inflight.write_out(&inflight_dir).await;
+                }
+            }
+        }
+        queue.write_out(&queues_dir).await;
+        inflight.write_out(&inflight_dir).await;
+    }
+
+    async fn apply_queue_op(
+        inflight_dir: &Path,
+        inflight: &mut PendingInflight,
+        queue: &mut PendingQueue,
+        op: QueueOp,
+    ) {
+        match op {
+            QueueOp::Write {
+                client_id,
+                seq,
+                body,
+            } => queue.store(client_id, seq, body),
+            QueueOp::Delete { client_id, seq } => queue.remove(client_id, seq),
+            QueueOp::StoreInflight(message) => inflight.store(message),
+            QueueOp::RemoveInflight {
+                client_id,
+                packet_id,
+                direction,
+            } => inflight.remove(client_id, packet_id, direction),
+            QueueOp::RemoveAllInflight { client_id } => {
+                inflight.forget_client(&client_id);
+                let client_dir = inflight_dir.join(&client_id);
+                match fs::remove_dir_all(&client_dir).await {
+                    Ok(()) => {}
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => warn!(client_id, "Failed to remove inflight directory: {e}"),
+                }
+            }
+        }
+    }
+
+    /// Deletes `path`, ignoring a missing file and reporting any other error via `on_error`.
+    async fn remove_if_present(path: &Path, on_error: impl FnOnce()) {
+        match fs::remove_file(path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(_) => on_error(),
+        }
+    }
+
+    fn inflight_path(inflight_dir: &Path, key: &InflightKey) -> PathBuf {
+        let direction_tag = match key.2 {
+            InflightDirection::Inbound => "inbound",
+            InflightDirection::Outbound => "outbound",
+        };
+        inflight_dir
+            .join(&key.0)
+            .join(format!("{direction_tag}_{}.json", key.1))
     }
 
     /// # Errors
@@ -148,7 +502,22 @@ impl FileBackend {
     /// Returns an error if flushing sessions fails.
     pub async fn shutdown(&self) -> Result<()> {
         self.shutdown.store(true, Ordering::Relaxed);
+        self.flush_queue_writes().await;
         self.flush_sessions().await
+    }
+
+    fn send_queue_op(&self, op: QueueOp) -> Result<()> {
+        self.queue_writer
+            .send(op)
+            .map_err(|_| MqttError::Io("storage writer task is no longer running".to_string()))
+    }
+
+    /// Waits until every queued-message write and delete issued so far has reached disk.
+    pub async fn flush_queue_writes(&self) {
+        let (done_tx, done_rx) = oneshot::channel();
+        if self.queue_flush.send(done_tx).await.is_ok() {
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), done_rx).await;
+        }
     }
 
     async fn check_storage_version(base_dir: &Path) -> Result<()> {
@@ -250,6 +619,16 @@ impl FileBackend {
     /// zero or partial bytes into place, and a crash before its retry would make that
     /// permanent. The temp file is removed if the write or rename fails.
     async fn write_file_atomic<T: serde::Serialize>(&self, path: PathBuf, data: &T) -> Result<()> {
+        Self::write_atomic(path, data, true).await
+    }
+
+    /// Serializes and atomically installs `data` at `path`; `durable` adds an fsync before the
+    /// rename, which queue files skip because their loss is tolerated and their rate is high.
+    async fn write_atomic<T: serde::Serialize>(
+        path: PathBuf,
+        data: &T,
+        durable: bool,
+    ) -> Result<()> {
         let serialized = serde_json::to_vec_pretty(data)
             .map_err(|e| MqttError::Configuration(format!("Failed to serialize data: {e}")))?;
 
@@ -266,7 +645,7 @@ impl FileBackend {
                 TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
             ));
 
-            match Self::write_temp_file(&temp_path, &serialized).await {
+            match Self::write_temp_file(&temp_path, &serialized, durable).await {
                 Ok(()) => {}
                 Err(e) => {
                     let _ = fs::remove_file(&temp_path).await;
@@ -291,7 +670,7 @@ impl FileBackend {
     }
 
     /// Writes the payload to `temp_path` and makes it durable before it is renamed into place.
-    async fn write_temp_file(temp_path: &Path, serialized: &[u8]) -> Result<()> {
+    async fn write_temp_file(temp_path: &Path, serialized: &[u8], durable: bool) -> Result<()> {
         let mut file = File::create(temp_path)
             .await
             .map_err(|e| MqttError::Io(format!("Failed to create temp file: {e}")))?;
@@ -304,9 +683,11 @@ impl FileBackend {
             .await
             .map_err(|e| MqttError::Io(format!("Failed to flush temp file: {e}")))?;
 
-        file.sync_data()
-            .await
-            .map_err(|e| MqttError::Io(format!("Failed to sync temp file: {e}")))?;
+        if durable {
+            file.sync_data()
+                .await
+                .map_err(|e| MqttError::Io(format!("Failed to sync temp file: {e}")))?;
+        }
 
         Ok(())
     }
@@ -536,76 +917,42 @@ impl StorageBackend for FileBackend {
         Ok(())
     }
 
-    async fn queue_message(&self, message: QueuedMessage) -> Result<()> {
-        let client_dir = self.queues_dir.join(&message.client_id);
-        fs::create_dir_all(&client_dir).await.map_err(|e| {
-            MqttError::Configuration(format!(
-                "Failed to create queue dir for {}: {}",
-                message.client_id, e
-            ))
-        })?;
+    fn queue_handle(&self, client_id: &str) -> QueueHandle {
+        self.queues.handle(client_id)
+    }
 
-        let timestamp = message.queued_at_secs * 1000;
-        let seq = self.queue_seq.fetch_add(1, Ordering::Relaxed);
-        let filename = format!("{timestamp}_{seq}.json");
-        let path = client_dir.join(filename);
-
-        debug!("Queuing message for client: {}", message.client_id);
-        self.write_file_atomic(path, &message).await?;
-
-        Ok(())
+    fn queue_message(
+        &self,
+        message: QueuedMessage,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        let client_id = message.client_id.clone();
+        self.queues.handle(&client_id).push(message);
+        debug!("Queued message for client: {}", client_id);
+        std::future::ready(Ok(()))
     }
 
     async fn get_queued_messages(&self, client_id: &str) -> Result<Vec<QueuedMessage>> {
-        let client_dir = self.queues_dir.join(client_id);
-        if !client_dir.exists() {
-            return Ok(Vec::new());
-        }
-
-        let files = self.list_files(&client_dir, "json").await?;
-        let mut messages = Vec::new();
-
-        for file_path in files {
-            if let Some(mut message) = self.read_file::<QueuedMessage>(file_path.clone()).await? {
-                message.recompute_expiry();
-                if !message.is_expired() {
-                    messages.push(message);
-                } else if let Err(e) = fs::remove_file(&file_path).await {
-                    warn!("Failed to remove expired queued message: {e}");
-                }
-            }
-        }
-
-        messages.sort_by_key(|msg| msg.queued_at_secs);
-
-        Ok(messages)
+        Ok(self.queues.handle(client_id).peek_all().await)
     }
 
-    async fn remove_queued_messages(&self, client_id: &str) -> Result<()> {
-        let client_dir = self.queues_dir.join(client_id);
-        if client_dir.exists() {
-            fs::remove_dir_all(&client_dir).await.map_err(|e| {
-                MqttError::Io(format!("Failed to remove queue dir for {client_id}: {e}"))
-            })?;
-            debug!("Removed all queued messages for client: {}", client_id);
-        }
-
-        Ok(())
+    fn remove_queued_messages(
+        &self,
+        client_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        self.queues.handle(client_id).clear(None);
+        debug!("Removed all queued messages for client: {}", client_id);
+        std::future::ready(Ok(()))
     }
 
-    async fn store_inflight_message(&self, message: InflightMessage) -> Result<()> {
-        let client_dir = self.inflight_dir.join(&message.client_id);
-        let direction_tag = match message.direction {
-            InflightDirection::Inbound => "inbound",
-            InflightDirection::Outbound => "outbound",
-        };
-        let filename = format!("{direction_tag}_{}.json", message.packet_id);
-        let path = client_dir.join(filename);
-
-        self.write_file_atomic(path, &message).await
+    fn store_inflight_message(
+        &self,
+        message: InflightMessage,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        std::future::ready(self.send_queue_op(QueueOp::StoreInflight(Box::new(message))))
     }
 
     async fn get_inflight_messages(&self, client_id: &str) -> Result<Vec<InflightMessage>> {
+        self.flush_queue_writes().await;
         let client_dir = self.inflight_dir.join(client_id);
         if !client_dir.exists() {
             return Ok(Vec::new());
@@ -627,45 +974,26 @@ impl StorageBackend for FileBackend {
         Ok(messages)
     }
 
-    async fn remove_inflight_message(
+    fn remove_inflight_message(
         &self,
         client_id: &str,
         packet_id: u16,
         direction: InflightDirection,
-    ) -> Result<()> {
-        let client_dir = self.inflight_dir.join(client_id);
-        let direction_tag = match direction {
-            InflightDirection::Inbound => "inbound",
-            InflightDirection::Outbound => "outbound",
-        };
-        let filename = format!("{direction_tag}_{packet_id}.json");
-        let path = client_dir.join(filename);
-
-        if path.exists() {
-            fs::remove_file(&path)
-                .await
-                .map_err(|e| MqttError::Io(format!("failed to remove inflight file: {e}")))?;
-        }
-
-        if client_dir.exists() {
-            if let Ok(mut dir) = fs::read_dir(&client_dir).await {
-                if dir.next_entry().await.ok().flatten().is_none() {
-                    let _ = fs::remove_dir(&client_dir).await;
-                }
-            }
-        }
-
-        Ok(())
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        std::future::ready(self.send_queue_op(QueueOp::RemoveInflight {
+            client_id: client_id.to_string(),
+            packet_id,
+            direction,
+        }))
     }
 
-    async fn remove_all_inflight_messages(&self, client_id: &str) -> Result<()> {
-        let client_dir = self.inflight_dir.join(client_id);
-        if client_dir.exists() {
-            fs::remove_dir_all(&client_dir)
-                .await
-                .map_err(|e| MqttError::Io(format!("failed to remove inflight dir: {e}")))?;
-        }
-        Ok(())
+    fn remove_all_inflight_messages(
+        &self,
+        client_id: &str,
+    ) -> impl std::future::Future<Output = Result<()>> + Send {
+        std::future::ready(self.send_queue_op(QueueOp::RemoveAllInflight {
+            client_id: client_id.to_string(),
+        }))
     }
 
     async fn cleanup_expired(&self) -> Result<()> {
@@ -699,44 +1027,23 @@ impl StorageBackend for FileBackend {
             }
         }
 
-        // Clean expired queued messages
-        let mut queue_entries = fs::read_dir(&self.queues_dir)
-            .await
-            .map_err(|e| MqttError::Io(format!("Failed to read queues directory: {e}")))?;
-
-        while let Some(entry) = queue_entries
-            .next_entry()
-            .await
-            .map_err(|e| MqttError::Io(format!("Failed to read queue entry: {e}")))?
-        {
-            let client_dir = entry.path();
-            let is_dir = fs::metadata(&client_dir).await.is_ok_and(|m| m.is_dir());
-            if is_dir {
-                let queue_files = self.list_files(&client_dir, "json").await?;
-                for file_path in queue_files {
-                    if let Some(message) =
-                        self.read_file::<QueuedMessage>(file_path.clone()).await?
-                    {
-                        if message.is_expired() {
-                            if let Err(e) = fs::remove_file(&file_path).await {
-                                warn!("Failed to remove expired queued message: {e}");
-                            } else {
-                                removed_count += 1;
-                            }
+        for queue in self.queues.handles() {
+            removed_count += queue.purge_expired();
+            for (seq, path) in queue.scanned_entries() {
+                match self.read_file::<QueuedMessage>(path).await? {
+                    Some(mut message) => {
+                        message.recompute_expiry();
+                        if message.is_expired() && queue.remove_seq(seq) {
+                            removed_count += 1;
                         }
                     }
-                }
-
-                // Remove empty client directories
-                if let Ok(mut dir) = fs::read_dir(&client_dir).await {
-                    if dir.next_entry().await.ok().flatten().is_none() {
-                        if let Err(e) = fs::remove_dir(&client_dir).await {
-                            warn!("Failed to remove empty queue directory: {e}");
-                        }
+                    None => {
+                        queue.remove_seq(seq);
                     }
                 }
             }
         }
+        self.queues.evict_idle();
 
         removed_count += self.cleanup_expired_inflight().await?;
 
@@ -763,6 +1070,95 @@ mod tests {
         let mut packet = PublishPacket::new(topic.to_string(), payload, QoS::AtMostOnce);
         packet.retain = true;
         RetainedMessage::new(packet)
+    }
+
+    fn queued(client: &str, tag: &str) -> QueuedMessage {
+        QueuedMessage::new(
+            PublishPacket::new(
+                format!("q/{tag}"),
+                tag.as_bytes().to_vec(),
+                QoS::AtLeastOnce,
+            ),
+            client.to_string(),
+            QoS::AtLeastOnce,
+            None,
+        )
+    }
+
+    fn topics(messages: &[QueuedMessage]) -> Vec<&str> {
+        messages.iter().map(|m| m.topic.as_str()).collect()
+    }
+
+    #[tokio::test]
+    async fn take_before_the_writer_persists_still_returns_the_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let backend = FileBackend::new(dir.path()).await.unwrap();
+        let queue = backend.queue_handle("fast");
+        queue.push(queued("fast", "m1"));
+        let taken = queue.take(1).await;
+        assert_eq!(topics(&taken), ["q/m1"]);
+        assert_eq!(queue.count(), 0);
+        backend.flush_queue_writes().await;
+        let client_dir = backend.queues_dir.join("fast");
+        let files = if client_dir.exists() {
+            backend.list_files(&client_dir, "json").await.unwrap()
+        } else {
+            Vec::new()
+        };
+        assert!(
+            files.is_empty(),
+            "a taken message must leave no file behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_rebuilds_count_and_order_from_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let backend = FileBackend::new(dir.path()).await.unwrap();
+            let queue = backend.queue_handle("persist");
+            for tag in ["a", "b", "c", "d", "e"] {
+                queue.push(queued("persist", tag));
+            }
+            let taken = queue.take(2).await;
+            assert_eq!(topics(&taken), ["q/a", "q/b"]);
+            queue.requeue_front(vec![queued("persist", "r1"), queued("persist", "r2")]);
+            backend.flush_queue_writes().await;
+        }
+        let reopened = FileBackend::new(dir.path()).await.unwrap();
+        let queue = reopened.queue_handle("persist");
+        assert_eq!(queue.count(), 5);
+        let taken = queue.take(10).await;
+        assert_eq!(topics(&taken), ["q/r1", "q/r2", "q/c", "q/d", "q/e"]);
+        queue.push(queued("persist", "after"));
+        assert!(queue.next_seq() > SEQ_FLOOR);
+    }
+
+    #[tokio::test]
+    async fn legacy_queue_files_are_migrated_and_ordered_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let client_dir = dir.path().join("queues").join("legacy");
+        tokio::fs::create_dir_all(&client_dir).await.unwrap();
+        for (index, tag) in ["old0", "old1", "old2"].iter().enumerate() {
+            let message = queued("legacy", tag);
+            let path = client_dir.join(format!("1700000000000_{index}.json"));
+            tokio::fs::write(&path, serde_json::to_vec(&message).unwrap())
+                .await
+                .unwrap();
+        }
+        let backend = FileBackend::new(dir.path()).await.unwrap();
+        let queue = backend.queue_handle("legacy");
+        assert_eq!(queue.count(), 3);
+        queue.push(queued("legacy", "new"));
+        let taken = queue.take(10).await;
+        assert_eq!(topics(&taken), ["q/old0", "q/old1", "q/old2", "q/new"]);
+        let remaining = backend.list_files(&client_dir, "json").await.unwrap();
+        assert!(
+            remaining
+                .iter()
+                .all(|p| !p.file_name().unwrap().to_str().unwrap().contains('_')),
+            "legacy names must be gone after migration"
+        );
     }
 
     /// A file the broker cannot read must not stop it from loading the rest.

--- a/crates/mqtt5/src/broker/storage/memory_backend.rs
+++ b/crates/mqtt5/src/broker/storage/memory_backend.rs
@@ -3,8 +3,8 @@
 //! Provides volatile storage for development and testing scenarios.
 
 use super::{
-    ClientSession, InflightDirection, InflightMessage, QueuedMessage, RetainedMessage,
-    StorageBackend,
+    ClientSession, InflightDirection, InflightMessage, QueueHandle, QueueLimits, QueueRegistry,
+    QueuedMessage, RetainedMessage, StorageBackend,
 };
 use crate::error::Result;
 use crate::validation::topic_matches_filter;
@@ -19,7 +19,7 @@ type InflightMap = HashMap<String, HashMap<(u16, InflightDirection), InflightMes
 pub struct MemoryBackend {
     retained: Arc<Mutex<HashMap<String, RetainedMessage>>>,
     sessions: Arc<Mutex<HashMap<String, ClientSession>>>,
-    queues: Arc<Mutex<HashMap<String, Vec<QueuedMessage>>>>,
+    queues: QueueRegistry,
     inflight: Arc<Mutex<InflightMap>>,
 }
 
@@ -27,10 +27,15 @@ impl MemoryBackend {
     /// Create new memory storage backend
     #[must_use]
     pub fn new() -> Self {
+        Self::with_queue_limits(QueueLimits::default())
+    }
+
+    #[must_use]
+    pub fn with_queue_limits(limits: QueueLimits) -> Self {
         Self {
             retained: Arc::new(Mutex::new(HashMap::new())),
             sessions: Arc::new(Mutex::new(HashMap::new())),
-            queues: Arc::new(Mutex::new(HashMap::new())),
+            queues: QueueRegistry::new(limits, None),
             inflight: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -133,42 +138,29 @@ impl StorageBackend for MemoryBackend {
         std::future::ready(Ok(()))
     }
 
+    fn queue_handle(&self, client_id: &str) -> QueueHandle {
+        self.queues.handle(client_id)
+    }
+
     fn queue_message(
         &self,
         message: QueuedMessage,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let mut queues = self.queues.lock();
-        let queue = queues.entry(message.client_id.clone()).or_default();
-        queue.push(message.clone());
-        debug!("Queued message for client: {}", message.client_id);
+        let client_id = message.client_id.clone();
+        self.queues.handle(&client_id).push(message);
+        debug!("Queued message for client: {}", client_id);
         std::future::ready(Ok(()))
     }
 
-    fn get_queued_messages(
-        &self,
-        client_id: &str,
-    ) -> impl std::future::Future<Output = Result<Vec<QueuedMessage>>> + Send {
-        let queues = self.queues.lock();
-        let messages = if let Some(messages) = queues.get(client_id) {
-            let mut valid_messages = Vec::new();
-            for message in messages {
-                if !message.is_expired() {
-                    valid_messages.push(message.clone());
-                }
-            }
-            valid_messages
-        } else {
-            Vec::new()
-        };
-        std::future::ready(Ok(messages))
+    async fn get_queued_messages(&self, client_id: &str) -> Result<Vec<QueuedMessage>> {
+        Ok(self.queues.handle(client_id).peek_all().await)
     }
 
     fn remove_queued_messages(
         &self,
         client_id: &str,
     ) -> impl std::future::Future<Output = Result<()>> + Send {
-        let mut queues = self.queues.lock();
-        queues.remove(client_id);
+        self.queues.handle(client_id).clear(None);
         debug!("Removed all queued messages for client: {}", client_id);
         std::future::ready(Ok(()))
     }
@@ -254,15 +246,10 @@ impl StorageBackend for MemoryBackend {
             });
         }
 
-        {
-            let mut queues = self.queues.lock();
-            for queue in queues.values_mut() {
-                let original_len = queue.len();
-                queue.retain(|message| !message.is_expired());
-                removed_count += original_len - queue.len();
-            }
-            queues.retain(|_, queue| !queue.is_empty());
+        for queue in self.queues.handles() {
+            removed_count += queue.purge_expired();
         }
+        self.queues.evict_idle();
 
         {
             let mut inflight = self.inflight.lock();

--- a/crates/mqtt5/src/broker/storage/mod.rs
+++ b/crates/mqtt5/src/broker/storage/mod.rs
@@ -3,6 +3,7 @@
 //! Provides durable storage for retained messages, client sessions, and message queues.
 //! Designed for production use with atomic operations and efficient file-based storage.
 
+pub mod client_queue;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod file_backend;
 pub mod memory_backend;
@@ -10,6 +11,10 @@ pub mod queue;
 pub mod retained;
 pub mod sessions;
 
+pub use client_queue::{
+    ClientQueue, PushOutcome, QueueHandle, QueueLimits, QueueOp, QueueRegistry, QueueWriter,
+    SEQ_FLOOR,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use file_backend::FileBackend;
 pub use memory_backend::MemoryBackend;
@@ -297,10 +302,33 @@ pub struct QueuedMessage {
     pub expires_at: Option<SystemTime>,
     /// Packet ID for `QoS` 1/2 delivery
     pub packet_id: Option<u16>,
+    /// Re-delivery of a message the client may already have seen
+    #[serde(default)]
+    pub dup: bool,
+    #[serde(default)]
+    pub retain: bool,
+    /// Server data flow the delivery was bound to, when the subscription came in on one
+    #[serde(default)]
+    pub target_flow: Option<u64>,
+    #[serde(default)]
+    pub subscription_identifiers: Vec<u32>,
+    #[serde(default)]
+    pub user_properties: Vec<(String, String)>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub response_topic: Option<String>,
+    #[serde(default)]
+    pub correlation_data: Option<Vec<u8>>,
+    #[serde(default)]
+    pub payload_format_indicator: Option<bool>,
 }
 
 /// Storage backend trait for broker persistence
 pub trait StorageBackend: Send + Sync {
+    /// The client's queue, created on first touch; the only path for queued-message state.
+    fn queue_handle(&self, client_id: &str) -> QueueHandle;
+
     /// Store a retained message
     fn store_retained_message(
         &self,
@@ -871,6 +899,7 @@ impl QueuedMessage {
         let expires_at =
             message_expiry_interval.map(|interval| now + Duration::from_secs(u64::from(interval)));
 
+        let props = V5PublishProps::from_packet(&packet);
         Self {
             topic: packet.topic_name,
             payload: packet.payload.to_vec(),
@@ -880,7 +909,22 @@ impl QueuedMessage {
             message_expiry_interval,
             expires_at,
             packet_id,
+            dup: packet.dup,
+            retain: packet.retain,
+            target_flow: None,
+            subscription_identifiers: packet.properties.subscription_identifiers(),
+            user_properties: props.user_properties,
+            content_type: props.content_type,
+            response_topic: props.response_topic,
+            correlation_data: props.correlation_data,
+            payload_format_indicator: props.payload_format_indicator,
         }
+    }
+
+    #[must_use]
+    pub fn with_target_flow(mut self, target_flow: Option<u64>) -> Self {
+        self.target_flow = target_flow;
+        self
     }
 
     /// Recompute `expires_at` from stored fields (call after deserialization)
@@ -896,10 +940,23 @@ impl QueuedMessage {
     pub fn to_publish_packet(&self) -> PublishPacket {
         let mut packet = PublishPacket::new(&self.topic, self.payload.clone(), self.qos);
         packet.packet_id = self.packet_id;
+        packet.dup = self.dup;
+        packet.retain = self.retain;
 
         if let Some(remaining) = self.remaining_expiry_interval() {
             packet.properties.set_message_expiry_interval(remaining);
         }
+        for id in &self.subscription_identifiers {
+            packet.properties.set_subscription_identifier(*id);
+        }
+        apply_v5_props(
+            &mut packet,
+            &self.user_properties,
+            self.content_type.as_deref(),
+            self.response_topic.as_deref(),
+            self.correlation_data.as_deref(),
+            self.payload_format_indicator,
+        );
 
         packet
     }
@@ -1055,6 +1112,14 @@ pub enum DynamicStorage {
 }
 
 impl StorageBackend for DynamicStorage {
+    fn queue_handle(&self, client_id: &str) -> QueueHandle {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::File(backend) => backend.queue_handle(client_id),
+            Self::Memory(backend) => backend.queue_handle(client_id),
+        }
+    }
+
     async fn store_retained_message(&self, topic: &str, message: RetainedMessage) -> Result<()> {
         match self {
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/mqtt5/src/broker/storage/tests.rs
+++ b/crates/mqtt5/src/broker/storage/tests.rs
@@ -621,6 +621,7 @@ async fn test_file_backend_inflight_persistence() {
             InflightPhase::AwaitingPubrel,
         );
         backend.store_inflight_message(msg2).await.unwrap();
+        backend.shutdown().await.unwrap();
     }
 
     {

--- a/crates/mqtt5/src/client/direct/ack.rs
+++ b/crates/mqtt5/src/client/direct/ack.rs
@@ -333,7 +333,9 @@ impl AckCallbackManager {
         };
         let actual = strip_shared_subscription_prefix(topic_filter).to_string();
         if actual.contains('+') || actual.contains('#') {
-            self.wildcard.lock().push(entry);
+            let mut wildcard = self.wildcard.lock();
+            wildcard.retain(|existing| existing.topic_filter != topic_filter);
+            wildcard.push(entry);
         } else {
             self.exact.lock().insert(actual, entry);
         }
@@ -474,9 +476,9 @@ mod tests {
             "a matching publish invokes exactly one ack callback, never both"
         );
         assert_eq!(
-            hits_second.load(Ordering::SeqCst),
+            hits_first.load(Ordering::SeqCst),
             0,
-            "the duplicate registration is shadowed and never fires"
+            "re-registering a filter replaces the earlier callback, as it does for exact filters"
         );
     }
 }

--- a/crates/mqtt5/src/client/direct/mod.rs
+++ b/crates/mqtt5/src/client/direct/mod.rs
@@ -73,7 +73,7 @@ pub(crate) enum SubscriptionPersistence {
     Skip,
 }
 
-pub(crate) type StoredSubscription = (String, SubscriptionOptions, CallbackId);
+pub(crate) type StoredSubscription = (String, SubscriptionOptions, Option<u32>, CallbackId);
 pub(crate) type StoredSubscriptions = Arc<Mutex<Vec<StoredSubscription>>>;
 pub(crate) type ConnectionEpoch = Arc<AtomicU64>;
 
@@ -1100,6 +1100,7 @@ impl DirectClientInner {
         maybe_store_subscriptions(
             &self.stored_subscriptions,
             &packet.filters,
+            packet.properties.get_subscription_identifier(),
             callback_id,
             persistence,
         );
@@ -1173,7 +1174,7 @@ impl DirectClientInner {
         {
             let mut stored = self.stored_subscriptions.lock();
             for topic in &packet.filters {
-                stored.retain(|(stored_topic, _, _)| stored_topic != topic);
+                stored.retain(|(stored_topic, _, _, _)| stored_topic != topic);
             }
         }
 
@@ -1503,6 +1504,7 @@ impl DirectClientInner {
 fn maybe_store_subscriptions(
     stored_subscriptions: &StoredSubscriptions,
     filters: &[TopicFilter],
+    subscription_identifier: Option<u32>,
     callback_id: CallbackId,
     persistence: SubscriptionPersistence,
 ) {
@@ -1512,7 +1514,12 @@ fn maybe_store_subscriptions(
 
     let mut stored = stored_subscriptions.lock();
     for filter in filters {
-        stored.push((filter.filter.clone(), filter.options, callback_id));
+        stored.push((
+            filter.filter.clone(),
+            filter.options,
+            subscription_identifier,
+            callback_id,
+        ));
     }
 }
 
@@ -1721,14 +1728,14 @@ pub mod tests {
             },
         }];
 
-        maybe_store_subscriptions(&stored, &filters, 7, SubscriptionPersistence::Skip);
+        maybe_store_subscriptions(&stored, &filters, None, 7, SubscriptionPersistence::Skip);
         assert!(stored.lock().is_empty());
 
-        maybe_store_subscriptions(&stored, &filters, 7, SubscriptionPersistence::Persist);
+        maybe_store_subscriptions(&stored, &filters, None, 7, SubscriptionPersistence::Persist);
         let stored = stored.lock();
         assert_eq!(stored.len(), 1);
         assert_eq!(stored[0].0, "test/topic");
-        assert_eq!(stored[0].2, 7);
+        assert_eq!(stored[0].3, 7);
     }
 
     #[tokio::test]

--- a/crates/mqtt5/src/client/mod.rs
+++ b/crates/mqtt5/src/client/mod.rs
@@ -568,10 +568,11 @@ impl MqttClient {
         {
             Ok(results) => {
                 if let Some(&(packet_id, qos)) = results.first() {
-                    if let Some(options) = stored_options {
+                    if let Some(stored) = stored_options {
                         inner.stored_ack_subscriptions.lock().push((
                             topic_filter.clone(),
-                            options,
+                            stored,
+                            options.subscription_identifier,
                             callback_id,
                         ));
                     }
@@ -588,6 +589,36 @@ impl MqttClient {
                 Err(e)
             }
         }
+    }
+
+    /// Registers a deferred-ack callback for `topic_filter` without sending a SUBSCRIBE.
+    ///
+    /// Use it before connecting when the broker may hold a persistent session for this client:
+    /// messages the broker flushes right after CONNACK then reach the callback instead of
+    /// being auto-acknowledged and dropped. A later `subscribe_with_ack` for the same filter
+    /// replaces the callback.
+    ///
+    /// # Errors
+    /// Returns `Configuration` when deferred ack is not enabled in the connect options.
+    pub async fn register_ack_callback<F>(
+        &self,
+        topic_filter: impl Into<String>,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: Fn(PublishPacket, AckToken) + Send + Sync + 'static,
+    {
+        let topic_filter = topic_filter.into();
+        let inner = self.inner.read().await;
+        if !inner.options.deferred_ack {
+            return Err(MqttError::Configuration(
+                "register_ack_callback requires ConnectOptions::with_deferred_ack(true)"
+                    .to_string(),
+            ));
+        }
+        let callback: crate::client::direct::ack::AckPublishCallback = Arc::new(callback);
+        inner.ack_callbacks.register(&topic_filter, callback);
+        Ok(())
     }
 
     #[doc(hidden)]
@@ -679,7 +710,7 @@ impl MqttClient {
         inner
             .stored_ack_subscriptions
             .lock()
-            .retain(|(topic, _, _)| topic != &topic_filter);
+            .retain(|(topic, _, _, _)| topic != &topic_filter);
 
         let packet = UnsubscribePacket {
             packet_id: 0,

--- a/crates/mqtt5/src/client/state.rs
+++ b/crates/mqtt5/src/client/state.rs
@@ -57,7 +57,7 @@ impl MqttClient {
         if session_present {
             tracing::info!("Session resumed, restoring {} callbacks", stored_subs.len());
             let inner = self.inner.read().await;
-            for (topic, _, callback_id) in stored_subs {
+            for (topic, _, _, callback_id) in stored_subs {
                 if !inner.callback_manager.restore_callback(callback_id) {
                     tracing::warn!("Failed to restore callback for {topic}: not found in registry");
                 }
@@ -67,9 +67,9 @@ impl MqttClient {
                 "Session not resumed, restoring {} subscriptions",
                 stored_subs.len()
             );
-            for (topic, options, callback_id) in stored_subs {
+            for (topic, options, subscription_identifier, callback_id) in stored_subs {
                 if let Err(e) = self
-                    .resubscribe_internal(&topic, options, callback_id)
+                    .resubscribe_internal(&topic, options, subscription_identifier, callback_id)
                     .await
                 {
                     tracing::warn!("Failed to restore subscription to {}: {}", topic, e);
@@ -97,9 +97,9 @@ impl MqttClient {
             "Session not resumed, re-subscribing {} deferred-ack subscription(s)",
             subs.len()
         );
-        for (topic, options, callback_id) in subs {
+        for (topic, options, subscription_identifier, callback_id) in subs {
             if let Err(e) = self
-                .resubscribe_ack_internal(&topic, options, callback_id)
+                .resubscribe_ack_internal(&topic, options, subscription_identifier, callback_id)
                 .await
             {
                 tracing::warn!("Failed to re-subscribe deferred-ack topic {topic}: {e}");
@@ -111,16 +111,21 @@ impl MqttClient {
         &self,
         topic: &str,
         options: SubscriptionOptions,
+        subscription_identifier: Option<u32>,
         callback_id: CallbackId,
     ) -> Result<()> {
         let inner = self.inner.read().await;
+        let mut properties = Properties::new();
+        if let Some(id) = subscription_identifier {
+            properties.set_subscription_identifier(id);
+        }
         let packet = SubscribePacket {
             packet_id: inner.packet_id_generator.next(),
             filters: vec![crate::packet::subscribe::TopicFilter {
                 filter: topic.to_string(),
                 options,
             }],
-            properties: Properties::new(),
+            properties,
             protocol_version: inner.options.protocol_version.as_u8(),
         };
         inner
@@ -325,6 +330,7 @@ impl MqttClient {
         &self,
         topic: &str,
         options: SubscriptionOptions,
+        subscription_identifier: Option<u32>,
         callback_id: CallbackId,
     ) -> Result<()> {
         let inner = self.inner.read().await;
@@ -332,13 +338,17 @@ impl MqttClient {
         drop(inner);
 
         let inner = self.inner.read().await;
+        let mut properties = Properties::new();
+        if let Some(id) = subscription_identifier {
+            properties.set_subscription_identifier(id);
+        }
         let packet = SubscribePacket {
             packet_id: inner.packet_id_generator.next(),
             filters: vec![crate::packet::subscribe::TopicFilter {
                 filter: topic.to_string(),
                 options,
             }],
-            properties: Properties::new(),
+            properties,
             protocol_version: inner.options.protocol_version.as_u8(),
         };
         inner

--- a/crates/mqtt5/src/transport/packet_io.rs
+++ b/crates/mqtt5/src/transport/packet_io.rs
@@ -7,7 +7,7 @@ use crate::error::{MqttError, Result};
 use crate::packet::{FixedHeader, MqttPacket, Packet, PacketType};
 use crate::transport::tls::{TlsReadHalf, TlsWriteHalf};
 use crate::Transport;
-use bytes::{BufMut, BytesMut};
+use bytes::{Buf, BufMut, BytesMut};
 use std::future::Future;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
@@ -300,74 +300,67 @@ pub fn encode_packet_to_buffer(packet: &Packet, buf: &mut BytesMut) -> Result<()
     Ok(())
 }
 
+const READ_CHUNK: usize = 4096;
+
+/// Reads one packet, keeping every byte received so far in `read_buffer`.
+///
+/// The future is cancel-safe: all progress lives in `read_buffer`, the only
+/// await is a single transport read into a stack chunk, and bytes belonging to
+/// the next packet stay in the buffer for the next call.
+///
 /// # Errors
 /// Returns error if reading from transport fails or packet is malformed
 pub async fn read_packet_reusing_buffer<T: Transport>(
     transport: &mut T,
     protocol_version: u8,
-    payload_buffer: &mut BytesMut,
+    read_buffer: &mut BytesMut,
     max_packet_size: usize,
 ) -> Result<Packet> {
-    let mut header_bytes = [0u8; 5];
-    let mut header_len = 0usize;
-
-    let mut byte = [0u8; 1];
-    let n = transport.read(&mut byte).await?;
-    if n == 0 {
-        return Err(MqttError::ClientClosed);
-    }
-    header_bytes[header_len] = byte[0];
-    header_len += 1;
-
     loop {
-        let n = transport.read(&mut byte).await?;
+        if let Some(header_len) = fixed_header_len(read_buffer)? {
+            let mut header_slice: &[u8] = &read_buffer[..header_len];
+            let fixed_header = FixedHeader::decode(&mut header_slice)?;
+            let remaining = fixed_header.remaining_length as usize;
+            if remaining > max_packet_size {
+                return Err(MqttError::PacketTooLarge {
+                    size: remaining,
+                    max: max_packet_size,
+                });
+            }
+            let frame_len = header_len + remaining;
+            if read_buffer.len() >= frame_len {
+                let mut frame = read_buffer.split_to(frame_len);
+                frame.advance(header_len);
+                return Packet::decode_from_body_with_version(
+                    fixed_header.packet_type,
+                    &fixed_header,
+                    &mut frame,
+                    protocol_version,
+                );
+            }
+            read_buffer.reserve(frame_len - read_buffer.len());
+        }
+        let mut chunk = [0u8; READ_CHUNK];
+        let n = transport.read(&mut chunk).await?;
         if n == 0 {
             return Err(MqttError::ClientClosed);
         }
-        header_bytes[header_len] = byte[0];
-        header_len += 1;
+        read_buffer.extend_from_slice(&chunk[..n]);
+    }
+}
 
-        if (byte[0] & crate::constants::masks::CONTINUATION_BIT) == 0 {
-            break;
+fn fixed_header_len(buf: &[u8]) -> Result<Option<usize>> {
+    for (index, byte) in buf.iter().enumerate().skip(1) {
+        if (byte & crate::constants::masks::CONTINUATION_BIT) == 0 {
+            return Ok(Some(index + 1));
         }
-
-        if header_len > 4 {
+        if index == 4 {
             return Err(MqttError::MalformedPacket(
                 "Invalid remaining length encoding".to_string(),
             ));
         }
     }
-
-    let mut header_slice: &[u8] = &header_bytes[..header_len];
-    let fixed_header = FixedHeader::decode(&mut header_slice)?;
-
-    let remaining = fixed_header.remaining_length as usize;
-    if remaining > max_packet_size {
-        return Err(MqttError::PacketTooLarge {
-            size: remaining,
-            max: max_packet_size,
-        });
-    }
-
-    payload_buffer.clear();
-    payload_buffer.reserve(remaining);
-    payload_buffer.resize(remaining, 0);
-
-    let mut bytes_read = 0;
-    while bytes_read < remaining {
-        let n = transport.read(&mut payload_buffer[bytes_read..]).await?;
-        if n == 0 {
-            return Err(MqttError::ClientClosed);
-        }
-        bytes_read += n;
-    }
-
-    Packet::decode_from_body_with_version(
-        fixed_header.packet_type,
-        &fixed_header,
-        payload_buffer,
-        protocol_version,
-    )
+    Ok(None)
 }
 
 /// Implementation for TCP write half
@@ -461,6 +454,158 @@ mod tests {
     use crate::protocol::v5::reason_codes::ReasonCode;
     use crate::transport::mock::MockTransport;
     use crate::QoS;
+    use std::collections::VecDeque;
+    use tokio::sync::mpsc;
+
+    struct ChunkTransport {
+        chunks: mpsc::UnboundedReceiver<Vec<u8>>,
+        pending: VecDeque<u8>,
+    }
+
+    impl ChunkTransport {
+        fn new() -> (mpsc::UnboundedSender<Vec<u8>>, Self) {
+            let (tx, chunks) = mpsc::unbounded_channel();
+            (
+                tx,
+                Self {
+                    chunks,
+                    pending: VecDeque::new(),
+                },
+            )
+        }
+    }
+
+    impl Transport for ChunkTransport {
+        fn connect(&mut self) -> impl Future<Output = Result<()>> + Send {
+            std::future::ready(Ok(()))
+        }
+
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            if self.pending.is_empty() {
+                match self.chunks.recv().await {
+                    Some(chunk) => self.pending.extend(chunk),
+                    None => return Ok(0),
+                }
+            }
+            let mut copied = 0;
+            while copied < buf.len() {
+                match self.pending.pop_front() {
+                    Some(byte) => {
+                        buf[copied] = byte;
+                        copied += 1;
+                    }
+                    None => break,
+                }
+            }
+            Ok(copied)
+        }
+
+        fn write(&mut self, _buf: &[u8]) -> impl Future<Output = Result<()>> + Send {
+            std::future::ready(Ok(()))
+        }
+
+        fn close(&mut self) -> impl Future<Output = Result<()>> + Send {
+            std::future::ready(Ok(()))
+        }
+    }
+
+    fn encoded_publish(topic: &str, payload: &[u8]) -> Vec<u8> {
+        let mut publish = PublishPacket::new(topic, payload.to_vec(), QoS::AtLeastOnce);
+        publish.packet_id = Some(7);
+        let mut buf = BytesMut::new();
+        encode_packet_to_buffer(&Packet::Publish(publish), &mut buf).unwrap();
+        buf.to_vec()
+    }
+
+    #[tokio::test]
+    async fn read_survives_cancellation_mid_packet() {
+        let (tx, mut transport) = ChunkTransport::new();
+        let bytes = encoded_publish("cancel/safe", b"hello world");
+        let (first, second) = bytes.split_at(3);
+        tx.send(first.to_vec()).unwrap();
+        let mut read_buffer = BytesMut::with_capacity(64);
+
+        tokio::select! {
+            biased;
+            result = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024) => {
+                panic!("packet completed from a partial frame: {result:?}");
+            }
+            () = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+        }
+        assert_eq!(read_buffer.len(), first.len());
+
+        tx.send(second.to_vec()).unwrap();
+        let packet = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap();
+        match packet {
+            Packet::Publish(publish) => {
+                assert_eq!(publish.topic_name, "cancel/safe");
+                assert_eq!(publish.payload.as_ref(), b"hello world");
+                assert_eq!(publish.packet_id, Some(7));
+            }
+            other => panic!("unexpected packet {other:?}"),
+        }
+        assert!(read_buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_keeps_next_packet_bytes_in_buffer() {
+        let (tx, mut transport) = ChunkTransport::new();
+        let mut bytes = encoded_publish("first", b"1");
+        bytes.extend(encoded_publish("second", b"22"));
+        bytes.extend(crate::constants::packets::PINGREQ_BYTES);
+        tx.send(bytes).unwrap();
+        let mut read_buffer = BytesMut::with_capacity(8);
+
+        let first = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap();
+        let second = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap();
+        let third = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap();
+        assert!(matches!(first, Packet::Publish(p) if p.topic_name == "first"));
+        assert!(matches!(second, Packet::Publish(p) if p.topic_name == "second"));
+        assert!(matches!(third, Packet::PingReq));
+        assert!(read_buffer.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_rejects_oversized_packet_before_reading_body() {
+        let (tx, mut transport) = ChunkTransport::new();
+        tx.send(encoded_publish("big", &[0u8; 300])).unwrap();
+        let mut read_buffer = BytesMut::new();
+        let err = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 100)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MqttError::PacketTooLarge { .. }));
+    }
+
+    #[tokio::test]
+    async fn read_rejects_invalid_remaining_length_encoding() {
+        let (tx, mut transport) = ChunkTransport::new();
+        tx.send(vec![0x30, 0x80, 0x80, 0x80, 0x80, 0x01]).unwrap();
+        let mut read_buffer = BytesMut::new();
+        let err = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MqttError::MalformedPacket(_)));
+    }
+
+    #[tokio::test]
+    async fn read_reports_closed_transport() {
+        let (tx, mut transport) = ChunkTransport::new();
+        tx.send(vec![0x30]).unwrap();
+        drop(tx);
+        let mut read_buffer = BytesMut::new();
+        let err = read_packet_reusing_buffer(&mut transport, 5, &mut read_buffer, 1024)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MqttError::ClientClosed));
+    }
 
     #[tokio::test]
     async fn test_read_packet_pingresp() {

--- a/crates/mqtt5/tests/bridge_ingress_overlap.rs
+++ b/crates/mqtt5/tests/bridge_ingress_overlap.rs
@@ -1,0 +1,199 @@
+#![cfg(feature = "broker")]
+use mqtt5::broker::bridge::{BridgeConfig, BridgeDirection};
+use mqtt5::broker::{BrokerConfig, BrokerShutdownHandle, MqttBroker, StorageConfig};
+use mqtt5::client::MqttClient;
+use mqtt5::time::Duration;
+use mqtt5::QoS;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use tokio::task::JoinHandle;
+
+fn broker_config(bind: SocketAddr) -> BrokerConfig {
+    BrokerConfig::default()
+        .with_bind_address(bind)
+        .with_max_clients(100)
+        .with_storage(StorageConfig::new().with_persistence(false))
+}
+
+async fn wait_for_ready(mut rx: tokio::sync::watch::Receiver<bool>) {
+    while !*rx.borrow_and_update() {
+        rx.changed().await.expect("broker ready channel closed");
+    }
+}
+
+struct RunningBroker {
+    addr: SocketAddr,
+    task: JoinHandle<()>,
+    shutdown: BrokerShutdownHandle,
+}
+
+impl RunningBroker {
+    async fn stop(self) {
+        self.shutdown.shutdown();
+        tokio::time::timeout(Duration::from_secs(5), self.task)
+            .await
+            .expect("broker stops on shutdown")
+            .expect("broker task joins");
+    }
+}
+
+async fn start_broker(config: BrokerConfig) -> RunningBroker {
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let addr = broker.local_addr().unwrap();
+    let ready = broker.ready_receiver();
+    let shutdown = broker.shutdown_handle();
+    let task = tokio::spawn(async move {
+        if let Err(e) = broker.run().await {
+            eprintln!("broker run() error: {e}");
+        }
+    });
+    wait_for_ready(ready).await;
+    RunningBroker {
+        addr,
+        task,
+        shutdown,
+    }
+}
+
+fn free_port() -> SocketAddr {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap()
+}
+
+async fn wait_until(deadline: Duration, cond: impl Fn() -> bool) -> bool {
+    let started = tokio::time::Instant::now();
+    while started.elapsed() < deadline {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    cond()
+}
+
+fn overlapping_bridge(remote: SocketAddr) -> BridgeConfig {
+    let mut config = BridgeConfig::new("overlap", remote.to_string())
+        .add_topic("sensors/#", BridgeDirection::In, QoS::AtLeastOnce)
+        .add_topic("sensors/+/temp", BridgeDirection::In, QoS::AtLeastOnce);
+    config.topics[0].local_prefix = Some("a/".to_string());
+    config.topics[1].local_prefix = Some("b/".to_string());
+    config.initial_reconnect_delay = Duration::from_millis(200);
+    config.first_retry_delay = Duration::from_millis(200);
+    config.max_reconnect_delay = Duration::from_millis(500);
+    config
+}
+
+async fn subscribe_all(client: &MqttClient, filter: &str) -> Arc<Mutex<Vec<String>>> {
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    client
+        .subscribe(filter, move |msg| {
+            sink.lock().unwrap().push(msg.topic.clone());
+        })
+        .await
+        .unwrap();
+    received
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn overlapping_incoming_mappings_route_one_copy_each() {
+    let remote = start_broker(broker_config(free_port())).await;
+
+    let mut local_config = broker_config(free_port());
+    local_config.bridges = vec![overlapping_bridge(remote.addr)];
+    let local = start_broker(local_config).await;
+
+    let local_client = MqttClient::new("local-subscriber");
+    local_client
+        .connect(&format!("mqtt://{}", local.addr))
+        .await
+        .unwrap();
+    let received = subscribe_all(&local_client, "#").await;
+
+    let remote_client = MqttClient::new("remote-publisher");
+    remote_client
+        .connect(&format!("mqtt://{}", remote.addr))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    remote_client
+        .publish_qos1("sensors/x/temp", b"21")
+        .await
+        .unwrap();
+
+    assert!(
+        wait_until(Duration::from_secs(5), || received.lock().unwrap().len()
+            >= 2)
+        .await,
+        "both mappings deliver a local copy"
+    );
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let mut topics = received.lock().unwrap().clone();
+    topics.sort();
+    assert_eq!(
+        topics,
+        vec![
+            "a/sensors/x/temp".to_string(),
+            "b/sensors/x/temp".to_string()
+        ],
+        "exactly one copy per mapping, none duplicated across overlapping filters"
+    );
+
+    remote_client.disconnect().await.unwrap();
+    local_client.disconnect().await.unwrap();
+    local.stop().await;
+    remote.stop().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn bridge_keeps_delivering_across_remote_restarts() {
+    let remote_bind = free_port();
+    let mut remote = start_broker(broker_config(remote_bind)).await;
+
+    let mut local_config = broker_config(free_port());
+    local_config.bridges = vec![overlapping_bridge(remote.addr)];
+    let local = start_broker(local_config).await;
+
+    let local_client = MqttClient::new("local-subscriber");
+    local_client
+        .connect(&format!("mqtt://{}", local.addr))
+        .await
+        .unwrap();
+    let received = subscribe_all(&local_client, "a/#").await;
+
+    for round in 0..3 {
+        if round > 0 {
+            remote.stop().await;
+            remote = start_broker(broker_config(remote_bind)).await;
+        }
+        let publisher = MqttClient::new(format!("remote-publisher-{round}"));
+        publisher
+            .connect(&format!("mqtt://{}", remote.addr))
+            .await
+            .unwrap();
+
+        let before = received.lock().unwrap().len();
+        let mut delivered = false;
+        for _ in 0..100 {
+            publisher
+                .publish_qos1("sensors/y/temp", format!("{round}").into_bytes())
+                .await
+                .unwrap();
+            if wait_until(Duration::from_millis(200), || {
+                received.lock().unwrap().len() > before
+            })
+            .await
+            {
+                delivered = true;
+                break;
+            }
+        }
+        assert!(delivered, "delivery resumes after remote restart {round}");
+        publisher.disconnect().await.unwrap();
+    }
+
+    local_client.disconnect().await.unwrap();
+    local.stop().await;
+    remote.stop().await;
+}

--- a/crates/mqtt5/tests/broker_bridge_integration.rs
+++ b/crates/mqtt5/tests/broker_bridge_integration.rs
@@ -84,10 +84,16 @@ async fn test_bridge_message_routing() {
     let router = Arc::new(MessageRouter::new());
 
     // Register a test client to receive messages
-    let (tx, rx) = flume::bounded(10);
+    let (qos1_tx, _qos1_rx) = tokio::sync::mpsc::channel(10);
+    let (qos0_tx, mut rx) = tokio::sync::mpsc::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
     router
-        .register_client("test-client".to_string(), tx, dtx)
+        .register_client(
+            "test-client".to_string(),
+            mqtt5::broker::router::DeliveryLanes { qos1_tx, qos0_tx },
+            router.queue_handle("test-client"),
+            dtx,
+        )
         .await;
     router
         .subscribe(
@@ -114,7 +120,7 @@ async fn test_bridge_message_routing() {
     router.route_message(&packet, None).await;
 
     // Verify message was routed locally
-    let received = timeout(Duration::from_millis(500), rx.recv_async())
+    let received = timeout(Duration::from_millis(500), rx.recv())
         .await
         .expect("Timeout waiting for message")
         .expect("Should receive message");

--- a/crates/mqtt5/tests/change_only_delivery.rs
+++ b/crates/mqtt5/tests/change_only_delivery.rs
@@ -12,11 +12,16 @@ use tokio::time::timeout;
 async fn test_change_only_filters_duplicate_payloads() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("change_only_client".to_string(), tx, dtx)
+        .register_client(
+            "change_only_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("change_only_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -42,7 +47,7 @@ async fn test_change_only_filters_duplicate_payloads() {
     );
     router.route_message(&packet1, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result1.is_ok(), "First message should be delivered");
 
     let packet2 = PublishPacket::new(
@@ -52,7 +57,7 @@ async fn test_change_only_filters_duplicate_payloads() {
     );
     router.route_message(&packet2, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_err(),
         "Duplicate payload should not be delivered in change-only mode"
@@ -63,11 +68,16 @@ async fn test_change_only_filters_duplicate_payloads() {
 async fn test_change_only_allows_different_payloads() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("change_only_client".to_string(), tx, dtx)
+        .register_client(
+            "change_only_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("change_only_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -93,7 +103,7 @@ async fn test_change_only_allows_different_payloads() {
     );
     router.route_message(&packet1, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result1.is_ok(), "First message should be delivered");
     let received1 = result1.unwrap().unwrap();
     assert_eq!(&received1.publish.payload[..], b"25.5");
@@ -105,7 +115,7 @@ async fn test_change_only_allows_different_payloads() {
     );
     router.route_message(&packet2, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result2.is_ok(), "Different payload should be delivered");
     let received2 = result2.unwrap().unwrap();
     assert_eq!(&received2.publish.payload[..], b"26.0");
@@ -115,11 +125,16 @@ async fn test_change_only_allows_different_payloads() {
 async fn test_change_only_disabled_allows_duplicates() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("regular_client".to_string(), tx, dtx)
+        .register_client(
+            "regular_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("regular_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -145,7 +160,7 @@ async fn test_change_only_disabled_allows_duplicates() {
     );
     router.route_message(&packet1, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result1.is_ok(), "First message should be delivered");
 
     let packet2 = PublishPacket::new(
@@ -155,7 +170,7 @@ async fn test_change_only_disabled_allows_duplicates() {
     );
     router.route_message(&packet2, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_ok(),
         "Duplicate payload should be delivered when change_only=false"
@@ -166,11 +181,16 @@ async fn test_change_only_disabled_allows_duplicates() {
 async fn test_change_only_per_topic_tracking() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("change_only_client".to_string(), tx, dtx)
+        .register_client(
+            "change_only_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("change_only_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -196,7 +216,7 @@ async fn test_change_only_per_topic_tracking() {
     );
     router.route_message(&packet_temp, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result1.is_ok(), "Temperature message should be delivered");
 
     let packet_humidity = PublishPacket::new(
@@ -206,7 +226,7 @@ async fn test_change_only_per_topic_tracking() {
     );
     router.route_message(&packet_humidity, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_ok(),
         "Same payload on different topic should be delivered"
@@ -217,11 +237,16 @@ async fn test_change_only_per_topic_tracking() {
 async fn test_change_only_state_persistence() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("persistent_client".to_string(), tx.clone(), dtx)
+        .register_client(
+            "persistent_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("persistent_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -243,7 +268,7 @@ async fn test_change_only_state_persistence() {
     let packet1 = PublishPacket::new("test/topic".to_string(), &b"data1"[..], QoS::AtMostOnce);
     router.route_message(&packet1, None).await;
 
-    let _ = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let _ = timeout(Duration::from_millis(100), rx.recv()).await;
 
     let state = router.get_change_only_state("persistent_client").await;
     assert!(
@@ -269,11 +294,16 @@ async fn test_change_only_state_load_on_reconnect() {
         .load_change_only_state("reconnect_client", state)
         .await;
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("reconnect_client".to_string(), tx, dtx)
+        .register_client(
+            "reconnect_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("reconnect_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -295,7 +325,7 @@ async fn test_change_only_state_load_on_reconnect() {
     let packet_same = PublishPacket::new("test/topic".to_string(), &b"data1"[..], QoS::AtMostOnce);
     router.route_message(&packet_same, None).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_err(),
         "Same payload should be blocked after state restore"
@@ -304,7 +334,7 @@ async fn test_change_only_state_load_on_reconnect() {
     let packet_new = PublishPacket::new("test/topic".to_string(), &b"data2"[..], QoS::AtMostOnce);
     router.route_message(&packet_new, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_ok(),
         "New payload should be delivered after state restore"
@@ -355,11 +385,16 @@ async fn test_change_only_state_should_deliver() {
 async fn test_change_only_with_qos_levels() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("qos_client".to_string(), tx, dtx)
+        .register_client(
+            "qos_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("qos_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -385,7 +420,7 @@ async fn test_change_only_with_qos_levels() {
     );
     router.route_message(&packet1, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result1.is_ok(), "QoS1 message should be delivered");
 
     let packet2 = PublishPacket::new(
@@ -395,7 +430,7 @@ async fn test_change_only_with_qos_levels() {
     );
     router.route_message(&packet2, None).await;
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_err(),
         "Duplicate QoS1 message should be filtered in change-only mode"
@@ -406,17 +441,27 @@ async fn test_change_only_with_qos_levels() {
 async fn test_change_only_multiple_clients_independent() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx1, rx1) = flume::bounded(10);
-    let (tx2, rx2) = flume::bounded(10);
+    let (lanes1, mut rx1) = mqtt5::broker::router::DeliveryLanes::channel(10);
+    let (lanes2, mut rx2) = mqtt5::broker::router::DeliveryLanes::channel(10);
 
     let (dtx1, _drx1) = tokio::sync::oneshot::channel();
     let (dtx2, _drx2) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("client1".to_string(), tx1, dtx1)
+        .register_client(
+            "client1".to_string(),
+            lanes1.clone(),
+            router.queue_handle("client1"),
+            dtx1,
+        )
         .await;
     router
-        .register_client("client2".to_string(), tx2, dtx2)
+        .register_client(
+            "client2".to_string(),
+            lanes2.clone(),
+            router.queue_handle("client2"),
+            dtx2,
+        )
         .await;
 
     router
@@ -454,16 +499,16 @@ async fn test_change_only_multiple_clients_independent() {
     let packet = PublishPacket::new("test/topic".to_string(), &b"data"[..], QoS::AtMostOnce);
     router.route_message(&packet, None).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx1.recv_async()).await;
-    let result2 = timeout(Duration::from_millis(100), rx2.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx1.recv()).await;
+    let result2 = timeout(Duration::from_millis(100), rx2.recv()).await;
 
     assert!(result1.is_ok(), "Client1 should receive first message");
     assert!(result2.is_ok(), "Client2 should receive first message");
 
     router.route_message(&packet, None).await;
 
-    let result1_dup = timeout(Duration::from_millis(100), rx1.recv_async()).await;
-    let result2_dup = timeout(Duration::from_millis(100), rx2.recv_async()).await;
+    let result1_dup = timeout(Duration::from_millis(100), rx1.recv()).await;
+    let result2_dup = timeout(Duration::from_millis(100), rx2.recv()).await;
 
     assert!(result1_dup.is_err(), "Client1 should not receive duplicate");
     assert!(result2_dup.is_err(), "Client2 should not receive duplicate");

--- a/crates/mqtt5/tests/integration_no_local.rs
+++ b/crates/mqtt5/tests/integration_no_local.rs
@@ -12,11 +12,16 @@ use tokio::time::timeout;
 async fn test_no_local_true_filters_own_messages() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -42,7 +47,7 @@ async fn test_no_local_true_filters_own_messages() {
     );
     router.route_message(&packet, Some("test_client")).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_err(),
         "Client should not receive its own message when no_local=true"
@@ -53,11 +58,16 @@ async fn test_no_local_true_filters_own_messages() {
 async fn test_no_local_false_allows_own_messages() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -83,7 +93,7 @@ async fn test_no_local_false_allows_own_messages() {
     );
     router.route_message(&packet, Some("test_client")).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_ok(),
         "Client should receive its own message when no_local=false"
@@ -98,17 +108,27 @@ async fn test_no_local_false_allows_own_messages() {
 async fn test_no_local_other_clients_receive_messages() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx1, rx1) = flume::bounded(10);
-    let (tx2, rx2) = flume::bounded(10);
+    let (lanes1, mut rx1) = mqtt5::broker::router::DeliveryLanes::channel(10);
+    let (lanes2, mut rx2) = mqtt5::broker::router::DeliveryLanes::channel(10);
 
     let (dtx1, _drx1) = tokio::sync::oneshot::channel();
     router
-        .register_client("publisher".to_string(), tx1, dtx1)
+        .register_client(
+            "publisher".to_string(),
+            lanes1.clone(),
+            router.queue_handle("publisher"),
+            dtx1,
+        )
         .await;
 
     let (dtx2, _drx2) = tokio::sync::oneshot::channel();
     router
-        .register_client("subscriber".to_string(), tx2, dtx2)
+        .register_client(
+            "subscriber".to_string(),
+            lanes2.clone(),
+            router.queue_handle("subscriber"),
+            dtx2,
+        )
         .await;
 
     router
@@ -150,13 +170,13 @@ async fn test_no_local_other_clients_receive_messages() {
     );
     router.route_message(&packet, Some("publisher")).await;
 
-    let pub_result = timeout(Duration::from_millis(100), rx1.recv_async()).await;
+    let pub_result = timeout(Duration::from_millis(100), rx1.recv()).await;
     assert!(
         pub_result.is_err(),
         "Publisher should not receive its own message with no_local=true"
     );
 
-    let sub_result = timeout(Duration::from_millis(100), rx2.recv_async()).await;
+    let sub_result = timeout(Duration::from_millis(100), rx2.recv()).await;
     assert!(
         sub_result.is_ok(),
         "Subscriber should receive message from publisher"
@@ -171,11 +191,16 @@ async fn test_no_local_other_clients_receive_messages() {
 async fn test_no_local_with_wildcards() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -208,7 +233,7 @@ async fn test_no_local_with_wildcards() {
     );
     router.route_message(&packet2, Some("test_client")).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_err(),
         "Client should not receive any messages matching wildcard from itself when no_local=true"
@@ -219,11 +244,16 @@ async fn test_no_local_with_wildcards() {
 async fn test_no_local_with_multilevel_wildcard() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -249,7 +279,7 @@ async fn test_no_local_with_multilevel_wildcard() {
     );
     router.route_message(&packet, Some("test_client")).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(result.is_err(), "Client should not receive messages matching multilevel wildcard from itself when no_local=true");
 }
 
@@ -257,11 +287,16 @@ async fn test_no_local_with_multilevel_wildcard() {
 async fn test_no_local_server_generated_messages() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -287,7 +322,7 @@ async fn test_no_local_server_generated_messages() {
     );
     router.route_message(&packet, None).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_ok(),
         "Client should receive server-generated messages even with no_local=true"
@@ -302,11 +337,16 @@ async fn test_no_local_server_generated_messages() {
 async fn test_no_local_multiple_subscriptions_same_client() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -355,7 +395,7 @@ async fn test_no_local_multiple_subscriptions_same_client() {
     );
     router.route_message(&packet2, Some("test_client")).await;
 
-    let result1 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result1 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result1.is_ok(),
         "Client should receive message from topic2 with no_local=false"
@@ -365,7 +405,7 @@ async fn test_no_local_multiple_subscriptions_same_client() {
     assert_eq!(received.publish.topic_name, "test/topic2");
     assert_eq!(&received.publish.payload[..], b"message 2");
 
-    let result2 = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result2 = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result2.is_err(),
         "Client should not receive second message from topic1 with no_local=true"
@@ -376,11 +416,16 @@ async fn test_no_local_multiple_subscriptions_same_client() {
 async fn test_no_local_with_qos_levels() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("test_client".to_string(), tx, dtx)
+        .register_client(
+            "test_client".to_string(),
+            lanes.clone(),
+            router.queue_handle("test_client"),
+            dtx,
+        )
         .await;
 
     router
@@ -406,7 +451,7 @@ async fn test_no_local_with_qos_levels() {
     );
     router.route_message(&packet, Some("test_client")).await;
 
-    let result = timeout(Duration::from_millis(100), rx.recv_async()).await;
+    let result = timeout(Duration::from_millis(100), rx.recv()).await;
     assert!(
         result.is_err(),
         "Client should not receive its own QoS 1 message when no_local=true"

--- a/crates/mqtt5/tests/integration_retain_as_published.rs
+++ b/crates/mqtt5/tests/integration_retain_as_published.rs
@@ -12,11 +12,17 @@ use tokio::time::timeout;
 async fn test_retain_as_published_false_clears_retain_flag() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (qos1_tx, _qos1_rx) = tokio::sync::mpsc::channel(10);
+    let (qos0_tx, mut rx) = tokio::sync::mpsc::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("subscriber".to_string(), tx, dtx)
+        .register_client(
+            "subscriber".to_string(),
+            mqtt5::broker::router::DeliveryLanes { qos1_tx, qos0_tx },
+            router.queue_handle("subscriber"),
+            dtx,
+        )
         .await;
 
     router
@@ -43,7 +49,7 @@ async fn test_retain_as_published_false_clears_retain_flag() {
     packet.retain = true;
     router.route_message(&packet, Some("publisher")).await;
 
-    let received = timeout(Duration::from_millis(100), rx.recv_async())
+    let received = timeout(Duration::from_millis(100), rx.recv())
         .await
         .expect("timeout")
         .expect("message");
@@ -54,11 +60,17 @@ async fn test_retain_as_published_false_clears_retain_flag() {
 async fn test_retain_as_published_true_preserves_retain_flag() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx, rx) = flume::bounded(10);
+    let (qos1_tx, _qos1_rx) = tokio::sync::mpsc::channel(10);
+    let (qos0_tx, mut rx) = tokio::sync::mpsc::channel(10);
     let (dtx, _drx) = tokio::sync::oneshot::channel();
 
     router
-        .register_client("subscriber".to_string(), tx, dtx)
+        .register_client(
+            "subscriber".to_string(),
+            mqtt5::broker::router::DeliveryLanes { qos1_tx, qos0_tx },
+            router.queue_handle("subscriber"),
+            dtx,
+        )
         .await;
 
     router
@@ -85,7 +97,7 @@ async fn test_retain_as_published_true_preserves_retain_flag() {
     packet.retain = true;
     router.route_message(&packet, Some("publisher")).await;
 
-    let received = timeout(Duration::from_millis(100), rx.recv_async())
+    let received = timeout(Duration::from_millis(100), rx.recv())
         .await
         .expect("timeout")
         .expect("message");

--- a/crates/mqtt5/tests/qos1_backlog_delivery.rs
+++ b/crates/mqtt5/tests/qos1_backlog_delivery.rs
@@ -1,0 +1,195 @@
+#![cfg(feature = "broker")]
+use mqtt5::broker::config::StorageConfig;
+use mqtt5::broker::{BrokerConfig, MqttBroker};
+use mqtt5::{AckToken, ConnectOptions, MqttClient, PublishOptions, QoS, SubscribeOptions};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use ulid::Ulid;
+
+const CHANNEL_CAPACITY: usize = 4;
+const FLOOD: usize = 300;
+
+fn client_id(name: &str) -> String {
+    format!("backlog-{name}-{}", Ulid::new())
+}
+
+async fn start_broker() -> (String, tokio::task::JoinHandle<mqtt5::error::Result<()>>) {
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_client_channel_capacity(CHANNEL_CAPACITY)
+        .with_storage(StorageConfig::default().with_persistence(false));
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let port = broker.local_addr().unwrap().port();
+    let task = tokio::spawn(async move { broker.run().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (format!("mqtt://127.0.0.1:{port}"), task)
+}
+
+fn payload_index(payload: &[u8]) -> usize {
+    std::str::from_utf8(payload)
+        .unwrap()
+        .strip_prefix("msg-")
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+async fn flood(url: &str, topic: &str) -> MqttClient {
+    let publisher = MqttClient::new(client_id("pub"));
+    publisher.connect(url).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(30), async {
+        for index in 0..FLOOD {
+            publisher
+                .publish_qos1(topic, format!("msg-{index}").into_bytes())
+                .await
+                .unwrap();
+        }
+    })
+    .await
+    .expect("a slow subscriber must not stall the publisher");
+    publisher
+}
+
+async fn wait_until(deadline: Duration, cond: impl Fn() -> bool) -> bool {
+    let started = tokio::time::Instant::now();
+    while started.elapsed() < deadline {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    cond()
+}
+
+fn assert_in_order(received: &[usize]) {
+    let expected: Vec<usize> = (0..FLOOD).collect();
+    assert_eq!(received, expected.as_slice());
+}
+
+#[tokio::test]
+async fn flooded_qos1_subscriber_receives_every_message_in_order() {
+    let (url, broker_task) = start_broker().await;
+    let topic = format!("flood/{}", Ulid::new());
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let subscriber = MqttClient::new(client_id("sub"));
+    subscriber.connect(&url).await.unwrap();
+    subscriber
+        .subscribe_with_options(
+            topic.clone(),
+            SubscribeOptions {
+                qos: QoS::AtLeastOnce,
+                ..Default::default()
+            },
+            move |msg| sink.lock().unwrap().push(payload_index(&msg.payload)),
+        )
+        .await
+        .unwrap();
+
+    let publisher = flood(&url, &topic).await;
+
+    assert!(
+        wait_until(Duration::from_secs(30), || {
+            received.lock().unwrap().len() == FLOOD
+        })
+        .await,
+        "every queued message must be drained while the subscriber stays connected"
+    );
+    assert_in_order(&received.lock().unwrap());
+
+    subscriber.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    broker_task.abort();
+}
+
+#[tokio::test]
+async fn deferred_ack_subscriber_backlog_drains_as_the_window_frees() {
+    let (url, broker_task) = start_broker().await;
+    let topic = format!("flood/{}", Ulid::new());
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let tokens: Arc<Mutex<Vec<AckToken>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let held = Arc::clone(&tokens);
+    let subscriber = MqttClient::with_options(
+        ConnectOptions::new(client_id("sub"))
+            .with_deferred_ack(true)
+            .with_clean_start(false)
+            .with_session_expiry_interval(3600)
+            .with_receive_maximum(2),
+    );
+    subscriber.connect(&url).await.unwrap();
+    subscriber
+        .subscribe_with_ack(
+            topic.clone(),
+            SubscribeOptions {
+                qos: QoS::AtLeastOnce,
+                ..Default::default()
+            },
+            move |publish, token| {
+                sink.lock().unwrap().push(payload_index(&publish.payload));
+                held.lock().unwrap().push(token);
+            },
+        )
+        .await
+        .unwrap();
+
+    let publisher = flood(&url, &topic).await;
+
+    assert!(
+        wait_until(Duration::from_secs(5), || received.lock().unwrap().len()
+            == 2)
+        .await,
+        "the window admits receive_maximum messages"
+    );
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        received.lock().unwrap().len(),
+        2,
+        "no message may be sent beyond the window while acks are withheld"
+    );
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        publisher
+            .publish_with_options(
+                "probe/alive",
+                b"alive".to_vec(),
+                PublishOptions {
+                    qos: QoS::AtLeastOnce,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+    })
+    .await
+    .expect("the broker stays responsive with a full backlog");
+
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let before = received.lock().unwrap().len();
+            if before == FLOOD {
+                break;
+            }
+            let batch: Vec<AckToken> = tokens.lock().unwrap().drain(..).collect();
+            for token in batch {
+                token.ack();
+            }
+            assert!(
+                wait_until(Duration::from_secs(5), || {
+                    received.lock().unwrap().len() > before
+                })
+                .await,
+                "acking frees the window and the backlog keeps flowing"
+            );
+        }
+    })
+    .await
+    .expect("the whole backlog drains through the window");
+    assert_in_order(&received.lock().unwrap());
+
+    subscriber.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    broker_task.abort();
+}

--- a/crates/mqtt5/tests/retained_delivery_backpressure.rs
+++ b/crates/mqtt5/tests/retained_delivery_backpressure.rs
@@ -1,0 +1,78 @@
+#![cfg(feature = "broker")]
+use mqtt5::broker::config::StorageConfig;
+use mqtt5::broker::{BrokerConfig, MqttBroker};
+use mqtt5::{MqttClient, PublishOptions, QoS};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+const CHANNEL_CAPACITY: usize = 4;
+const RETAINED_TOPICS: usize = 9;
+
+async fn start_broker() -> (u16, tokio::task::JoinHandle<mqtt5::error::Result<()>>) {
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_client_channel_capacity(CHANNEL_CAPACITY)
+        .with_storage(StorageConfig::default().with_persistence(false));
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let port = broker.local_addr().unwrap().port();
+    let task = tokio::spawn(async move { broker.run().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (port, task)
+}
+
+#[tokio::test]
+async fn subscribe_with_more_retained_messages_than_channel_capacity_completes() {
+    let (port, broker_task) = start_broker().await;
+    let url = format!("mqtt://127.0.0.1:{port}");
+
+    let publisher = MqttClient::new("retained-publisher");
+    publisher.connect(&url).await.unwrap();
+    for index in 0..RETAINED_TOPICS {
+        let options = PublishOptions {
+            qos: QoS::AtMostOnce,
+            retain: true,
+            ..Default::default()
+        };
+        publisher
+            .publish_with_options(format!("probe/ret/{index}"), b"v".to_vec(), options)
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let received = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&received);
+    let subscriber = MqttClient::new("retained-subscriber");
+    subscriber.connect(&url).await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        subscriber
+            .subscribe("probe/ret/#", move |_msg| {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })
+            .await
+            .unwrap();
+    })
+    .await
+    .expect("SUBACK must arrive even when retained messages exceed the delivery channel");
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        subscriber
+            .publish_qos1("probe/other", b"alive".to_vec())
+            .await
+            .unwrap();
+    })
+    .await
+    .expect("the handler must keep servicing the socket after retained delivery");
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        received.load(Ordering::SeqCst) >= CHANNEL_CAPACITY,
+        "retained messages that fit the channel must be delivered"
+    );
+
+    subscriber.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    broker_task.abort();
+}

--- a/crates/mqtt5/tests/session_takeover_backlog.rs
+++ b/crates/mqtt5/tests/session_takeover_backlog.rs
@@ -1,0 +1,260 @@
+#![cfg(feature = "broker")]
+use mqtt5::broker::config::{StorageBackend, StorageConfig};
+use mqtt5::broker::{BrokerConfig, MqttBroker};
+use mqtt5::{AckToken, ConnectOptions, MqttClient, QoS, SubscribeOptions};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use ulid::Ulid;
+
+const CHANNEL_CAPACITY: usize = 4;
+const FLOOD: usize = 200;
+const HELD_WINDOW: u16 = 2;
+
+async fn start_broker() -> (String, tokio::task::JoinHandle<mqtt5::error::Result<()>>) {
+    let config = BrokerConfig::default()
+        .with_bind_address(([127, 0, 0, 1], 0))
+        .with_client_channel_capacity(CHANNEL_CAPACITY)
+        .with_storage(StorageConfig::default().with_backend(StorageBackend::Memory));
+    let mut broker = MqttBroker::with_config(config).await.unwrap();
+    let port = broker.local_addr().unwrap().port();
+    let task = tokio::spawn(async move { broker.run().await });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    (format!("mqtt://127.0.0.1:{port}"), task)
+}
+
+fn payload_index(payload: &[u8]) -> usize {
+    std::str::from_utf8(payload)
+        .unwrap()
+        .strip_prefix("msg-")
+        .unwrap()
+        .parse()
+        .unwrap()
+}
+
+fn qos1() -> SubscribeOptions {
+    SubscribeOptions {
+        qos: QoS::AtLeastOnce,
+        ..Default::default()
+    }
+}
+
+fn persistent(client_id: &str, clean_start: bool) -> ConnectOptions {
+    ConnectOptions::new(client_id)
+        .with_clean_start(clean_start)
+        .with_session_expiry_interval(3600)
+        .with_automatic_reconnect(false)
+}
+
+async fn wait_until(deadline: Duration, cond: impl Fn() -> bool) -> bool {
+    let started = tokio::time::Instant::now();
+    while started.elapsed() < deadline {
+        if cond() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    cond()
+}
+
+struct FirstConnection {
+    client: MqttClient,
+    received: Arc<Mutex<Vec<usize>>>,
+    tokens: Arc<Mutex<Vec<AckToken>>>,
+}
+
+async fn connect_holding_window(url: &str, client_id: &str, topic: &str) -> FirstConnection {
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let tokens: Arc<Mutex<Vec<AckToken>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let held = Arc::clone(&tokens);
+    let client = MqttClient::with_options(
+        persistent(client_id, false)
+            .with_deferred_ack(true)
+            .with_receive_maximum(HELD_WINDOW),
+    );
+    client.connect(url).await.unwrap();
+    client
+        .subscribe_with_ack(topic.to_string(), qos1(), move |publish, token| {
+            sink.lock().unwrap().push(payload_index(&publish.payload));
+            held.lock().unwrap().push(token);
+        })
+        .await
+        .unwrap();
+    FirstConnection {
+        client,
+        received,
+        tokens,
+    }
+}
+
+async fn flood(url: &str, topic: &str) -> MqttClient {
+    let publisher = MqttClient::new(format!("takeover-pub-{}", Ulid::new()));
+    publisher.connect(url).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(30), async {
+        for index in 0..FLOOD {
+            publisher
+                .publish_qos1(topic, format!("msg-{index}").into_bytes())
+                .await
+                .unwrap();
+        }
+    })
+    .await
+    .expect("a subscriber holding its window must not stall the publisher");
+    publisher
+}
+
+#[tokio::test]
+async fn takeover_resumes_the_backlog_in_order_without_loss() {
+    let (url, broker_task) = start_broker().await;
+    let client_id = format!("takeover-{}", Ulid::new());
+    let topic = format!("takeover/{}", Ulid::new());
+
+    let first = connect_holding_window(&url, &client_id, &topic).await;
+    let publisher = flood(&url, &topic).await;
+    assert!(
+        wait_until(Duration::from_secs(5), || {
+            first.received.lock().unwrap().len() == usize::from(HELD_WINDOW)
+        })
+        .await,
+        "the first connection holds exactly its window"
+    );
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let second = MqttClient::with_options(persistent(&client_id, false));
+    second.connect(&url).await.unwrap();
+    second
+        .subscribe_with_options(topic.clone(), qos1(), move |msg| {
+            sink.lock().unwrap().push(payload_index(&msg.payload));
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        wait_until(Duration::from_secs(30), || {
+            received.lock().unwrap().len() >= FLOOD
+        })
+        .await,
+        "the second connection drains the whole backlog"
+    );
+    let delivered = received.lock().unwrap().clone();
+    let expected: Vec<usize> = (0..FLOOD).collect();
+    assert_eq!(
+        delivered, expected,
+        "unacked messages are redelivered first, then the queue, in publish order"
+    );
+    assert!(
+        first.tokens.lock().unwrap().len() == usize::from(HELD_WINDOW),
+        "the displaced connection still holds its tokens"
+    );
+    assert!(
+        !first.client.is_connected().await,
+        "the displaced connection was told its session was taken over"
+    );
+
+    second.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    drop(first);
+    broker_task.abort();
+}
+
+#[tokio::test]
+async fn reconnect_right_after_close_resumes_the_backlog() {
+    let (url, broker_task) = start_broker().await;
+    let client_id = format!("takeover-{}", Ulid::new());
+    let topic = format!("takeover/{}", Ulid::new());
+
+    let first = connect_holding_window(&url, &client_id, &topic).await;
+    let publisher = flood(&url, &topic).await;
+    assert!(
+        wait_until(Duration::from_secs(5), || {
+            first.received.lock().unwrap().len() == usize::from(HELD_WINDOW)
+        })
+        .await,
+        "the first connection holds exactly its window"
+    );
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let second = MqttClient::with_options(persistent(&client_id, false));
+    let closing = tokio::spawn(async move { first.client.disconnect().await });
+    second.connect(&url).await.unwrap();
+    closing.await.unwrap().ok();
+    second
+        .subscribe_with_options(topic.clone(), qos1(), move |msg| {
+            sink.lock().unwrap().push(payload_index(&msg.payload));
+        })
+        .await
+        .unwrap();
+
+    let complete = wait_until(Duration::from_secs(30), || {
+        received.lock().unwrap().len() >= FLOOD
+    })
+    .await;
+    let delivered = received.lock().unwrap().clone();
+    assert!(
+        complete,
+        "a connection racing the previous close still gets the whole backlog; got {} of {FLOOD}, first {:?}, last {:?}",
+        delivered.len(),
+        delivered.first(),
+        delivered.last()
+    );
+    let expected: Vec<usize> = (0..FLOOD).collect();
+    assert_eq!(delivered, expected);
+
+    second.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    drop(first.tokens);
+    broker_task.abort();
+}
+
+#[tokio::test]
+async fn clean_start_takeover_discards_the_backlog_and_subscriptions() {
+    let (url, broker_task) = start_broker().await;
+    let client_id = format!("takeover-{}", Ulid::new());
+    let topic = format!("takeover/{}", Ulid::new());
+
+    let first = connect_holding_window(&url, &client_id, &topic).await;
+    let publisher = flood(&url, &topic).await;
+    assert!(
+        wait_until(Duration::from_secs(5), || {
+            first.received.lock().unwrap().len() == usize::from(HELD_WINDOW)
+        })
+        .await,
+        "the first connection holds exactly its window"
+    );
+
+    let received = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::clone(&received);
+    let second = MqttClient::with_options(persistent(&client_id, true));
+    second.connect(&url).await.unwrap();
+    second
+        .subscribe_with_options(topic.clone(), qos1(), move |msg| {
+            sink.lock().unwrap().push(payload_index(&msg.payload));
+        })
+        .await
+        .unwrap();
+
+    publisher
+        .publish_qos1(&topic, format!("msg-{FLOOD}").into_bytes())
+        .await
+        .unwrap();
+    assert!(
+        wait_until(Duration::from_secs(5), || {
+            received.lock().unwrap().contains(&FLOOD)
+        })
+        .await,
+        "a message published after the clean start reaches the new connection"
+    );
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert_eq!(
+        received.lock().unwrap().clone(),
+        vec![FLOOD],
+        "nothing from the old session's backlog reaches a clean-start connection"
+    );
+
+    second.disconnect().await.unwrap();
+    publisher.disconnect().await.unwrap();
+    drop(first);
+    broker_task.abort();
+}

--- a/crates/mqtt5/tests/shared_subscription_basic.rs
+++ b/crates/mqtt5/tests/shared_subscription_basic.rs
@@ -2,80 +2,56 @@
 //! Basic test for shared subscriptions
 
 use bytes::Bytes;
-use mqtt5::broker::router::MessageRouter;
+use mqtt5::broker::router::{DeliveryLanes, LaneReceivers, MessageRouter};
 use mqtt5::packet::publish::PublishPacket;
 use mqtt5::types::ProtocolVersion;
 use mqtt5::QoS;
 use std::sync::Arc;
 
+async fn register(router: &MessageRouter, client_id: &str, filter: &str) -> LaneReceivers {
+    let (lanes, rx) = DeliveryLanes::channel(100);
+    let (dtx, _drx) = tokio::sync::oneshot::channel();
+    router
+        .register_client(
+            client_id.to_string(),
+            lanes,
+            router.queue_handle(client_id),
+            dtx,
+        )
+        .await;
+    router
+        .subscribe(
+            client_id.to_string(),
+            filter.to_string(),
+            QoS::AtMostOnce,
+            None,
+            false,
+            false,
+            0,
+            ProtocolVersion::V5,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+    rx
+}
+
+fn drain_count(rx: &mut LaneReceivers) -> usize {
+    let mut count = 0;
+    while rx.try_recv().is_ok() {
+        count += 1;
+    }
+    count
+}
+
 #[tokio::test]
 async fn test_shared_subscription_distribution() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx1, rx1) = flume::bounded(100);
-    let (tx2, rx2) = flume::bounded(100);
-    let (tx3, rx3) = flume::bounded(100);
-
-    let (dtx1, _drx1) = tokio::sync::oneshot::channel();
-    router
-        .register_client("worker1".to_string(), tx1, dtx1)
-        .await;
-    let (dtx2, _drx2) = tokio::sync::oneshot::channel();
-    router
-        .register_client("worker2".to_string(), tx2, dtx2)
-        .await;
-    let (dtx3, _drx3) = tokio::sync::oneshot::channel();
-    router
-        .register_client("worker3".to_string(), tx3, dtx3)
-        .await;
-
-    router
-        .subscribe(
-            "worker1".to_string(),
-            "$share/workers/tasks/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
-
-    router
-        .subscribe(
-            "worker2".to_string(),
-            "$share/workers/tasks/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
-
-    router
-        .subscribe(
-            "worker3".to_string(),
-            "$share/workers/tasks/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
+    let mut rx1 = register(&router, "worker1", "$share/workers/tasks/+").await;
+    let mut rx2 = register(&router, "worker2", "$share/workers/tasks/+").await;
+    let mut rx3 = register(&router, "worker3", "$share/workers/tasks/+").await;
 
     for i in 0..9 {
         let publish = PublishPacket::new(
@@ -86,24 +62,9 @@ async fn test_shared_subscription_distribution() {
         router.route_message(&publish, None).await;
     }
 
-    let mut count1 = 0;
-    let mut count2 = 0;
-    let mut count3 = 0;
-
-    while rx1.try_recv().is_ok() {
-        count1 += 1;
-    }
-    while rx2.try_recv().is_ok() {
-        count2 += 1;
-    }
-    while rx3.try_recv().is_ok() {
-        count3 += 1;
-    }
-
-    println!("Worker 1 received: {count1} messages");
-    println!("Worker 2 received: {count2} messages");
-    println!("Worker 3 received: {count3} messages");
-    println!("Total: {} messages", count1 + count2 + count3);
+    let count1 = drain_count(&mut rx1);
+    let count2 = drain_count(&mut rx2);
+    let count3 = drain_count(&mut rx3);
 
     assert_eq!(count1, 3);
     assert_eq!(count2, 3);
@@ -115,70 +76,9 @@ async fn test_shared_subscription_distribution() {
 async fn test_mixed_shared_and_regular_subscriptions() {
     let router = Arc::new(MessageRouter::new());
 
-    let (tx_shared1, rx_shared1) = flume::bounded(100);
-    let (tx_shared2, rx_shared2) = flume::bounded(100);
-    let (tx_regular, rx_regular) = flume::bounded(100);
-
-    let (dtx1, _drx1) = tokio::sync::oneshot::channel();
-    router
-        .register_client("shared1".to_string(), tx_shared1, dtx1)
-        .await;
-    let (dtx2, _drx2) = tokio::sync::oneshot::channel();
-    router
-        .register_client("shared2".to_string(), tx_shared2, dtx2)
-        .await;
-    let (dtx3, _drx3) = tokio::sync::oneshot::channel();
-    router
-        .register_client("regular".to_string(), tx_regular, dtx3)
-        .await;
-
-    router
-        .subscribe(
-            "shared1".to_string(),
-            "$share/team/alerts/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
-
-    router
-        .subscribe(
-            "shared2".to_string(),
-            "$share/team/alerts/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
-
-    router
-        .subscribe(
-            "regular".to_string(),
-            "alerts/+".to_string(),
-            QoS::AtMostOnce,
-            None,
-            false,
-            false,
-            0,
-            ProtocolVersion::V5,
-            false,
-            None,
-        )
-        .await
-        .unwrap();
+    let mut rx_shared1 = register(&router, "shared1", "$share/team/alerts/+").await;
+    let mut rx_shared2 = register(&router, "shared2", "$share/team/alerts/+").await;
+    let mut rx_regular = register(&router, "regular", "alerts/+").await;
 
     for i in 0..4 {
         let publish = PublishPacket::new(
@@ -189,24 +89,9 @@ async fn test_mixed_shared_and_regular_subscriptions() {
         router.route_message(&publish, None).await;
     }
 
-    let mut shared1_count = 0;
-    let mut shared2_count = 0;
-    let mut regular_count = 0;
-
-    while rx_shared1.try_recv().is_ok() {
-        shared1_count += 1;
-    }
-    while rx_shared2.try_recv().is_ok() {
-        shared2_count += 1;
-    }
-    while rx_regular.try_recv().is_ok() {
-        regular_count += 1;
-    }
-
-    println!("\nMixed subscription test:");
-    println!("Shared1 received: {shared1_count} messages");
-    println!("Shared2 received: {shared2_count} messages");
-    println!("Regular received: {regular_count} messages");
+    let shared1_count = drain_count(&mut rx_shared1);
+    let shared2_count = drain_count(&mut rx_shared2);
+    let regular_count = drain_count(&mut rx_regular);
 
     assert_eq!(regular_count, 4);
     assert_eq!(shared1_count + shared2_count, 4);

--- a/crates/mqtt5/tests/turmoil_multi_client.rs
+++ b/crates/mqtt5/tests/turmoil_multi_client.rs
@@ -35,14 +35,15 @@ fn test_multi_client_message_routing() {
         let mut receivers = HashMap::new();
 
         // Client 1: Subscribes to temperature sensors
-        let (tx1, rx1) = flume::bounded(100);
-        clients.insert("temp_monitor", tx1);
+        let (lanes1, rx1) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        clients.insert("temp_monitor", lanes1);
         receivers.insert("temp_monitor", rx1);
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
             .register_client(
                 "temp_monitor".to_string(),
                 clients["temp_monitor"].clone(),
+                router.queue_handle("temp_monitor"),
                 dtx1,
             )
             .await;
@@ -63,14 +64,15 @@ fn test_multi_client_message_routing() {
             .unwrap();
 
         // Client 2: Subscribes to humidity sensors
-        let (tx2, rx2) = flume::bounded(100);
-        clients.insert("humidity_monitor", tx2);
+        let (lanes2, rx2) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        clients.insert("humidity_monitor", lanes2);
         receivers.insert("humidity_monitor", rx2);
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
             .register_client(
                 "humidity_monitor".to_string(),
                 clients["humidity_monitor"].clone(),
+                router.queue_handle("humidity_monitor"),
                 dtx2,
             )
             .await;
@@ -91,14 +93,15 @@ fn test_multi_client_message_routing() {
             .unwrap();
 
         // Client 3: Subscribes to all sensors (wildcard)
-        let (tx3, rx3) = flume::bounded(100);
-        clients.insert("all_monitor", tx3);
+        let (lanes3, rx3) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        clients.insert("all_monitor", lanes3);
         receivers.insert("all_monitor", rx3);
         let (dtx3, _drx3) = tokio::sync::oneshot::channel();
         router
             .register_client(
                 "all_monitor".to_string(),
                 clients["all_monitor"].clone(),
+                router.queue_handle("all_monitor"),
                 dtx3,
             )
             .await;
@@ -119,14 +122,15 @@ fn test_multi_client_message_routing() {
             .unwrap();
 
         // Client 4: Subscribes to specific room only
-        let (tx4, rx4) = flume::bounded(100);
-        clients.insert("room1_monitor", tx4);
+        let (lanes4, rx4) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        clients.insert("room1_monitor", lanes4);
         receivers.insert("room1_monitor", rx4);
         let (dtx4, _drx4) = tokio::sync::oneshot::channel();
         router
             .register_client(
                 "room1_monitor".to_string(),
                 clients["room1_monitor"].clone(),
+                router.queue_handle("room1_monitor"),
                 dtx4,
             )
             .await;
@@ -223,10 +227,15 @@ fn test_client_subscription_changes() {
         let router = Arc::new(MessageRouter::new());
 
         // Create a client
-        let (tx, rx) = flume::bounded(100);
+        let (lanes, mut rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
         router
-            .register_client("dynamic_client".to_string(), tx, dtx)
+            .register_client(
+                "dynamic_client".to_string(),
+                lanes.clone(),
+                router.queue_handle("dynamic_client"),
+                dtx,
+            )
             .await;
 
         // Initial subscription
@@ -318,16 +327,26 @@ fn test_message_ordering_with_multiple_clients() {
         let router = Arc::new(MessageRouter::new());
 
         // Create two clients subscribing to the same topic
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
+        let (lanes1, mut rx1) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        let (lanes2, mut rx2) = mqtt5::broker::router::DeliveryLanes::channel(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
-            .register_client("client1".to_string(), tx1, dtx1)
+            .register_client(
+                "client1".to_string(),
+                lanes1.clone(),
+                router.queue_handle("client1"),
+                dtx1,
+            )
             .await;
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("client2".to_string(), tx2, dtx2)
+            .register_client(
+                "client2".to_string(),
+                lanes2.clone(),
+                router.queue_handle("client2"),
+                dtx2,
+            )
             .await;
 
         router

--- a/crates/mqtt5/tests/turmoil_pubsub.rs
+++ b/crates/mqtt5/tests/turmoil_pubsub.rs
@@ -27,11 +27,16 @@ fn test_basic_publish_subscribe() {
         let router = Arc::new(MessageRouter::new());
 
         // Create publisher and subscriber
-        let (sub_tx, sub_rx) = flume::bounded(100);
+        let (sub_lanes, mut sub_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
 
         let (dtx, _drx) = tokio::sync::oneshot::channel();
         router
-            .register_client("subscriber".to_string(), sub_tx, dtx)
+            .register_client(
+                "subscriber".to_string(),
+                sub_lanes.clone(),
+                router.queue_handle("subscriber"),
+                dtx,
+            )
             .await;
         router
             .subscribe(
@@ -86,16 +91,26 @@ fn test_wildcard_subscriptions() {
         let router = Arc::new(MessageRouter::new());
 
         // Create subscribers with different wildcard patterns
-        let (single_tx, single_rx) = flume::bounded(100);
-        let (multi_tx, multi_rx) = flume::bounded(100);
+        let (single_lanes, mut single_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        let (multi_lanes, mut multi_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
-            .register_client("single_wildcard".to_string(), single_tx, dtx1)
+            .register_client(
+                "single_wildcard".to_string(),
+                single_lanes.clone(),
+                router.queue_handle("single_wildcard"),
+                dtx1,
+            )
             .await;
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("multi_wildcard".to_string(), multi_tx, dtx2)
+            .register_client(
+                "multi_wildcard".to_string(),
+                multi_lanes.clone(),
+                router.queue_handle("multi_wildcard"),
+                dtx2,
+            )
             .await;
 
         // Single-level wildcard subscription
@@ -197,21 +212,36 @@ fn test_multiple_subscribers_same_topic() {
         let router = Arc::new(MessageRouter::new());
 
         // Create multiple subscribers to the same topic
-        let (sub1_tx, mut sub1_rx) = flume::bounded(100);
-        let (sub2_tx, mut sub2_rx) = flume::bounded(100);
-        let (sub3_tx, mut sub3_rx) = flume::bounded(100);
+        let (sub1_lanes, mut sub1_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        let (sub2_lanes, mut sub2_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        let (sub3_lanes, mut sub3_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
-            .register_client("subscriber1".to_string(), sub1_tx, dtx1)
+            .register_client(
+                "subscriber1".to_string(),
+                sub1_lanes.clone(),
+                router.queue_handle("subscriber1"),
+                dtx1,
+            )
             .await;
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("subscriber2".to_string(), sub2_tx, dtx2)
+            .register_client(
+                "subscriber2".to_string(),
+                sub2_lanes.clone(),
+                router.queue_handle("subscriber2"),
+                dtx2,
+            )
             .await;
         let (dtx3, _drx3) = tokio::sync::oneshot::channel();
         router
-            .register_client("subscriber3".to_string(), sub3_tx, dtx3)
+            .register_client(
+                "subscriber3".to_string(),
+                sub3_lanes.clone(),
+                router.queue_handle("subscriber3"),
+                dtx3,
+            )
             .await;
 
         // All subscribe to the same topic
@@ -282,16 +312,26 @@ fn test_qos_levels() {
         let router = Arc::new(MessageRouter::new());
 
         // Create subscribers for different QoS levels
-        let (qos0_tx, qos0_rx) = flume::bounded(100);
-        let (qos1_tx, qos1_rx) = flume::bounded(100);
+        let (qos0_lanes, mut qos0_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
+        let (qos1_lanes, mut qos1_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
 
         let (dtx1, _drx1) = tokio::sync::oneshot::channel();
         router
-            .register_client("qos0_client".to_string(), qos0_tx, dtx1)
+            .register_client(
+                "qos0_client".to_string(),
+                qos0_lanes.clone(),
+                router.queue_handle("qos0_client"),
+                dtx1,
+            )
             .await;
         let (dtx2, _drx2) = tokio::sync::oneshot::channel();
         router
-            .register_client("qos1_client".to_string(), qos1_tx, dtx2)
+            .register_client(
+                "qos1_client".to_string(),
+                qos1_lanes.clone(),
+                router.queue_handle("qos1_client"),
+                dtx2,
+            )
             .await;
 
         // Subscribe with different QoS levels
@@ -374,10 +414,15 @@ fn test_unsubscribe_functionality() {
     sim.host("unsubscribe-test", || async {
         let router = Arc::new(MessageRouter::new());
 
-        let (sub_tx, sub_rx) = flume::bounded(100);
+        let (sub_lanes, mut sub_rx) = mqtt5::broker::router::DeliveryLanes::channel(100);
         let (dtx, _drx) = tokio::sync::oneshot::channel();
         router
-            .register_client("test_client".to_string(), sub_tx, dtx)
+            .register_client(
+                "test_client".to_string(),
+                sub_lanes.clone(),
+                router.queue_handle("test_client"),
+                dtx,
+            )
             .await;
 
         // Subscribe to topic

--- a/crates/mqtt5/tests/turmoil_shared_subscriptions.rs
+++ b/crates/mqtt5/tests/turmoil_shared_subscriptions.rs
@@ -1,22 +1,53 @@
-#![cfg(feature = "broker")]
+#![cfg(all(feature = "broker", feature = "turmoil-testing"))]
 //! Shared subscription tests using Turmoil
 //!
 //! These tests verify the shared subscription functionality using
 //! the existing `MessageRouter` directly, which we know works.
 
-#[cfg(feature = "turmoil-testing")]
-use mqtt5::broker::router::MessageRouter;
-#[cfg(feature = "turmoil-testing")]
+use mqtt5::broker::router::{DeliveryLanes, LaneReceivers, MessageRouter};
 use mqtt5::packet::publish::PublishPacket;
-#[cfg(feature = "turmoil-testing")]
 use mqtt5::time::Duration;
-#[cfg(feature = "turmoil-testing")]
 use mqtt5::types::ProtocolVersion;
-#[cfg(feature = "turmoil-testing")]
 use mqtt5::QoS;
-#[cfg(feature = "turmoil-testing")]
 use std::sync::Arc;
-#[cfg(feature = "turmoil-testing")]
+
+async fn register_worker(router: &MessageRouter, client_id: &str) -> LaneReceivers {
+    let (lanes, rx) = DeliveryLanes::channel(100);
+    let (dtx, _drx) = tokio::sync::oneshot::channel();
+    router
+        .register_client(
+            client_id.to_string(),
+            lanes,
+            router.queue_handle(client_id),
+            dtx,
+        )
+        .await;
+    router
+        .subscribe(
+            client_id.to_string(),
+            "$share/workers/tasks/+".to_string(),
+            QoS::AtMostOnce,
+            None,
+            false,
+            false,
+            0,
+            ProtocolVersion::V5,
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+    rx
+}
+
+fn drain_count(rx: &mut LaneReceivers) -> usize {
+    let mut count = 0;
+    while rx.try_recv().is_ok() {
+        count += 1;
+    }
+    count
+}
+
 #[test]
 fn test_shared_subscriptions_in_turmoil() {
     let mut sim = turmoil::Builder::new()
@@ -24,77 +55,12 @@ fn test_shared_subscriptions_in_turmoil() {
         .build();
 
     sim.host("test", || async {
-        // This test uses the known-working MessageRouter directly
         let router = Arc::new(MessageRouter::new());
 
-        // Create channels for three workers
-        let (tx1, rx1) = flume::bounded(100);
-        let (tx2, rx2) = flume::bounded(100);
-        let (tx3, rx3) = flume::bounded(100);
+        let mut rx1 = register_worker(&router, "worker1").await;
+        let mut rx2 = register_worker(&router, "worker2").await;
+        let mut rx3 = register_worker(&router, "worker3").await;
 
-        // Register workers
-        let (dtx1, _drx1) = tokio::sync::oneshot::channel();
-        router
-            .register_client("worker1".to_string(), tx1, dtx1)
-            .await;
-        let (dtx2, _drx2) = tokio::sync::oneshot::channel();
-        router
-            .register_client("worker2".to_string(), tx2, dtx2)
-            .await;
-        let (dtx3, _drx3) = tokio::sync::oneshot::channel();
-        router
-            .register_client("worker3".to_string(), tx3, dtx3)
-            .await;
-
-        router
-            .subscribe(
-                "worker1".to_string(),
-                "$share/workers/tasks/+".to_string(),
-                QoS::AtMostOnce,
-                None,
-                false,
-                false,
-                0,
-                ProtocolVersion::V5,
-                false,
-                None,
-            )
-            .await
-            .unwrap();
-
-        router
-            .subscribe(
-                "worker2".to_string(),
-                "$share/workers/tasks/+".to_string(),
-                QoS::AtMostOnce,
-                None,
-                false,
-                false,
-                0,
-                ProtocolVersion::V5,
-                false,
-                None,
-            )
-            .await
-            .unwrap();
-
-        router
-            .subscribe(
-                "worker3".to_string(),
-                "$share/workers/tasks/+".to_string(),
-                QoS::AtMostOnce,
-                None,
-                false,
-                false,
-                0,
-                ProtocolVersion::V5,
-                false,
-                None,
-            )
-            .await
-            .unwrap();
-
-        // Publish 9 messages
         for i in 0..9 {
             let publish = PublishPacket::new(
                 format!("tasks/job{}", i % 3),
@@ -104,23 +70,10 @@ fn test_shared_subscriptions_in_turmoil() {
             router.route_message(&publish, None).await;
         }
 
-        // Count messages received by each worker
-        let mut count1 = 0;
-        let mut count2 = 0;
-        let mut count3 = 0;
+        let count1 = drain_count(&mut rx1);
+        let count2 = drain_count(&mut rx2);
+        let count3 = drain_count(&mut rx3);
 
-        // Drain all channels
-        while rx1.try_recv().is_ok() {
-            count1 += 1;
-        }
-        while rx2.try_recv().is_ok() {
-            count2 += 1;
-        }
-        while rx3.try_recv().is_ok() {
-            count3 += 1;
-        }
-
-        // Verify distribution
         assert_eq!(count1 + count2 + count3, 9);
         assert!((2..=4).contains(&count1));
         assert!((2..=4).contains(&count2));

--- a/crates/mqttv5-cli/CLI_USAGE.md
+++ b/crates/mqttv5-cli/CLI_USAGE.md
@@ -1241,9 +1241,9 @@ The backend URL scheme must match the transport the client should use for the ba
   "insecure": boolean | null,
   "alpn_protocols": ["string"] | null,
   "try_private": boolean,
-  "clean_start": boolean,
+  "clean_start": false,
   "keepalive": number,
-  "protocol_version": "mqttv50" | "mqttv311" | "mqttv31",
+  "protocol_version": "mqttv50",
   "reconnect_delay": duration,
   "initial_reconnect_delay": duration,
   "max_reconnect_delay": duration,
@@ -1269,9 +1269,9 @@ The backend URL scheme must match the transport the client should use for the ba
 | `insecure` | `boolean\|null` | Disable TLS certificate verification | `false` |
 | `alpn_protocols` | `string[]\|null` | ALPN protocols (e.g., `["x-amzn-mqtt-ca"]` for AWS IoT) | `null` |
 | `try_private` | `boolean` | Send bridge user property (Mosquitto compatible) | `true` |
-| `clean_start` | `boolean` | Start with clean session | `false` |
+| `clean_start` | `boolean` | Must be `false`: the bridge acknowledges a remote message only after routing it locally, which needs a persistent session | `false` |
 | `keepalive` | `number` | Keep-alive interval in seconds | `60` |
-| `protocol_version` | `string` | MQTT protocol version | `"mqttv50"` |
+| `protocol_version` | `string` | Must be `"mqttv50"`: bridge flow control uses MQTT 5.0 session expiry and receive maximum | `"mqttv50"` |
 | `reconnect_delay` | `duration` | Reconnection delay (deprecated) | `"5s"` |
 | `initial_reconnect_delay` | `duration` | Initial reconnection delay | `"5s"` |
 | `max_reconnect_delay` | `duration` | Maximum reconnection delay | `"5m"` |

--- a/crates/mqttv5-cli/Cargo.toml
+++ b/crates/mqttv5-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqttv5-cli"
-version = "0.28.6"
+version = "0.28.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -22,7 +22,7 @@ opentelemetry = ["mqtt5/opentelemetry"]
 codec = ["mqtt5/codec-all"]
 
 [dependencies]
-mqtt5 = { path = "../mqtt5", version = "0.39" }
+mqtt5 = { path = "../mqtt5", version = "0.40" }
 anyhow = "1.0.103"
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/mqttv5-cli/src/commands/broker_cmd.rs
+++ b/crates/mqttv5-cli/src/commands/broker_cmd.rs
@@ -291,6 +291,8 @@ fn build_example_config() -> BrokerConfig {
         max_retained_messages: 0,
         max_retained_message_size: 0,
         client_channel_capacity: 10000,
+        max_outbound_inflight: 64,
+        drain_batch: 64,
         server_keep_alive: None,
         server_receive_maximum: None,
         response_information: None,
@@ -350,6 +352,7 @@ fn build_example_config() -> BrokerConfig {
             base_dir: PathBuf::from("./mqtt_storage"),
             cleanup_interval: std::time::Duration::from_secs(3600),
             enable_persistence: true,
+            ..StorageConfig::default()
         },
         change_only_delivery_config: ChangeOnlyDeliveryConfig::default(),
         echo_suppression_config: mqtt5::broker::config::EchoSuppressionConfig::default(),
@@ -1103,6 +1106,7 @@ async fn create_interactive_config(cmd: &mut RunArgs) -> Result<BrokerConfig> {
         base_dir: cmd.storage_dir.clone(),
         backend: cmd.storage_backend,
         cleanup_interval: std::time::Duration::from_secs(300),
+        ..StorageConfig::default()
     };
     config.storage_config = storage_config;
 


### PR DESCRIPTION
## What this fixes

A saturating QoS 1 flood to a slow-but-connected subscriber diverted overflow into an unbounded offline queue that was never drained while connected: delivery stalled and broker RSS grew from ~9 MB to ~15 GB in one run (original report: #148). The offline path and the live path now become one ordered, bounded, backpressured path.

## The fix

- **Per-client bounded `ClientQueue`** with drop-oldest caps, lock-free `count`, hand-off counter, `draining` flag, `Notify`-driven draining; file backend persists it write-behind with store/delete coalescing.
- **Two delivery lanes** — QoS >= 1 gated by a real window `min(client Receive Maximum, max_outbound_inflight)`, QoS 0 ungated — drained in bounded batches; PUBACK/PUBREC held until the message is placed, so real MQTT flow control applies.
- **Router plan-then-execute** with a per-publish deadline.
- **Two-phase session takeover** with a generation fence and a hand-off drop-guard; clean-start discard.
- **Bridge ingress** over deferred-ack; the **wasm broker** moved to the same two-lane + queue path.

Model-checked (TLA+, `specs/tla/qos1-backlog/`) and quorum-reviewed before coding, then three adversarial code-review rounds. Full workspace suite green (1679/0); host + wasm clippy clean.

Tracked residual edge cases: #150 (clean-start stray message), #151 (redelivery ordering).
