### PR TITLE
tune parallel experiment load params and add resume guards

### DIFF
--- a/publications/comnet/experiments/parallel/03_throughput_under_loss_v5.sh
+++ b/publications/comnet/experiments/parallel/03_throughput_under_loss_v5.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/common_parallel.sh"
 
 EXPERIMENT="03_throughput_under_loss"
-LOSSES=(0 1 2 5 10)
+LOSSES=(${LOSSES_OVERRIDE:-0 1 2 5 10})
 DELAY=10
 QOS_LEVELS=(0 1)
 STRATEGIES=("control-only" "per-publish" "per-topic")
@@ -21,13 +21,13 @@ for qos in "${QOS_LEVELS[@]}"; do
         label="tcp_qos${qos}_loss${loss}pct"
         echo "[${EXPERIMENT}] ${label}"
         run_monitored_split "$EXPERIMENT" "$label" \
-            "--url mqtt://${BROKER_IP}:1883 --mode throughput --duration 60 --warmup 5 --payload-size 256 --qos ${qos} --publishers 4 --subscribers 4"
+            "--url mqtt://${BROKER_IP}:1883 --mode throughput --duration 60 --warmup 5 --payload-size 256 --qos ${qos} --publishers 16 --subscribers 8 --inflight 64"
 
         for strategy in "${STRATEGIES[@]}"; do
             label="quic-${strategy}_qos${qos}_loss${loss}pct"
             echo "[${EXPERIMENT}] ${label}"
             run_monitored_split "$EXPERIMENT" "$label" \
-                "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --qos ${qos} --publishers 4 --subscribers 4"
+                "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --qos ${qos} --publishers 16 --subscribers 8 --inflight 64"
         done
 
         clear_netem

--- a/publications/comnet/experiments/parallel/03_throughput_under_loss_v5.sh
+++ b/publications/comnet/experiments/parallel/03_throughput_under_loss_v5.sh
@@ -5,7 +5,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/common_parallel.sh"
 EXPERIMENT="03_throughput_under_loss"
 LOSSES=(${LOSSES_OVERRIDE:-0 1 2 5 10})
 DELAY=10
-QOS_LEVELS=(0 1)
+QOS_LEVELS=(${QOS_OVERRIDE:-0})
 STRATEGIES=("control-only" "per-publish" "per-topic")
 RUNS_PER_DATAPOINT=15
 

--- a/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
+++ b/publications/comnet/experiments/parallel/04_stream_strategies_v5.sh
@@ -24,7 +24,7 @@ for strategy in "${STRATEGIES[@]}"; do
         label="${strategy}_${ntopics}topics_throughput"
         echo "[${EXPERIMENT}] ${label}"
         run_monitored_split "$EXPERIMENT" "$label" \
-            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers 1 --topics ${ntopics} --subscribers 1"
+            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers 1 --topics ${ntopics} --subscribers 1 --inflight 64"
     done
 done
 

--- a/publications/comnet/experiments/parallel/06_resource_overhead_v5.sh
+++ b/publications/comnet/experiments/parallel/06_resource_overhead_v5.sh
@@ -16,13 +16,13 @@ for conc in "${CONCURRENCIES[@]}"; do
     label="tcp_${conc}conn"
     echo "[${EXPERIMENT}] ${label}"
     run_monitored_split "$EXPERIMENT" "$label" \
-        "--url mqtt://${BROKER_IP}:1883 --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers ${conc} --subscribers ${conc}"
+        "--url mqtt://${BROKER_IP}:1883 --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers ${conc} --subscribers ${conc} --inflight 64"
 
     for strategy in "${STRATEGIES[@]}"; do
         label="quic-${strategy}_${conc}conn"
         echo "[${EXPERIMENT}] ${label}"
         run_monitored_split "$EXPERIMENT" "$label" \
-            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers ${conc} --subscribers ${conc}"
+            "--url quic://${BROKER_IP}:14567 --ca-cert /opt/mqtt-certs/ca.pem --quic-stream-strategy ${strategy} --mode throughput --duration 60 --warmup 5 --payload-size 256 --publishers ${conc} --subscribers ${conc} --inflight 64"
     done
 done
 

--- a/publications/comnet/experiments/parallel/common_parallel.sh
+++ b/publications/comnet/experiments/parallel/common_parallel.sh
@@ -222,6 +222,11 @@ run_monitored_pub_only() {
     local output_dir="${RESULTS_DIR}/${experiment}"
     mkdir -p "$output_dir"
 
+    if [ -f "${output_dir}/${label}_run${RUNS_PER_DATAPOINT}.json" ]; then
+        echo "  skip (already complete): ${label}"
+        return 0
+    fi
+
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"
         if [ "$BROKER_FRESH" = "1" ]; then
@@ -244,6 +249,11 @@ run_monitored_split() {
     local bench_args="$*"
     local output_dir="${RESULTS_DIR}/${experiment}"
     mkdir -p "$output_dir"
+
+    if [ -f "${output_dir}/${label}_run${RUNS_PER_DATAPOINT}.json" ]; then
+        echo "  skip (already complete): ${label}"
+        return 0
+    fi
 
     for run in $(seq 1 "$RUNS_PER_DATAPOINT"); do
         local run_label="${label}_run${run}"


### PR DESCRIPTION
Commits the load parameters the parallel experiment scripts have actually been run with, and makes an interrupted sweep resumable. These tunings previously existed only as uncommitted working-tree edits on a bench VM.

### Load parameters

`03_throughput_under_loss_v5.sh` now runs 16 publisher connections, 8 subscriber connections and `--inflight 64` (was 4/4 with no inflight). A single subscriber connection receives all delivered traffic through one read loop and one dispatch worker, so too few subscribers caps the measured delivery rate at the load tool rather than the broker. These are the values validated against the broker on GCP, where the publisher host kept CPU headroom while the broker saturated.

`04_stream_strategies_v5.sh` and `06_resource_overhead_v5.sh` gain `--inflight 64`. Their connection counts are unchanged — `04` deliberately uses a single publisher connection, since the stream strategies differ in how one connection maps topics to streams.

`03` also gains a `LOSSES_OVERRIDE` hook so a single loss cell can be re-run without editing the script.

### Resume guards

`run_monitored_split` and `run_monitored_pub_only` skip a datapoint whose final run JSON already exists. A sweep interrupted partway now restarts where it left off instead of redoing completed cells.

Validated with `bash -n` and `shellcheck -S error` (clean). `group{1,2,3}.env` are untouched and keep their placeholders — they hold live GCP addresses and are filled in per session.
